### PR TITLE
alleged glottal tap -> glottal stop. closes #83

### DIFF
--- a/data/PH/phoible_inventories.tsv
+++ b/data/PH/phoible_inventories.tsv
@@ -740,7 +740,7 @@
 			"ɡ"				
 			"ɡʱ"				
 			"h"				
-			"<x>"	"glottal tap? Possibly meant a glottal stop"			
+			"ʔ"				
 			"i"				
 			"e"				
 			"a"				


### PR DESCRIPTION
Called in a favor from SIL to get a scan of the original source that our grammar was citing.

> Gordon, Kent H. 1976. Phonology of Dhangar Kurux. Kathmandu: SIL and CNAS T.U.

That source uses "glottal catch" but uses glottal stop in the transcriptions, and it seems clear from the text that glottal stop is the right interpretation here. 

Ready for review/merge.