### PR TITLE
fix: handle marginal phonemes before assigning glyph IDs. Closes #72

### DIFF
--- a/code/aggregation/aggregate-raw-data.R
+++ b/code/aggregation/aggregate-raw-data.R
@@ -365,19 +365,10 @@ all.data$Phoneme <- denorm(all.data$Phoneme)
 all.data$Allophones <- denorm(all.data$Allophones)
 # FACTOR TO DROP UNUSED LEVELS
 all.data$Phoneme <- factor(all.data$Phoneme)
+# MARK MARGINAL PHONEMES AND REMOVE ANGLE BRACKETS
+all.data <- markMarginal(all.data)
 # ASSIGN GLYPH IDs
 all.data$GlyphID <- assignGlyphID(all.data$Phoneme)
-
-
-# # # # # # # # # # # # # # # # # # # # # # # # # # #
-# MARK MARGINAL PHONEMES AND REMOVE ANGLE BRACKETS  #
-# # # # # # # # # # # # # # # # # # # # # # # # # # #
-all.data <- markMarginal(all.data)
-
-
-# # # # # # # # # # # # # # #
-# TODO: VALIDATE ISO CODES  #
-# # # # # # # # # # # # # # #
 
 
 # # # # # # # # # # # # # #


### PR DESCRIPTION
This one is ready for review/merge. The `<` `>` used to mark marginal phonemes were getting incorporated into the `GlyphID`s, and consequently those `GlyphID`s were not finding a match in the features table and not getting a feature vector assigned. This reduces the number of phonemes lacking feature vectors from 221 down to 28.