### PR TITLE
fix q-as-ejective mistake in sebat bet gurage languages. 

### DIFF
--- a/data/GM/gm-afr-inventories.tsv
+++ b/data/GM/gm-afr-inventories.tsv
@@ -1,21455 +1,21455 @@
 LanguageCode	LanguageName	SpecificDialect	Phoneme	Notes	Allophones	AllophoneNotes	FileNames
 fub	Fulfulde (Cameroon)	CAM	b				adamawa_taylor1953.pdf
-fub	Fulfulde (Cameroon)	CAM	ɓ				
-fub	Fulfulde (Cameroon)	CAM	ʔʲ				
-fub	Fulfulde (Cameroon)	CAM	m				
-fub	Fulfulde (Cameroon)	CAM	ɲ				
-fub	Fulfulde (Cameroon)	CAM	f				
-fub	Fulfulde (Cameroon)	CAM	t				
-fub	Fulfulde (Cameroon)	CAM	d				
-fub	Fulfulde (Cameroon)	CAM	ɗ				
-fub	Fulfulde (Cameroon)	CAM	mb				
-fub	Fulfulde (Cameroon)	CAM	nd				
-fub	Fulfulde (Cameroon)	CAM	n̠d̠ʒ	updated from ɲdʒ			
-fub	Fulfulde (Cameroon)	CAM	ŋɡ				
-fub	Fulfulde (Cameroon)	CAM	n				
-fub	Fulfulde (Cameroon)	CAM	s				
-fub	Fulfulde (Cameroon)	CAM	<ʒ>	borrowed words only			
-fub	Fulfulde (Cameroon)	CAM	h		[h]	word final	
-fub	Fulfulde (Cameroon)	CAM	h		[ɦ]	word final	
-fub	Fulfulde (Cameroon)	CAM	l				
-fub	Fulfulde (Cameroon)	CAM	r				
-fub	Fulfulde (Cameroon)	CAM	t̠ʃ				
-fub	Fulfulde (Cameroon)	CAM	d̠ʒ				
-fub	Fulfulde (Cameroon)	CAM	ɡ				
-fub	Fulfulde (Cameroon)	CAM	k				
-fub	Fulfulde (Cameroon)	CAM	ŋ				
-fub	Fulfulde (Cameroon)	CAM	<q>	borrowed words only			
-fub	Fulfulde (Cameroon)	CAM	w				
-fub	Fulfulde (Cameroon)	CAM	j				
-fub	Fulfulde (Cameroon)	CAM	i				
-fub	Fulfulde (Cameroon)	CAM	e				
-fub	Fulfulde (Cameroon)	CAM	a				
-fub	Fulfulde (Cameroon)	CAM	o				
-fub	Fulfulde (Cameroon)	CAM	u				
-fub	Fulfulde (Cameroon)	CAM	bː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	dː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	ɗː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	kː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	ɡː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	t̠ʃː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	ɓː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	mː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	nː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	lː	entire inventory of geminates not given			
-fub	Fulfulde (Cameroon)	CAM	iː				
-fub	Fulfulde (Cameroon)	CAM	eː				
-fub	Fulfulde (Cameroon)	CAM	aː				
-fub	Fulfulde (Cameroon)	CAM	oː				
-fub	Fulfulde (Cameroon)	CAM	uː				
-							
+fub	Fulfulde (Cameroon)	CAM	ɓ
+fub	Fulfulde (Cameroon)	CAM	ʔʲ
+fub	Fulfulde (Cameroon)	CAM	m
+fub	Fulfulde (Cameroon)	CAM	ɲ
+fub	Fulfulde (Cameroon)	CAM	f
+fub	Fulfulde (Cameroon)	CAM	t
+fub	Fulfulde (Cameroon)	CAM	d
+fub	Fulfulde (Cameroon)	CAM	ɗ
+fub	Fulfulde (Cameroon)	CAM	mb
+fub	Fulfulde (Cameroon)	CAM	nd
+fub	Fulfulde (Cameroon)	CAM	n̠d̠ʒ	updated from ɲdʒ
+fub	Fulfulde (Cameroon)	CAM	ŋɡ
+fub	Fulfulde (Cameroon)	CAM	n
+fub	Fulfulde (Cameroon)	CAM	s
+fub	Fulfulde (Cameroon)	CAM	<ʒ>	borrowed words only
+fub	Fulfulde (Cameroon)	CAM	h		[h]	word final
+fub	Fulfulde (Cameroon)	CAM	h		[ɦ]	word final
+fub	Fulfulde (Cameroon)	CAM	l
+fub	Fulfulde (Cameroon)	CAM	r
+fub	Fulfulde (Cameroon)	CAM	t̠ʃ
+fub	Fulfulde (Cameroon)	CAM	d̠ʒ
+fub	Fulfulde (Cameroon)	CAM	ɡ
+fub	Fulfulde (Cameroon)	CAM	k
+fub	Fulfulde (Cameroon)	CAM	ŋ
+fub	Fulfulde (Cameroon)	CAM	<q>	borrowed words only
+fub	Fulfulde (Cameroon)	CAM	w
+fub	Fulfulde (Cameroon)	CAM	j
+fub	Fulfulde (Cameroon)	CAM	i
+fub	Fulfulde (Cameroon)	CAM	e
+fub	Fulfulde (Cameroon)	CAM	a
+fub	Fulfulde (Cameroon)	CAM	o
+fub	Fulfulde (Cameroon)	CAM	u
+fub	Fulfulde (Cameroon)	CAM	bː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	dː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	ɗː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	kː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	ɡː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	t̠ʃː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	ɓː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	mː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	nː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	lː	entire inventory of geminates not given
+fub	Fulfulde (Cameroon)	CAM	iː
+fub	Fulfulde (Cameroon)	CAM	eː
+fub	Fulfulde (Cameroon)	CAM	aː
+fub	Fulfulde (Cameroon)	CAM	oː
+fub	Fulfulde (Cameroon)	CAM	uː
+
 any	Anyi Sanvi		ɪ				agni_ahua2004_s.pdf
-any	Anyi Sanvi		ʊ				
-any	Anyi Sanvi		ɡb				
-any	Anyi Sanvi		kp				
-any	Anyi Sanvi		ɔ				
-any	Anyi Sanvi		c		[c]		
-any	Anyi Sanvi		c		[ç]		
-any	Anyi Sanvi		ɟ				
-any	Anyi Sanvi		ʌ				
-any	Anyi Sanvi		ɛ				
-any	Anyi Sanvi		b				
-any	Anyi Sanvi		e				
-any	Anyi Sanvi		d				
-any	Anyi Sanvi		ɡ				
-any	Anyi Sanvi		f				
-any	Anyi Sanvi		i				
-any	Anyi Sanvi		h				
-any	Anyi Sanvi		k				
-any	Anyi Sanvi		j				
-any	Anyi Sanvi		m				
-any	Anyi Sanvi		l				
-any	Anyi Sanvi		o				
-any	Anyi Sanvi		n		[n]		
-any	Anyi Sanvi		n		[ŋ]		
-any	Anyi Sanvi		n		[ɲ]		
-any	Anyi Sanvi		p				
-any	Anyi Sanvi		s		[s]		
-any	Anyi Sanvi		s		[z]		
-any	Anyi Sanvi		u				
-any	Anyi Sanvi		t				
-any	Anyi Sanvi		w				
-any	Anyi Sanvi		a				
-any	Anyi Sanvi		ĩ				
-any	Anyi Sanvi		ɪ̃				
-any	Anyi Sanvi		ʌ̃				
-any	Anyi Sanvi		ũ				
-any	Anyi Sanvi		ʊ̃				
-any	Anyi Sanvi		ã				
-any	Anyi Sanvi		<ɥ>	discussed as marginal phoneme, but no examples given			
-any	Anyi Sanvi		˦				
-any	Anyi Sanvi		˧				
-any	Anyi Sanvi		˨				
-any	Anyi Sanvi		˨˦				
-any	Anyi Sanvi		˦˨				
-							
+any	Anyi Sanvi		ʊ
+any	Anyi Sanvi		ɡb
+any	Anyi Sanvi		kp
+any	Anyi Sanvi		ɔ
+any	Anyi Sanvi		c		[c]
+any	Anyi Sanvi		c		[ç]
+any	Anyi Sanvi		ɟ
+any	Anyi Sanvi		ʌ
+any	Anyi Sanvi		ɛ
+any	Anyi Sanvi		b
+any	Anyi Sanvi		e
+any	Anyi Sanvi		d
+any	Anyi Sanvi		ɡ
+any	Anyi Sanvi		f
+any	Anyi Sanvi		i
+any	Anyi Sanvi		h
+any	Anyi Sanvi		k
+any	Anyi Sanvi		j
+any	Anyi Sanvi		m
+any	Anyi Sanvi		l
+any	Anyi Sanvi		o
+any	Anyi Sanvi		n		[n]
+any	Anyi Sanvi		n		[ŋ]
+any	Anyi Sanvi		n		[ɲ]
+any	Anyi Sanvi		p
+any	Anyi Sanvi		s		[s]
+any	Anyi Sanvi		s		[z]
+any	Anyi Sanvi		u
+any	Anyi Sanvi		t
+any	Anyi Sanvi		w
+any	Anyi Sanvi		a
+any	Anyi Sanvi		ĩ
+any	Anyi Sanvi		ɪ̃
+any	Anyi Sanvi		ʌ̃
+any	Anyi Sanvi		ũ
+any	Anyi Sanvi		ʊ̃
+any	Anyi Sanvi		ã
+any	Anyi Sanvi		<ɥ>	discussed as marginal phoneme, but no examples given
+any	Anyi Sanvi		˦
+any	Anyi Sanvi		˧
+any	Anyi Sanvi		˨
+any	Anyi Sanvi		˨˦
+any	Anyi Sanvi		˦˨
+
 any	Agni Djuablin		ɪ				agni_ahua2004_s.pdf
-any	Agni Djuablin		ʊ				
-any	Agni Djuablin		ʃ				
-any	Agni Djuablin		ɔ				
-any	Agni Djuablin		c				
-any	Agni Djuablin		ɟ				
-any	Agni Djuablin		ɛ				
-any	Agni Djuablin		b				
-any	Agni Djuablin		e				
-any	Agni Djuablin		d				
-any	Agni Djuablin		ɡ				
-any	Agni Djuablin		f		[f]		
-any	Agni Djuablin		f		[v]		
-any	Agni Djuablin		i				
-any	Agni Djuablin		h				
-any	Agni Djuablin		k				
-any	Agni Djuablin		j				
-any	Agni Djuablin		m				
-any	Agni Djuablin		r		[r]		
-any	Agni Djuablin		r		[ɾ]		
-any	Agni Djuablin		o				
-any	Agni Djuablin		n		[n]		
-any	Agni Djuablin		n		[ŋ]		
-any	Agni Djuablin		n		[ɲ]		
-any	Agni Djuablin		p				
-any	Agni Djuablin		s		[s]		
-any	Agni Djuablin		s		[z]		
-any	Agni Djuablin		u				
-any	Agni Djuablin		t				
-any	Agni Djuablin		w				
-any	Agni Djuablin		a				
-any	Agni Djuablin		ĩ				
-any	Agni Djuablin		ɪ̃				
-any	Agni Djuablin		ũ				
-any	Agni Djuablin		ʊ̃				
-any	Agni Djuablin		ã				
-any	Agni Djuablin		˦				
-any	Agni Djuablin		˧				
-any	Agni Djuablin		˨				
-any	Agni Djuablin		˨˦				
-any	Agni Djuablin		˦˨				
-							
+any	Agni Djuablin		ʊ
+any	Agni Djuablin		ʃ
+any	Agni Djuablin		ɔ
+any	Agni Djuablin		c
+any	Agni Djuablin		ɟ
+any	Agni Djuablin		ɛ
+any	Agni Djuablin		b
+any	Agni Djuablin		e
+any	Agni Djuablin		d
+any	Agni Djuablin		ɡ
+any	Agni Djuablin		f		[f]
+any	Agni Djuablin		f		[v]
+any	Agni Djuablin		i
+any	Agni Djuablin		h
+any	Agni Djuablin		k
+any	Agni Djuablin		j
+any	Agni Djuablin		m
+any	Agni Djuablin		r		[r]
+any	Agni Djuablin		r		[ɾ]
+any	Agni Djuablin		o
+any	Agni Djuablin		n		[n]
+any	Agni Djuablin		n		[ŋ]
+any	Agni Djuablin		n		[ɲ]
+any	Agni Djuablin		p
+any	Agni Djuablin		s		[s]
+any	Agni Djuablin		s		[z]
+any	Agni Djuablin		u
+any	Agni Djuablin		t
+any	Agni Djuablin		w
+any	Agni Djuablin		a
+any	Agni Djuablin		ĩ
+any	Agni Djuablin		ɪ̃
+any	Agni Djuablin		ũ
+any	Agni Djuablin		ʊ̃
+any	Agni Djuablin		ã
+any	Agni Djuablin		˦
+any	Agni Djuablin		˧
+any	Agni Djuablin		˨
+any	Agni Djuablin		˨˦
+any	Agni Djuablin		˦˨
+
 mtb	Agni Morofo		ɪ				agni_quaireau1987_o.pdf
-mtb	Agni Morofo		ʊ				
-mtb	Agni Morofo		ɔ				
-mtb	Agni Morofo		c				
-mtb	Agni Morofo		ɟ				
-mtb	Agni Morofo		ɛ				
-mtb	Agni Morofo		b				
-mtb	Agni Morofo		kp				
-mtb	Agni Morofo		ɡb				
-mtb	Agni Morofo		e				
-mtb	Agni Morofo		d				
-mtb	Agni Morofo		ɲ				
-mtb	Agni Morofo		ɡ				
-mtb	Agni Morofo		f				
-mtb	Agni Morofo		i				
-mtb	Agni Morofo		h				
-mtb	Agni Morofo		v				
-mtb	Agni Morofo		z				
-mtb	Agni Morofo		k				
-mtb	Agni Morofo		j				
-mtb	Agni Morofo		mb				
-mtb	Agni Morofo		nd				
-mtb	Agni Morofo		ɱv				
-mtb	Agni Morofo		ŋmɡb				
-mtb	Agni Morofo		nz				
-mtb	Agni Morofo		ɲɟ				
-mtb	Agni Morofo		ŋɡ				
-mtb	Agni Morofo		mː				
-mtb	Agni Morofo		nː				
-mtb	Agni Morofo		ɲː				
-mtb	Agni Morofo		m				
-mtb	Agni Morofo		o				
-mtb	Agni Morofo		n				
-mtb	Agni Morofo		p				
-mtb	Agni Morofo		s				
-mtb	Agni Morofo		u				
-mtb	Agni Morofo		t				
-mtb	Agni Morofo		w				
-mtb	Agni Morofo		a				
-mtb	Agni Morofo		ĩ				
-mtb	Agni Morofo		ɪ̃				
-mtb	Agni Morofo		ũ				
-mtb	Agni Morofo		ʊ̃				
-mtb	Agni Morofo		ã				
-mtb	Agni Morofo		ɥ				
-mtb	Agni Morofo		˦				
-mtb	Agni Morofo		˨				
-mtb	Agni Morofo		˨˦				
-mtb	Agni Morofo		˦˨				
-							
+mtb	Agni Morofo		ʊ
+mtb	Agni Morofo		ɔ
+mtb	Agni Morofo		c
+mtb	Agni Morofo		ɟ
+mtb	Agni Morofo		ɛ
+mtb	Agni Morofo		b
+mtb	Agni Morofo		kp
+mtb	Agni Morofo		ɡb
+mtb	Agni Morofo		e
+mtb	Agni Morofo		d
+mtb	Agni Morofo		ɲ
+mtb	Agni Morofo		ɡ
+mtb	Agni Morofo		f
+mtb	Agni Morofo		i
+mtb	Agni Morofo		h
+mtb	Agni Morofo		v
+mtb	Agni Morofo		z
+mtb	Agni Morofo		k
+mtb	Agni Morofo		j
+mtb	Agni Morofo		mb
+mtb	Agni Morofo		nd
+mtb	Agni Morofo		ɱv
+mtb	Agni Morofo		ŋmɡb
+mtb	Agni Morofo		nz
+mtb	Agni Morofo		ɲɟ
+mtb	Agni Morofo		ŋɡ
+mtb	Agni Morofo		mː
+mtb	Agni Morofo		nː
+mtb	Agni Morofo		ɲː
+mtb	Agni Morofo		m
+mtb	Agni Morofo		o
+mtb	Agni Morofo		n
+mtb	Agni Morofo		p
+mtb	Agni Morofo		s
+mtb	Agni Morofo		u
+mtb	Agni Morofo		t
+mtb	Agni Morofo		w
+mtb	Agni Morofo		a
+mtb	Agni Morofo		ĩ
+mtb	Agni Morofo		ɪ̃
+mtb	Agni Morofo		ũ
+mtb	Agni Morofo		ʊ̃
+mtb	Agni Morofo		ã
+mtb	Agni Morofo		ɥ
+mtb	Agni Morofo		˦
+mtb	Agni Morofo		˨
+mtb	Agni Morofo		˨˦
+mtb	Agni Morofo		˦˨
+
 aka	Akan		i				aka_dolphyne1988.pdf
-aka	Akan		ɪ				
-aka	Akan		e				
-aka	Akan		ɛ				
-aka	Akan		æ				
-aka	Akan		a				
-aka	Akan		u				
-aka	Akan		ʊ				
-aka	Akan		o				
-aka	Akan		ɔ				
-aka	Akan		iː				
-aka	Akan		ɪː				
-aka	Akan		eː				
-aka	Akan		ɛː				
-aka	Akan		æː				
-aka	Akan		aː				
-aka	Akan		uː				
-aka	Akan		ʊː				
-aka	Akan		oː				
-aka	Akan		ɔː				
-aka	Akan		ĩ				
-aka	Akan		ɪ̃				
-aka	Akan		ẽ				
-aka	Akan		ɛ̃				
-aka	Akan		æ̃				
-aka	Akan		ã				
-aka	Akan		ũ				
-aka	Akan		ʊ̃				
-aka	Akan		õ				
-aka	Akan		ɔ̃				
-aka	Akan		p				
-aka	Akan		b				
-aka	Akan		t				
-aka	Akan		d				
-aka	Akan		ts				
-aka	Akan		dz				
-aka	Akan		kʷ				
-aka	Akan		ɡʷ				
-aka	Akan		tɕ				
-aka	Akan		dʑ				
-aka	Akan		tɕᶣ				
-aka	Akan		dʑᶣ				
-aka	Akan		m				
-aka	Akan		n				
-aka	Akan		ɲ				
-aka	Akan		ŋ				
-aka	Akan		ɲᶣ				
-aka	Akan		ŋʷ				
-aka	Akan		f				
-aka	Akan		s				
-aka	Akan		l				
-aka	Akan		r				
-aka	Akan		ɕ				
-aka	Akan		ɕᶣ				
-aka	Akan		sᶣ				
-aka	Akan		h				
-aka	Akan		w				
-aka	Akan		ɥ				
-aka	Akan		˦				
-aka	Akan		˨				
-							
+aka	Akan		ɪ
+aka	Akan		e
+aka	Akan		ɛ
+aka	Akan		æ
+aka	Akan		a
+aka	Akan		u
+aka	Akan		ʊ
+aka	Akan		o
+aka	Akan		ɔ
+aka	Akan		iː
+aka	Akan		ɪː
+aka	Akan		eː
+aka	Akan		ɛː
+aka	Akan		æː
+aka	Akan		aː
+aka	Akan		uː
+aka	Akan		ʊː
+aka	Akan		oː
+aka	Akan		ɔː
+aka	Akan		ĩ
+aka	Akan		ɪ̃
+aka	Akan		ẽ
+aka	Akan		ɛ̃
+aka	Akan		æ̃
+aka	Akan		ã
+aka	Akan		ũ
+aka	Akan		ʊ̃
+aka	Akan		õ
+aka	Akan		ɔ̃
+aka	Akan		p
+aka	Akan		b
+aka	Akan		t
+aka	Akan		d
+aka	Akan		ts
+aka	Akan		dz
+aka	Akan		kʷ
+aka	Akan		ɡʷ
+aka	Akan		tɕ
+aka	Akan		dʑ
+aka	Akan		tɕᶣ
+aka	Akan		dʑᶣ
+aka	Akan		m
+aka	Akan		n
+aka	Akan		ɲ
+aka	Akan		ŋ
+aka	Akan		ɲᶣ
+aka	Akan		ŋʷ
+aka	Akan		f
+aka	Akan		s
+aka	Akan		l
+aka	Akan		r
+aka	Akan		ɕ
+aka	Akan		ɕᶣ
+aka	Akan		sᶣ
+aka	Akan		h
+aka	Akan		w
+aka	Akan		ɥ
+aka	Akan		˦
+aka	Akan		˨
+
 cko	anufɔ		˦				chakosi_stanford1970.pdf
-cko	anufɔ		˨				
-cko	anufɔ		ɡb				
-cko	anufɔ		ɡbʲ	contrast only before front vowels			
-cko	anufɔ		ɟ				
-cko	anufɔ		ɟʲ	contrast only before front vowels			
-cko	anufɔ		c				
-cko	anufɔ		cʲ	contrast only before front vowels			
-cko	anufɔ		ɕᶣ	contrast only before front vowels			
-cko	anufɔ		ʑᶣ	contrast only before front vowels			
-cko	anufɔ		kp				
-cko	anufɔ		kpʲ	contrast only before front vowels			
-cko	anufɔ		ŋ				
-cko	anufɔ		ŋm				
-cko	anufɔ		ŋmʲ	contrast only before front vowels			
-cko	anufɔ		ɔ				
-cko	anufɔ		ɛ				
-cko	anufɔ		a				
-cko	anufɔ		ʃ				
-cko	anufɔ		b				
-cko	anufɔ		bʲ	contrast only before front vowels			
-cko	anufɔ		bʷ	contrast only before front vowels			
-cko	anufɔ		e				
-cko	anufɔ		d				
-cko	anufɔ		dʲ	contrast only before front vowels			
-cko	anufɔ		ɡ				
-cko	anufɔ		ɡʷ	contrast only before front vowels			
-cko	anufɔ		f				
-cko	anufɔ		fʲ	contrast only before front vowels			
-cko	anufɔ		fʷ	contrast only before front vowels			
-cko	anufɔ		i				
-cko	anufɔ		h				
-cko	anufɔ		k				
-cko	anufɔ		kʷ	contrast only before front vowels			
-cko	anufɔ		j				
-cko	anufɔ		m				
-cko	anufɔ		mʲ	contrast only before front vowels			
-cko	anufɔ		l				
-cko	anufɔ		lᶣ	contrast only before front vowels			
-cko	anufɔ		r				
-cko	anufɔ		o				
-cko	anufɔ		n				
-cko	anufɔ		p				
-cko	anufɔ		pʷ	contrast only before front vowels			
-cko	anufɔ		pʲ	contrast only before front vowels			
-cko	anufɔ		s				
-cko	anufɔ		z				
-cko	anufɔ		ɲ	contrast only before front vowels			
-cko	anufɔ		u				
-cko	anufɔ		t				
-cko	anufɔ		tʲ	contrast only before front vowels			
-cko	anufɔ		w				
-cko	anufɔ		ɥ	contrast only before front vowels			
-cko	anufɔ		ɥ̥	contrast only before front vowels			
-cko	anufɔ		ĩ				
-cko	anufɔ		ɛ̃				
-cko	anufɔ		ũ				
-cko	anufɔ		ɔ̃				
-cko	anufɔ		ã				
-							
+cko	anufɔ		˨
+cko	anufɔ		ɡb
+cko	anufɔ		ɡbʲ	contrast only before front vowels
+cko	anufɔ		ɟ
+cko	anufɔ		ɟʲ	contrast only before front vowels
+cko	anufɔ		c
+cko	anufɔ		cʲ	contrast only before front vowels
+cko	anufɔ		ɕᶣ	contrast only before front vowels
+cko	anufɔ		ʑᶣ	contrast only before front vowels
+cko	anufɔ		kp
+cko	anufɔ		kpʲ	contrast only before front vowels
+cko	anufɔ		ŋ
+cko	anufɔ		ŋm
+cko	anufɔ		ŋmʲ	contrast only before front vowels
+cko	anufɔ		ɔ
+cko	anufɔ		ɛ
+cko	anufɔ		a
+cko	anufɔ		ʃ
+cko	anufɔ		b
+cko	anufɔ		bʲ	contrast only before front vowels
+cko	anufɔ		bʷ	contrast only before front vowels
+cko	anufɔ		e
+cko	anufɔ		d
+cko	anufɔ		dʲ	contrast only before front vowels
+cko	anufɔ		ɡ
+cko	anufɔ		ɡʷ	contrast only before front vowels
+cko	anufɔ		f
+cko	anufɔ		fʲ	contrast only before front vowels
+cko	anufɔ		fʷ	contrast only before front vowels
+cko	anufɔ		i
+cko	anufɔ		h
+cko	anufɔ		k
+cko	anufɔ		kʷ	contrast only before front vowels
+cko	anufɔ		j
+cko	anufɔ		m
+cko	anufɔ		mʲ	contrast only before front vowels
+cko	anufɔ		l
+cko	anufɔ		lᶣ	contrast only before front vowels
+cko	anufɔ		r
+cko	anufɔ		o
+cko	anufɔ		n
+cko	anufɔ		p
+cko	anufɔ		pʷ	contrast only before front vowels
+cko	anufɔ		pʲ	contrast only before front vowels
+cko	anufɔ		s
+cko	anufɔ		z
+cko	anufɔ		ɲ	contrast only before front vowels
+cko	anufɔ		u
+cko	anufɔ		t
+cko	anufɔ		tʲ	contrast only before front vowels
+cko	anufɔ		w
+cko	anufɔ		ɥ	contrast only before front vowels
+cko	anufɔ		ɥ̥	contrast only before front vowels
+cko	anufɔ		ĩ
+cko	anufɔ		ɛ̃
+cko	anufɔ		ũ
+cko	anufɔ		ɔ̃
+cko	anufɔ		ã
+
 bvx	babole		i				babole.pdf
-bvx	babole		u				
-bvx	babole		e				
-bvx	babole		ɛ				
-bvx	babole		ɔ				
-bvx	babole		a				
-bvx	babole		p	alternates with h			
-bvx	babole		b	marginal, alternates with ɸ	[b]	[b] found before [i]/[u] and phrase initially	
-bvx	babole		b	marginal, alternates with ɸ	[ɸ]	[b] found before [i]/[u] and phrase initially	
-bvx	babole		t				
-bvx	babole		k				
-bvx	babole		s				
-bvx	babole		h				
-bvx	babole		<ts>	marginal			
-bvx	babole		<dz>	marginal			
-bvx	babole		<mp>	marginal			
-bvx	babole		<nt>	marginal			
-bvx	babole		<nts>	marginal			
-bvx	babole		<ŋk>	marginal			
-bvx	babole		<ndz>	marginal			
-bvx	babole		<ns>	marginal			
-bvx	babole		<w>	marginal			
-bvx	babole		<j>	marginal			
-bvx	babole		mb				
-bvx	babole		ŋɡ				
-bvx	babole		m				
-bvx	babole		l		[l]	[d] is found only before [i]	
-bvx	babole		l		[d]	[d] is found only before [i]	
-bvx	babole		n				
-bvx	babole		˦				
-bvx	babole		˨				
-bvx	babole		˦˨				
-bvx	babole		˨˦				
-							
+bvx	babole		u
+bvx	babole		e
+bvx	babole		ɛ
+bvx	babole		ɔ
+bvx	babole		a
+bvx	babole		p	alternates with h
+bvx	babole		b	marginal, alternates with ɸ	[b]	[b] found before [i]/[u] and phrase initially
+bvx	babole		b	marginal, alternates with ɸ	[ɸ]	[b] found before [i]/[u] and phrase initially
+bvx	babole		t
+bvx	babole		k
+bvx	babole		s
+bvx	babole		h
+bvx	babole		<ts>	marginal
+bvx	babole		<dz>	marginal
+bvx	babole		<mp>	marginal
+bvx	babole		<nt>	marginal
+bvx	babole		<nts>	marginal
+bvx	babole		<ŋk>	marginal
+bvx	babole		<ndz>	marginal
+bvx	babole		<ns>	marginal
+bvx	babole		<w>	marginal
+bvx	babole		<j>	marginal
+bvx	babole		mb
+bvx	babole		ŋɡ
+bvx	babole		m
+bvx	babole		l		[l]	[d] is found only before [i]
+bvx	babole		l		[d]	[d] is found only before [i]
+bvx	babole		n
+bvx	babole		˦
+bvx	babole		˨
+bvx	babole		˦˨
+bvx	babole		˨˦
+
 bcw	bana		p		[p]	before vowels	bana_hofmann1990_o.pdf
-bcw	bana		p		[pʰ]	before vowels	
-bcw	bana		b				
-bcw	bana		t		[t]	before vowels	
-bcw	bana		t		[tʰ]	before vowels	
-bcw	bana		d				
-bcw	bana		ts		[ts]	palatal prosody	
-bcw	bana		ts		[t̠ʃ]	palatal prosody	
-bcw	bana		dz		[dz]	palatal prosody	
-bcw	bana		dz		[d̠ʒ]	palatal prosody	
-bcw	bana		k		[k]	before vowels/palatal prosody	
-bcw	bana		k		[kʲ]	before vowels/palatal prosody	
-bcw	bana		k		[kʰ]	before vowels/palatal prosody	
-bcw	bana		ɡʷ		[ɡʷ]	palatal prosody	
-bcw	bana		ɡʷ		[ɡʲ]	palatal prosody	
-bcw	bana		kʷ				
-bcw	bana		ɡ				
-bcw	bana		ɓ				
-bcw	bana		ɗ				
-bcw	bana		ʔ		[ʔ]	palatal prosody	
-bcw	bana		ʔ		[ʔʲ]	palatal prosody	
-bcw	bana		ʔʷ				
-bcw	bana		mb				
-bcw	bana		nd				
-bcw	bana		ndz		[ndz]	palatal prosody	
-bcw	bana		ndz		[n̠d̠ʒ]	palatal prosody	
-bcw	bana		ŋɡ		[ŋɡ]	palatal prosody	
-bcw	bana		ŋɡ		[ŋɡʲ]	palatal prosody	
-bcw	bana		ŋɡʷ				
-bcw	bana		f				
-bcw	bana		s		[s]	palatal prosody	
-bcw	bana		s		[ʃ]	palatal prosody	
-bcw	bana		χ		[χ]	palatal prosody	
-bcw	bana		χ		[χʲ]	palatal prosody	
-bcw	bana		χʷ				
-bcw	bana		ɬ				
-bcw	bana		v				
-bcw	bana		ɮ				
-bcw	bana		z		[z]	palatal prosody	
-bcw	bana		z		[ʒ]	palatal prosody	
-bcw	bana		ʁ		[ʁ]	palatal prosody	
-bcw	bana		ʁ		[ɣ]	palatal prosody	
-bcw	bana		ʁʷ				
-bcw	bana		m				
-bcw	bana		n				
-bcw	bana		ŋ				
-bcw	bana		ŋʷ				
-bcw	bana		<ⱱ>	marginal, only in ideophones and between high central vowels			
-bcw	bana		ɾ		[ɾ]	pre-pause	
-bcw	bana		ɾ		[r̥]	pre-pause	
-bcw	bana		j				
-bcw	bana		w				
-bcw	bana		ɛ				
-bcw	bana		ə		[ə]	palatal prosody	
-bcw	bana		ə		[i]	palatal prosody	
-bcw	bana		ɨ				
-bcw	bana		˦				
-bcw	bana		˨				
-bcw	bana		˦˨				
-bcw	bana		˨˦				
-							
+bcw	bana		p		[pʰ]	before vowels
+bcw	bana		b
+bcw	bana		t		[t]	before vowels
+bcw	bana		t		[tʰ]	before vowels
+bcw	bana		d
+bcw	bana		ts		[ts]	palatal prosody
+bcw	bana		ts		[t̠ʃ]	palatal prosody
+bcw	bana		dz		[dz]	palatal prosody
+bcw	bana		dz		[d̠ʒ]	palatal prosody
+bcw	bana		k		[k]	before vowels/palatal prosody
+bcw	bana		k		[kʲ]	before vowels/palatal prosody
+bcw	bana		k		[kʰ]	before vowels/palatal prosody
+bcw	bana		ɡʷ		[ɡʷ]	palatal prosody
+bcw	bana		ɡʷ		[ɡʲ]	palatal prosody
+bcw	bana		kʷ
+bcw	bana		ɡ
+bcw	bana		ɓ
+bcw	bana		ɗ
+bcw	bana		ʔ		[ʔ]	palatal prosody
+bcw	bana		ʔ		[ʔʲ]	palatal prosody
+bcw	bana		ʔʷ
+bcw	bana		mb
+bcw	bana		nd
+bcw	bana		ndz		[ndz]	palatal prosody
+bcw	bana		ndz		[n̠d̠ʒ]	palatal prosody
+bcw	bana		ŋɡ		[ŋɡ]	palatal prosody
+bcw	bana		ŋɡ		[ŋɡʲ]	palatal prosody
+bcw	bana		ŋɡʷ
+bcw	bana		f
+bcw	bana		s		[s]	palatal prosody
+bcw	bana		s		[ʃ]	palatal prosody
+bcw	bana		χ		[χ]	palatal prosody
+bcw	bana		χ		[χʲ]	palatal prosody
+bcw	bana		χʷ
+bcw	bana		ɬ
+bcw	bana		v
+bcw	bana		ɮ
+bcw	bana		z		[z]	palatal prosody
+bcw	bana		z		[ʒ]	palatal prosody
+bcw	bana		ʁ		[ʁ]	palatal prosody
+bcw	bana		ʁ		[ɣ]	palatal prosody
+bcw	bana		ʁʷ
+bcw	bana		m
+bcw	bana		n
+bcw	bana		ŋ
+bcw	bana		ŋʷ
+bcw	bana		<ⱱ>	marginal, only in ideophones and between high central vowels
+bcw	bana		ɾ		[ɾ]	pre-pause
+bcw	bana		ɾ		[r̥]	pre-pause
+bcw	bana		j
+bcw	bana		w
+bcw	bana		ɛ
+bcw	bana		ə		[ə]	palatal prosody
+bcw	bana		ə		[i]	palatal prosody
+bcw	bana		ɨ
+bcw	bana		˦
+bcw	bana		˨
+bcw	bana		˦˨
+bcw	bana		˨˦
+
 bdh	baka		a				kresh_aja.pdf
-bdh	baka		u				
-bdh	baka		i				
-bdh	baka		ɛ				
-bdh	baka		ɔ				
-bdh	baka		ɐ				
-bdh	baka		b				
-bdh	baka		ɓ				
-bdh	baka		br	suspicious?			
-bdh	baka		tɕ				
-bdh	baka		d				
-bdh	baka		ɗ				
-bdh	baka		ɖ				
-bdh	baka		f				
-bdh	baka		ɡ				
-bdh	baka		ɡb				
-bdh	baka		h				
-bdh	baka		x				
-bdh	baka		ɣ				
-bdh	baka		ħ				
-bdh	baka		ʕ				
-bdh	baka		e				
-bdh	baka		dʑ				
-bdh	baka		ɪ				
-bdh	baka		k				
-bdh	baka		kp				
-bdh	baka		l				
-bdh	baka		m				
-bdh	baka		n				
-bdh	baka		ɲ				
-bdh	baka		ŋ				
-bdh	baka		o				
-bdh	baka		p				
-bdh	baka		r				
-bdh	baka		ɾ				
-bdh	baka		ʃ				
-bdh	baka		s				
-bdh	baka		t				
-bdh	baka		ts				
-bdh	baka		θ				
-bdh	baka		ʊ				
-bdh	baka		ⱱ				
-bdh	baka		v				
-bdh	baka		w				
-bdh	baka		j				
-bdh	baka		ʒ				
-							
+bdh	baka		u
+bdh	baka		i
+bdh	baka		ɛ
+bdh	baka		ɔ
+bdh	baka		ɐ
+bdh	baka		b
+bdh	baka		ɓ
+bdh	baka		br	suspicious?
+bdh	baka		tɕ
+bdh	baka		d
+bdh	baka		ɗ
+bdh	baka		ɖ
+bdh	baka		f
+bdh	baka		ɡ
+bdh	baka		ɡb
+bdh	baka		h
+bdh	baka		x
+bdh	baka		ɣ
+bdh	baka		ħ
+bdh	baka		ʕ
+bdh	baka		e
+bdh	baka		dʑ
+bdh	baka		ɪ
+bdh	baka		k
+bdh	baka		kp
+bdh	baka		l
+bdh	baka		m
+bdh	baka		n
+bdh	baka		ɲ
+bdh	baka		ŋ
+bdh	baka		o
+bdh	baka		p
+bdh	baka		r
+bdh	baka		ɾ
+bdh	baka		ʃ
+bdh	baka		s
+bdh	baka		t
+bdh	baka		ts
+bdh	baka		θ
+bdh	baka		ʊ
+bdh	baka		ⱱ
+bdh	baka		v
+bdh	baka		w
+bdh	baka		j
+bdh	baka		ʒ
+
 aja	aja		a				kresh_aja.pdf
-aja	aja		u				
-aja	aja		i				
-aja	aja		ɛ				
-aja	aja		ɔ				
-aja	aja		ɐ				
-aja	aja		b				
-aja	aja		ɓ				
-aja	aja		tɕ				
-aja	aja		d				
-aja	aja		ɟ				
-aja	aja		ɗ				
-aja	aja		ɖ				
-aja	aja		f				
-aja	aja		ɡ				
-aja	aja		ɡb				
-aja	aja		h				
-aja	aja		x				
-aja	aja		ɣ				
-aja	aja		ħ				
-aja	aja		ʕ				
-aja	aja		e				
-aja	aja		dʑ				
-aja	aja		ɪ				
-aja	aja		k				
-aja	aja		kp				
-aja	aja		l				
-aja	aja		m				
-aja	aja		n				
-aja	aja		ɲ				
-aja	aja		ŋ				
-aja	aja		o				
-aja	aja		p				
-aja	aja		r				
-aja	aja		ɾ				
-aja	aja		ʃ				
-aja	aja		s				
-aja	aja		t				
-aja	aja		ʈ				
-aja	aja		c				
-aja	aja		ts				
-aja	aja		θ				
-aja	aja		ʊ				
-aja	aja		ⱱ				
-aja	aja		v				
-aja	aja		w				
-aja	aja		j				
-aja	aja		ʒ				
-							
+aja	aja		u
+aja	aja		i
+aja	aja		ɛ
+aja	aja		ɔ
+aja	aja		ɐ
+aja	aja		b
+aja	aja		ɓ
+aja	aja		tɕ
+aja	aja		d
+aja	aja		ɟ
+aja	aja		ɗ
+aja	aja		ɖ
+aja	aja		f
+aja	aja		ɡ
+aja	aja		ɡb
+aja	aja		h
+aja	aja		x
+aja	aja		ɣ
+aja	aja		ħ
+aja	aja		ʕ
+aja	aja		e
+aja	aja		dʑ
+aja	aja		ɪ
+aja	aja		k
+aja	aja		kp
+aja	aja		l
+aja	aja		m
+aja	aja		n
+aja	aja		ɲ
+aja	aja		ŋ
+aja	aja		o
+aja	aja		p
+aja	aja		r
+aja	aja		ɾ
+aja	aja		ʃ
+aja	aja		s
+aja	aja		t
+aja	aja		ʈ
+aja	aja		c
+aja	aja		ts
+aja	aja		θ
+aja	aja		ʊ
+aja	aja		ⱱ
+aja	aja		v
+aja	aja		w
+aja	aja		j
+aja	aja		ʒ
+
 bip	bila		i				bila.pdf
-bip	bila		ɪ				
-bip	bila		u				
-bip	bila		ʊ				
-bip	bila		e				
-bip	bila		ɛ				
-bip	bila		o				
-bip	bila		ɔ				
-bip	bila		a				
-bip	bila		ɓ				
-bip	bila		ɗ				
-bip	bila		p				
-bip	bila		t				
-bip	bila		t̠ʃ				
-bip	bila		k				
-bip	bila		kp				
-bip	bila		mb				
-bip	bila		nd				
-bip	bila		n̠d̠ʒ	updated from ɲdʒ			
-bip	bila		ŋɡ				
-bip	bila		ŋmɡb				
-bip	bila		ɸ				
-bip	bila		s				
-bip	bila		h				
-bip	bila		mb				
-bip	bila		nd				
-bip	bila		ɲ				
-bip	bila		l				
-bip	bila		j				
-bip	bila		w				
-bip	bila		˦				
-bip	bila		˧				
-bip	bila		˨				
-bip	bila		˨˧				
-bip	bila		˨˦				
-							
+bip	bila		ɪ
+bip	bila		u
+bip	bila		ʊ
+bip	bila		e
+bip	bila		ɛ
+bip	bila		o
+bip	bila		ɔ
+bip	bila		a
+bip	bila		ɓ
+bip	bila		ɗ
+bip	bila		p
+bip	bila		t
+bip	bila		t̠ʃ
+bip	bila		k
+bip	bila		kp
+bip	bila		mb
+bip	bila		nd
+bip	bila		n̠d̠ʒ	updated from ɲdʒ
+bip	bila		ŋɡ
+bip	bila		ŋmɡb
+bip	bila		ɸ
+bip	bila		s
+bip	bila		h
+bip	bila		mb
+bip	bila		nd
+bip	bila		ɲ
+bip	bila		l
+bip	bila		j
+bip	bila		w
+bip	bila		˦
+bip	bila		˧
+bip	bila		˨
+bip	bila		˨˧
+bip	bila		˨˦
+
 bqp	busa		i				busa.pdf
-bqp	busa		e				
-bqp	busa		a				
-bqp	busa		o				
-bqp	busa		u				
-bqp	busa		ɛ				
-bqp	busa		ɔ				
-bqp	busa		ɛ̃				
-bqp	busa		ɔ̃				
-bqp	busa		ũ				
-bqp	busa		ĩ				
-bqp	busa		ã				
-bqp	busa		kp				
-bqp	busa		ɡb				
-bqp	busa		p				
-bqp	busa		b				
-bqp	busa		t				
-bqp	busa		d				
-bqp	busa		k				
-bqp	busa		ɡ				
-bqp	busa		f				
-bqp	busa		s				
-bqp	busa		v				
-bqp	busa		z				
-bqp	busa		m				
-bqp	busa		n		[n]	word-initial,word-medial	
-bqp	busa		n		[l]	word-initial,word-medial	
-bqp	busa		n		[r]	word-initial,word-medial	
-bqp	busa		w				
-bqp	busa		j				
-bqp	busa		˦				
-bqp	busa		˧				
-bqp	busa		˨				
-							
+bqp	busa		e
+bqp	busa		a
+bqp	busa		o
+bqp	busa		u
+bqp	busa		ɛ
+bqp	busa		ɔ
+bqp	busa		ɛ̃
+bqp	busa		ɔ̃
+bqp	busa		ũ
+bqp	busa		ĩ
+bqp	busa		ã
+bqp	busa		kp
+bqp	busa		ɡb
+bqp	busa		p
+bqp	busa		b
+bqp	busa		t
+bqp	busa		d
+bqp	busa		k
+bqp	busa		ɡ
+bqp	busa		f
+bqp	busa		s
+bqp	busa		v
+bqp	busa		z
+bqp	busa		m
+bqp	busa		n		[n]	word-initial,word-medial
+bqp	busa		n		[l]	word-initial,word-medial
+bqp	busa		n		[r]	word-initial,word-medial
+bqp	busa		w
+bqp	busa		j
+bqp	busa		˦
+bqp	busa		˧
+bqp	busa		˨
+
 fub	fulfulde (fuunaangere)	fuunaangere	ʔ				fulfulde_bickoe2000_o.pdf
-fub	fulfulde (fuunaangere)	fuunaangere	r				
-fub	fulfulde (fuunaangere)	fuunaangere	ʔʲ				
-fub	fulfulde (fuunaangere)	fuunaangere	ŋ				
-fub	fulfulde (fuunaangere)	fuunaangere	ɓ				
-fub	fulfulde (fuunaangere)	fuunaangere	ɗ				
-fub	fulfulde (fuunaangere)	fuunaangere	d̠ʒ				
-fub	fulfulde (fuunaangere)	fuunaangere	a				
-fub	fulfulde (fuunaangere)	fuunaangere	t̠ʃ				
-fub	fulfulde (fuunaangere)	fuunaangere	b				
-fub	fulfulde (fuunaangere)	fuunaangere	e				
-fub	fulfulde (fuunaangere)	fuunaangere	d				
-fub	fulfulde (fuunaangere)	fuunaangere	ɡ				
-fub	fulfulde (fuunaangere)	fuunaangere	f				
-fub	fulfulde (fuunaangere)	fuunaangere	i				
-fub	fulfulde (fuunaangere)	fuunaangere	h				
-fub	fulfulde (fuunaangere)	fuunaangere	k				
-fub	fulfulde (fuunaangere)	fuunaangere	j				
-fub	fulfulde (fuunaangere)	fuunaangere	m				
-fub	fulfulde (fuunaangere)	fuunaangere	l				
-fub	fulfulde (fuunaangere)	fuunaangere	o				
-fub	fulfulde (fuunaangere)	fuunaangere	n				
-fub	fulfulde (fuunaangere)	fuunaangere	p				
-fub	fulfulde (fuunaangere)	fuunaangere	q				
-fub	fulfulde (fuunaangere)	fuunaangere	s				
-fub	fulfulde (fuunaangere)	fuunaangere	ɲ				
-fub	fulfulde (fuunaangere)	fuunaangere	u				
-fub	fulfulde (fuunaangere)	fuunaangere	t				
-fub	fulfulde (fuunaangere)	fuunaangere	mb				
-fub	fulfulde (fuunaangere)	fuunaangere	nd				
-fub	fulfulde (fuunaangere)	fuunaangere	n̠d̠ʒ	updated from ɲdʒ			
-fub	fulfulde (fuunaangere)	fuunaangere	ŋɡ				
-fub	fulfulde (fuunaangere)	fuunaangere	w				
-fub	fulfulde (fuunaangere)	fuunaangere	v				
-fub	fulfulde (fuunaangere)	fuunaangere	iː				
-fub	fulfulde (fuunaangere)	fuunaangere	eː				
-fub	fulfulde (fuunaangere)	fuunaangere	uː				
-fub	fulfulde (fuunaangere)	fuunaangere	oː				
-fub	fulfulde (fuunaangere)	fuunaangere	aː				
-							
+fub	fulfulde (fuunaangere)	fuunaangere	r
+fub	fulfulde (fuunaangere)	fuunaangere	ʔʲ
+fub	fulfulde (fuunaangere)	fuunaangere	ŋ
+fub	fulfulde (fuunaangere)	fuunaangere	ɓ
+fub	fulfulde (fuunaangere)	fuunaangere	ɗ
+fub	fulfulde (fuunaangere)	fuunaangere	d̠ʒ
+fub	fulfulde (fuunaangere)	fuunaangere	a
+fub	fulfulde (fuunaangere)	fuunaangere	t̠ʃ
+fub	fulfulde (fuunaangere)	fuunaangere	b
+fub	fulfulde (fuunaangere)	fuunaangere	e
+fub	fulfulde (fuunaangere)	fuunaangere	d
+fub	fulfulde (fuunaangere)	fuunaangere	ɡ
+fub	fulfulde (fuunaangere)	fuunaangere	f
+fub	fulfulde (fuunaangere)	fuunaangere	i
+fub	fulfulde (fuunaangere)	fuunaangere	h
+fub	fulfulde (fuunaangere)	fuunaangere	k
+fub	fulfulde (fuunaangere)	fuunaangere	j
+fub	fulfulde (fuunaangere)	fuunaangere	m
+fub	fulfulde (fuunaangere)	fuunaangere	l
+fub	fulfulde (fuunaangere)	fuunaangere	o
+fub	fulfulde (fuunaangere)	fuunaangere	n
+fub	fulfulde (fuunaangere)	fuunaangere	p
+fub	fulfulde (fuunaangere)	fuunaangere	q
+fub	fulfulde (fuunaangere)	fuunaangere	s
+fub	fulfulde (fuunaangere)	fuunaangere	ɲ
+fub	fulfulde (fuunaangere)	fuunaangere	u
+fub	fulfulde (fuunaangere)	fuunaangere	t
+fub	fulfulde (fuunaangere)	fuunaangere	mb
+fub	fulfulde (fuunaangere)	fuunaangere	nd
+fub	fulfulde (fuunaangere)	fuunaangere	n̠d̠ʒ	updated from ɲdʒ
+fub	fulfulde (fuunaangere)	fuunaangere	ŋɡ
+fub	fulfulde (fuunaangere)	fuunaangere	w
+fub	fulfulde (fuunaangere)	fuunaangere	v
+fub	fulfulde (fuunaangere)	fuunaangere	iː
+fub	fulfulde (fuunaangere)	fuunaangere	eː
+fub	fulfulde (fuunaangere)	fuunaangere	uː
+fub	fulfulde (fuunaangere)	fuunaangere	oː
+fub	fulfulde (fuunaangere)	fuunaangere	aː
+
 fuv	fulfulde (NGA)	Kaceccereere	a				fulfulde_mcintosh1984_o.pdf
-fuv	fulfulde (NGA)	Kaceccereere	ɑː				
-fuv	fulfulde (NGA)	Kaceccereere	ɛ				
-fuv	fulfulde (NGA)	Kaceccereere	eː				
-fuv	fulfulde (NGA)	Kaceccereere	ɪ				
-fuv	fulfulde (NGA)	Kaceccereere	iː				
-fuv	fulfulde (NGA)	Kaceccereere	ɔ				
-fuv	fulfulde (NGA)	Kaceccereere	oː				
-fuv	fulfulde (NGA)	Kaceccereere	ʊ				
-fuv	fulfulde (NGA)	Kaceccereere	uː				
-fuv	fulfulde (NGA)	Kaceccereere	ɗ				
-fuv	fulfulde (NGA)	Kaceccereere	ɗː				
-fuv	fulfulde (NGA)	Kaceccereere	ɓ				
-fuv	fulfulde (NGA)	Kaceccereere	ɓː				
-fuv	fulfulde (NGA)	Kaceccereere	ʔ				
-fuv	fulfulde (NGA)	Kaceccereere	ʔʲ				
-fuv	fulfulde (NGA)	Kaceccereere	ʔʲː				
-fuv	fulfulde (NGA)	Kaceccereere	t				
-fuv	fulfulde (NGA)	Kaceccereere	tː				
-fuv	fulfulde (NGA)	Kaceccereere	l				
-fuv	fulfulde (NGA)	Kaceccereere	lː				
-fuv	fulfulde (NGA)	Kaceccereere	n				
-fuv	fulfulde (NGA)	Kaceccereere	nː				
-fuv	fulfulde (NGA)	Kaceccereere	m				
-fuv	fulfulde (NGA)	Kaceccereere	mː				
-fuv	fulfulde (NGA)	Kaceccereere	ɲ				
-fuv	fulfulde (NGA)	Kaceccereere	ɲː				
-fuv	fulfulde (NGA)	Kaceccereere	ŋ				
-fuv	fulfulde (NGA)	Kaceccereere	ŋː				
-fuv	fulfulde (NGA)	Kaceccereere	r				
-fuv	fulfulde (NGA)	Kaceccereere	rː				
-fuv	fulfulde (NGA)	Kaceccereere	w				
-fuv	fulfulde (NGA)	Kaceccereere	j				
-fuv	fulfulde (NGA)	Kaceccereere	h				
-fuv	fulfulde (NGA)	Kaceccereere	f				
-fuv	fulfulde (NGA)	Kaceccereere	s				
-fuv	fulfulde (NGA)	Kaceccereere	d				
-fuv	fulfulde (NGA)	Kaceccereere	dː				
-fuv	fulfulde (NGA)	Kaceccereere	ɡ				
-fuv	fulfulde (NGA)	Kaceccereere	ɡː				
-fuv	fulfulde (NGA)	Kaceccereere	b				
-fuv	fulfulde (NGA)	Kaceccereere	bː				
-fuv	fulfulde (NGA)	Kaceccereere	k				
-fuv	fulfulde (NGA)	Kaceccereere	kː				
-fuv	fulfulde (NGA)	Kaceccereere	p				
-fuv	fulfulde (NGA)	Kaceccereere	pː				
-fuv	fulfulde (NGA)	Kaceccereere	d̠ʒ				
-fuv	fulfulde (NGA)	Kaceccereere	d̠ʒː				
-fuv	fulfulde (NGA)	Kaceccereere	t̠ʃ				
-fuv	fulfulde (NGA)	Kaceccereere	t̠ʃː				
-fuv	fulfulde (NGA)	Kaceccereere	nd				
-fuv	fulfulde (NGA)	Kaceccereere	ndː				
-fuv	fulfulde (NGA)	Kaceccereere	mb				
-fuv	fulfulde (NGA)	Kaceccereere	mbː				
-fuv	fulfulde (NGA)	Kaceccereere	n̠d̠ʒ	updated from ɲdʒ			
-fuv	fulfulde (NGA)	Kaceccereere	ŋɡ				
-fuv	fulfulde (NGA)	Kaceccereere	ŋɡː				
-							
+fuv	fulfulde (NGA)	Kaceccereere	ɑː
+fuv	fulfulde (NGA)	Kaceccereere	ɛ
+fuv	fulfulde (NGA)	Kaceccereere	eː
+fuv	fulfulde (NGA)	Kaceccereere	ɪ
+fuv	fulfulde (NGA)	Kaceccereere	iː
+fuv	fulfulde (NGA)	Kaceccereere	ɔ
+fuv	fulfulde (NGA)	Kaceccereere	oː
+fuv	fulfulde (NGA)	Kaceccereere	ʊ
+fuv	fulfulde (NGA)	Kaceccereere	uː
+fuv	fulfulde (NGA)	Kaceccereere	ɗ
+fuv	fulfulde (NGA)	Kaceccereere	ɗː
+fuv	fulfulde (NGA)	Kaceccereere	ɓ
+fuv	fulfulde (NGA)	Kaceccereere	ɓː
+fuv	fulfulde (NGA)	Kaceccereere	ʔ
+fuv	fulfulde (NGA)	Kaceccereere	ʔʲ
+fuv	fulfulde (NGA)	Kaceccereere	ʔʲː
+fuv	fulfulde (NGA)	Kaceccereere	t
+fuv	fulfulde (NGA)	Kaceccereere	tː
+fuv	fulfulde (NGA)	Kaceccereere	l
+fuv	fulfulde (NGA)	Kaceccereere	lː
+fuv	fulfulde (NGA)	Kaceccereere	n
+fuv	fulfulde (NGA)	Kaceccereere	nː
+fuv	fulfulde (NGA)	Kaceccereere	m
+fuv	fulfulde (NGA)	Kaceccereere	mː
+fuv	fulfulde (NGA)	Kaceccereere	ɲ
+fuv	fulfulde (NGA)	Kaceccereere	ɲː
+fuv	fulfulde (NGA)	Kaceccereere	ŋ
+fuv	fulfulde (NGA)	Kaceccereere	ŋː
+fuv	fulfulde (NGA)	Kaceccereere	r
+fuv	fulfulde (NGA)	Kaceccereere	rː
+fuv	fulfulde (NGA)	Kaceccereere	w
+fuv	fulfulde (NGA)	Kaceccereere	j
+fuv	fulfulde (NGA)	Kaceccereere	h
+fuv	fulfulde (NGA)	Kaceccereere	f
+fuv	fulfulde (NGA)	Kaceccereere	s
+fuv	fulfulde (NGA)	Kaceccereere	d
+fuv	fulfulde (NGA)	Kaceccereere	dː
+fuv	fulfulde (NGA)	Kaceccereere	ɡ
+fuv	fulfulde (NGA)	Kaceccereere	ɡː
+fuv	fulfulde (NGA)	Kaceccereere	b
+fuv	fulfulde (NGA)	Kaceccereere	bː
+fuv	fulfulde (NGA)	Kaceccereere	k
+fuv	fulfulde (NGA)	Kaceccereere	kː
+fuv	fulfulde (NGA)	Kaceccereere	p
+fuv	fulfulde (NGA)	Kaceccereere	pː
+fuv	fulfulde (NGA)	Kaceccereere	d̠ʒ
+fuv	fulfulde (NGA)	Kaceccereere	d̠ʒː
+fuv	fulfulde (NGA)	Kaceccereere	t̠ʃ
+fuv	fulfulde (NGA)	Kaceccereere	t̠ʃː
+fuv	fulfulde (NGA)	Kaceccereere	nd
+fuv	fulfulde (NGA)	Kaceccereere	ndː
+fuv	fulfulde (NGA)	Kaceccereere	mb
+fuv	fulfulde (NGA)	Kaceccereere	mbː
+fuv	fulfulde (NGA)	Kaceccereere	n̠d̠ʒ	updated from ɲdʒ
+fuv	fulfulde (NGA)	Kaceccereere	ŋɡ
+fuv	fulfulde (NGA)	Kaceccereere	ŋɡː
+
 her	herero		θ				herero.pdf
-her	herero		h				
-her	herero		p				
-her	herero		t̪				
-her	herero		t				
-her	herero		ɕ				
-her	herero		k				
-her	herero		mb				
-her	herero		nd̪				
-her	herero		nd̪				
-her	herero		ndʑ				
-her	herero		ŋɡ				
-her	herero		mb				
-her	herero		n̪				
-her	herero		n				
-her	herero		ɲ				
-her	herero		v				
-her	herero		ð				
-her	herero		ɾ				
-her	herero		w				
-her	herero		j				
-her	herero		˦				
-her	herero		˨				
-her	herero		i				
-her	herero		e				
-her	herero		a				
-her	herero		u				
-her	herero		o				
-							
+her	herero		h
+her	herero		p
+her	herero		t̪
+her	herero		t
+her	herero		ɕ
+her	herero		k
+her	herero		mb
+her	herero		nd̪
+her	herero		nd̪
+her	herero		ndʑ
+her	herero		ŋɡ
+her	herero		mb
+her	herero		n̪
+her	herero		n
+her	herero		ɲ
+her	herero		v
+her	herero		ð
+her	herero		ɾ
+her	herero		w
+her	herero		j
+her	herero		˦
+her	herero		˨
+her	herero		i
+her	herero		e
+her	herero		a
+her	herero		u
+her	herero		o
+
 sef	Senoufo-Cebaara	Tangari	˦				Herington_etal2009-TanagriPhonology.pdf
-sef	Senoufo-Cebaara	Tangari	˧				
-sef	Senoufo-Cebaara	Tangari	˨				
-sef	Senoufo-Cebaara	Tangari	p		[p]	free variation	
-sef	Senoufo-Cebaara	Tangari	p		[pʰ]	free variation	
-sef	Senoufo-Cebaara	Tangari	b				
-sef	Senoufo-Cebaara	Tangari	t		[t]	free variation	
-sef	Senoufo-Cebaara	Tangari	t		[tʰ]	free variation	
-sef	Senoufo-Cebaara	Tangari	d				
-sef	Senoufo-Cebaara	Tangari	k		[k]	free variation	
-sef	Senoufo-Cebaara	Tangari	k		[kʰ]	free variation	
-sef	Senoufo-Cebaara	Tangari	ɡ		[ɡ]	word final	
-sef	Senoufo-Cebaara	Tangari	ɡ		[ɡ̚]	word final	
-sef	Senoufo-Cebaara	Tangari	ɡb				
-sef	Senoufo-Cebaara	Tangari	kp	word initial only			
-sef	Senoufo-Cebaara	Tangari	ʔ	word medial only			
-sef	Senoufo-Cebaara	Tangari	f				
-sef	Senoufo-Cebaara	Tangari	v	word initial only			
-sef	Senoufo-Cebaara	Tangari	s				
-sef	Senoufo-Cebaara	Tangari	z	word initial only			
-sef	Senoufo-Cebaara	Tangari	ʃ				
-sef	Senoufo-Cebaara	Tangari	ʒ	word initial only			
-sef	Senoufo-Cebaara	Tangari	t̠ʃ				
-sef	Senoufo-Cebaara	Tangari	d̠ʒ				
-sef	Senoufo-Cebaara	Tangari	m				
-sef	Senoufo-Cebaara	Tangari	n				
-sef	Senoufo-Cebaara	Tangari	ŋ	word initial only			
-sef	Senoufo-Cebaara	Tangari	l				
-sef	Senoufo-Cebaara	Tangari	r		[r]		
-sef	Senoufo-Cebaara	Tangari	r		[r̥]		
-sef	Senoufo-Cebaara	Tangari	r		[ɾ]		
-sef	Senoufo-Cebaara	Tangari	e				
-sef	Senoufo-Cebaara	Tangari	ɛ				
-sef	Senoufo-Cebaara	Tangari	ɛ̃				
-sef	Senoufo-Cebaara	Tangari	ɛː				
-sef	Senoufo-Cebaara	Tangari	o				
-sef	Senoufo-Cebaara	Tangari	ɔ				
-sef	Senoufo-Cebaara	Tangari	ɔː				
-sef	Senoufo-Cebaara	Tangari	ɔ̃				
-sef	Senoufo-Cebaara	Tangari	ɔ̃ː				
-sef	Senoufo-Cebaara	Tangari	a				
-sef	Senoufo-Cebaara	Tangari	ã				
-sef	Senoufo-Cebaara	Tangari	ãː				
-sef	Senoufo-Cebaara	Tangari	aː				
-							
+sef	Senoufo-Cebaara	Tangari	˧
+sef	Senoufo-Cebaara	Tangari	˨
+sef	Senoufo-Cebaara	Tangari	p		[p]	free variation
+sef	Senoufo-Cebaara	Tangari	p		[pʰ]	free variation
+sef	Senoufo-Cebaara	Tangari	b
+sef	Senoufo-Cebaara	Tangari	t		[t]	free variation
+sef	Senoufo-Cebaara	Tangari	t		[tʰ]	free variation
+sef	Senoufo-Cebaara	Tangari	d
+sef	Senoufo-Cebaara	Tangari	k		[k]	free variation
+sef	Senoufo-Cebaara	Tangari	k		[kʰ]	free variation
+sef	Senoufo-Cebaara	Tangari	ɡ		[ɡ]	word final
+sef	Senoufo-Cebaara	Tangari	ɡ		[ɡ̚]	word final
+sef	Senoufo-Cebaara	Tangari	ɡb
+sef	Senoufo-Cebaara	Tangari	kp	word initial only
+sef	Senoufo-Cebaara	Tangari	ʔ	word medial only
+sef	Senoufo-Cebaara	Tangari	f
+sef	Senoufo-Cebaara	Tangari	v	word initial only
+sef	Senoufo-Cebaara	Tangari	s
+sef	Senoufo-Cebaara	Tangari	z	word initial only
+sef	Senoufo-Cebaara	Tangari	ʃ
+sef	Senoufo-Cebaara	Tangari	ʒ	word initial only
+sef	Senoufo-Cebaara	Tangari	t̠ʃ
+sef	Senoufo-Cebaara	Tangari	d̠ʒ
+sef	Senoufo-Cebaara	Tangari	m
+sef	Senoufo-Cebaara	Tangari	n
+sef	Senoufo-Cebaara	Tangari	ŋ	word initial only
+sef	Senoufo-Cebaara	Tangari	l
+sef	Senoufo-Cebaara	Tangari	r		[r]
+sef	Senoufo-Cebaara	Tangari	r		[r̥]
+sef	Senoufo-Cebaara	Tangari	r		[ɾ]
+sef	Senoufo-Cebaara	Tangari	e
+sef	Senoufo-Cebaara	Tangari	ɛ
+sef	Senoufo-Cebaara	Tangari	ɛ̃
+sef	Senoufo-Cebaara	Tangari	ɛː
+sef	Senoufo-Cebaara	Tangari	o
+sef	Senoufo-Cebaara	Tangari	ɔ
+sef	Senoufo-Cebaara	Tangari	ɔː
+sef	Senoufo-Cebaara	Tangari	ɔ̃
+sef	Senoufo-Cebaara	Tangari	ɔ̃ː
+sef	Senoufo-Cebaara	Tangari	a
+sef	Senoufo-Cebaara	Tangari	ã
+sef	Senoufo-Cebaara	Tangari	ãː
+sef	Senoufo-Cebaara	Tangari	aː
+
 khq	songhoy		˦				khq.pdf
-khq	songhoy		˨				
-khq	songhoy		˦˨				
-khq	songhoy		˨˦				
-khq	songhoy		˦˨˦				
-khq	songhoy		˨˦˨				
-khq	songhoy		i		[i]	word final	
-khq	songhoy		i		[ĩ]	word final	
-khq	songhoy		e		[e]	word final	
-khq	songhoy		e		[ẽ]	word final	
-khq	songhoy		ɛ		[ɛ]	word final	
-khq	songhoy		ɛ		[ɛ̃]	word final	
-khq	songhoy		ɔ		[ɔ]	word final	
-khq	songhoy		ɔ		[ɔ̃]	word final	
-khq	songhoy		u		[u]	word final	
-khq	songhoy		u		[ũ]	word final	
-khq	songhoy		a		[a]	word final	
-khq	songhoy		a		[ã	word final	
-khq	songhoy		o		[o]	word final	
-khq	songhoy		o		[õ]	word final	
-khq	songhoy		iː		[iː]	word final	
-khq	songhoy		iː		[ĩː]	word final	
-khq	songhoy		eː		[eː]	word final	
-khq	songhoy		eː		[ẽː]	word final	
-khq	songhoy		ɛː		[ɛː]	word final	
-khq	songhoy		ɛː		[ɛ̃ː]	word final	
-khq	songhoy		ɔː		[ɔː]	word final	
-khq	songhoy		ɔː		[ɔ̃ː]	word final	
-khq	songhoy		uː		[uː]	word final	
-khq	songhoy		uː		[ũː]	word final	
-khq	songhoy		aː		[aː]	word final	
-khq	songhoy		aː		[ãː]	word final	
-khq	songhoy		oː		[oː]	word final	
-khq	songhoy		oː		[õː]	word final	
-khq	songhoy		p				
-khq	songhoy		b				
-khq	songhoy		t				
-khq	songhoy		d				
-khq	songhoy		t̠ʃ				
-khq	songhoy		ɡᶣ				
-khq	songhoy		k				
-khq	songhoy		ɡ				
-khq	songhoy		f				
-khq	songhoy		s				
-khq	songhoy		ʃ				
-khq	songhoy		z				
-khq	songhoy		m				
-khq	songhoy		n				
-khq	songhoy		ŋ				
-khq	songhoy		ɲ				
-khq	songhoy		j̃				
-khq	songhoy		ŋʷ				
-khq	songhoy		l				
-khq	songhoy		r				
-khq	songhoy		w				
-khq	songhoy		j̃				
-khq	songhoy		h				
-khq	songhoy		ʔ				
-							
+khq	songhoy		˨
+khq	songhoy		˦˨
+khq	songhoy		˨˦
+khq	songhoy		˦˨˦
+khq	songhoy		˨˦˨
+khq	songhoy		i		[i]	word final
+khq	songhoy		i		[ĩ]	word final
+khq	songhoy		e		[e]	word final
+khq	songhoy		e		[ẽ]	word final
+khq	songhoy		ɛ		[ɛ]	word final
+khq	songhoy		ɛ		[ɛ̃]	word final
+khq	songhoy		ɔ		[ɔ]	word final
+khq	songhoy		ɔ		[ɔ̃]	word final
+khq	songhoy		u		[u]	word final
+khq	songhoy		u		[ũ]	word final
+khq	songhoy		a		[a]	word final
+khq	songhoy		a		[ã	word final
+khq	songhoy		o		[o]	word final
+khq	songhoy		o		[õ]	word final
+khq	songhoy		iː		[iː]	word final
+khq	songhoy		iː		[ĩː]	word final
+khq	songhoy		eː		[eː]	word final
+khq	songhoy		eː		[ẽː]	word final
+khq	songhoy		ɛː		[ɛː]	word final
+khq	songhoy		ɛː		[ɛ̃ː]	word final
+khq	songhoy		ɔː		[ɔː]	word final
+khq	songhoy		ɔː		[ɔ̃ː]	word final
+khq	songhoy		uː		[uː]	word final
+khq	songhoy		uː		[ũː]	word final
+khq	songhoy		aː		[aː]	word final
+khq	songhoy		aː		[ãː]	word final
+khq	songhoy		oː		[oː]	word final
+khq	songhoy		oː		[õː]	word final
+khq	songhoy		p
+khq	songhoy		b
+khq	songhoy		t
+khq	songhoy		d
+khq	songhoy		t̠ʃ
+khq	songhoy		ɡᶣ
+khq	songhoy		k
+khq	songhoy		ɡ
+khq	songhoy		f
+khq	songhoy		s
+khq	songhoy		ʃ
+khq	songhoy		z
+khq	songhoy		m
+khq	songhoy		n
+khq	songhoy		ŋ
+khq	songhoy		ɲ
+khq	songhoy		j̃
+khq	songhoy		ŋʷ
+khq	songhoy		l
+khq	songhoy		r
+khq	songhoy		w
+khq	songhoy		j̃
+khq	songhoy		h
+khq	songhoy		ʔ
+
 ksf	kpaʔ		ɓ				kpa.pdf
-ksf	kpaʔ		ɗ				
-ksf	kpaʔ		p				
-ksf	kpaʔ		b				
-ksf	kpaʔ		f				
-ksf	kpaʔ		<v>	mainly in ideophones			
-ksf	kpaʔ		t				
-ksf	kpaʔ		d				
-ksf	kpaʔ		s				
-ksf	kpaʔ		z				
-ksf	kpaʔ		t̠ʃ				
-ksf	kpaʔ		d̠ʒ				
-ksf	kpaʔ		k				
-ksf	kpaʔ		ɡ				
-ksf	kpaʔ		kp				
-ksf	kpaʔ		ɡb				
-ksf	kpaʔ		w				
-ksf	kpaʔ		l				
-ksf	kpaʔ		r				
-ksf	kpaʔ		j				
-ksf	kpaʔ		ɣ				
-ksf	kpaʔ		m				
-ksf	kpaʔ		n				
-ksf	kpaʔ		ɲ				
-ksf	kpaʔ		ŋ				
-ksf	kpaʔ		i				
-ksf	kpaʔ		e				
-ksf	kpaʔ		ɛ				
-ksf	kpaʔ		ɨ				
-ksf	kpaʔ		ə				
-ksf	kpaʔ		ʌ				
-ksf	kpaʔ		u				
-ksf	kpaʔ		o				
-ksf	kpaʔ		ɔ				
-ksf	kpaʔ		a				
-ksf	kpaʔ		ɑ				
-ksf	kpaʔ		iː				
-ksf	kpaʔ		eː				
-ksf	kpaʔ		ɛː				
-ksf	kpaʔ		uː				
-ksf	kpaʔ		oː				
-ksf	kpaʔ		ɔː				
-ksf	kpaʔ		aː				
-ksf	kpaʔ		˦				
-ksf	kpaʔ		˧				
-ksf	kpaʔ		˨				
-ksf	kpaʔ		˦˨	only long vowels			
-ksf	kpaʔ		˨˦	only long vowels			
-							
+ksf	kpaʔ		ɗ
+ksf	kpaʔ		p
+ksf	kpaʔ		b
+ksf	kpaʔ		f
+ksf	kpaʔ		<v>	mainly in ideophones
+ksf	kpaʔ		t
+ksf	kpaʔ		d
+ksf	kpaʔ		s
+ksf	kpaʔ		z
+ksf	kpaʔ		t̠ʃ
+ksf	kpaʔ		d̠ʒ
+ksf	kpaʔ		k
+ksf	kpaʔ		ɡ
+ksf	kpaʔ		kp
+ksf	kpaʔ		ɡb
+ksf	kpaʔ		w
+ksf	kpaʔ		l
+ksf	kpaʔ		r
+ksf	kpaʔ		j
+ksf	kpaʔ		ɣ
+ksf	kpaʔ		m
+ksf	kpaʔ		n
+ksf	kpaʔ		ɲ
+ksf	kpaʔ		ŋ
+ksf	kpaʔ		i
+ksf	kpaʔ		e
+ksf	kpaʔ		ɛ
+ksf	kpaʔ		ɨ
+ksf	kpaʔ		ə
+ksf	kpaʔ		ʌ
+ksf	kpaʔ		u
+ksf	kpaʔ		o
+ksf	kpaʔ		ɔ
+ksf	kpaʔ		a
+ksf	kpaʔ		ɑ
+ksf	kpaʔ		iː
+ksf	kpaʔ		eː
+ksf	kpaʔ		ɛː
+ksf	kpaʔ		uː
+ksf	kpaʔ		oː
+ksf	kpaʔ		ɔː
+ksf	kpaʔ		aː
+ksf	kpaʔ		˦
+ksf	kpaʔ		˧
+ksf	kpaʔ		˨
+ksf	kpaʔ		˦˨	only long vowels
+ksf	kpaʔ		˨˦	only long vowels
+
 lea	lega-shabunda	beya	i				lega.pdf
-lea	lega-shabunda	beya	ɪ				
-lea	lega-shabunda	beya	u				
-lea	lega-shabunda	beya	ʊ				
-lea	lega-shabunda	beya	e				
-lea	lega-shabunda	beya	a				
-lea	lega-shabunda	beya	o				
-lea	lega-shabunda	beya	iː				
-lea	lega-shabunda	beya	ɪː				
-lea	lega-shabunda	beya	uː				
-lea	lega-shabunda	beya	ʊː				
-lea	lega-shabunda	beya	eː				
-lea	lega-shabunda	beya	aː				
-lea	lega-shabunda	beya	oː				
-lea	lega-shabunda	beya	<f>	borrowed words only			
-lea	lega-shabunda	beya	<v>	borrowed words only			
-lea	lega-shabunda	beya	<t̠ʃ>	borrowed words only			
-lea	lega-shabunda	beya	<d̠ʒ>	borrowed words only			
-lea	lega-shabunda	beya	ʃ	rare			
-lea	lega-shabunda	beya	w				
-lea	lega-shabunda	beya	p		[p]		
-lea	lega-shabunda	beya	p		[mp]		
-lea	lega-shabunda	beya	b		[b]		
-lea	lega-shabunda	beya	b		[mb]		
-lea	lega-shabunda	beya	t		[t]	intervocalic	
-lea	lega-shabunda	beya	t		[r]	intervocalic	
-lea	lega-shabunda	beya	t		[nt]	intervocalic	
-lea	lega-shabunda	beya	l		[l]	post-nasal	
-lea	lega-shabunda	beya	l		[d]	post-nasal	
-lea	lega-shabunda	beya	l		[nd]	post-nasal	
-lea	lega-shabunda	beya	ɡ		[ɡ]	intervocalic	
-lea	lega-shabunda	beya	ɡ		[ɣ]	intervocalic	
-lea	lega-shabunda	beya	ɡ		[ŋɡ]	intervocalic	
-lea	lega-shabunda	beya	ɟ		[ɟ]		
-lea	lega-shabunda	beya	ɟ		[ɡʲ]		
-lea	lega-shabunda	beya	ɟ		[ŋɡʲ]		
-lea	lega-shabunda	beya	k		[k]		
-lea	lega-shabunda	beya	k		[ŋk]		
-lea	lega-shabunda	beya	s		[s]		
-lea	lega-shabunda	beya	s		[ns]		
-lea	lega-shabunda	beya	z		[z]		
-lea	lega-shabunda	beya	z		[nz]		
-lea	lega-shabunda	beya	n		[n]		
-lea	lega-shabunda	beya	n		[nʲ]		
-lea	lega-shabunda	beya	m				
-lea	lega-shabunda	beya	ɲ	distinct from palatalized alveolar			
-lea	lega-shabunda	beya	˦				
-lea	lega-shabunda	beya	˧				
-lea	lega-shabunda	beya	˨				
-lea	lega-shabunda	beya	↓˦				
-lea	lega-shabunda	beya	˦˨				
-lea	lega-shabunda	beya	˨˦				
-							
+lea	lega-shabunda	beya	ɪ
+lea	lega-shabunda	beya	u
+lea	lega-shabunda	beya	ʊ
+lea	lega-shabunda	beya	e
+lea	lega-shabunda	beya	a
+lea	lega-shabunda	beya	o
+lea	lega-shabunda	beya	iː
+lea	lega-shabunda	beya	ɪː
+lea	lega-shabunda	beya	uː
+lea	lega-shabunda	beya	ʊː
+lea	lega-shabunda	beya	eː
+lea	lega-shabunda	beya	aː
+lea	lega-shabunda	beya	oː
+lea	lega-shabunda	beya	<f>	borrowed words only
+lea	lega-shabunda	beya	<v>	borrowed words only
+lea	lega-shabunda	beya	<t̠ʃ>	borrowed words only
+lea	lega-shabunda	beya	<d̠ʒ>	borrowed words only
+lea	lega-shabunda	beya	ʃ	rare
+lea	lega-shabunda	beya	w
+lea	lega-shabunda	beya	p		[p]
+lea	lega-shabunda	beya	p		[mp]
+lea	lega-shabunda	beya	b		[b]
+lea	lega-shabunda	beya	b		[mb]
+lea	lega-shabunda	beya	t		[t]	intervocalic
+lea	lega-shabunda	beya	t		[r]	intervocalic
+lea	lega-shabunda	beya	t		[nt]	intervocalic
+lea	lega-shabunda	beya	l		[l]	post-nasal
+lea	lega-shabunda	beya	l		[d]	post-nasal
+lea	lega-shabunda	beya	l		[nd]	post-nasal
+lea	lega-shabunda	beya	ɡ		[ɡ]	intervocalic
+lea	lega-shabunda	beya	ɡ		[ɣ]	intervocalic
+lea	lega-shabunda	beya	ɡ		[ŋɡ]	intervocalic
+lea	lega-shabunda	beya	ɟ		[ɟ]
+lea	lega-shabunda	beya	ɟ		[ɡʲ]
+lea	lega-shabunda	beya	ɟ		[ŋɡʲ]
+lea	lega-shabunda	beya	k		[k]
+lea	lega-shabunda	beya	k		[ŋk]
+lea	lega-shabunda	beya	s		[s]
+lea	lega-shabunda	beya	s		[ns]
+lea	lega-shabunda	beya	z		[z]
+lea	lega-shabunda	beya	z		[nz]
+lea	lega-shabunda	beya	n		[n]
+lea	lega-shabunda	beya	n		[nʲ]
+lea	lega-shabunda	beya	m
+lea	lega-shabunda	beya	ɲ	distinct from palatalized alveolar
+lea	lega-shabunda	beya	˦
+lea	lega-shabunda	beya	˧
+lea	lega-shabunda	beya	˨
+lea	lega-shabunda	beya	↓˦
+lea	lega-shabunda	beya	˦˨
+lea	lega-shabunda	beya	˨˦
+
 lmp	limbum (southern)	southern	b		[b]	before vls consonants and word final	limbum_bah2004_o.pdf
-lmp	limbum (southern)	southern	b		[p]	before vls consonants and word final	
-lmp	limbum (southern)	southern	t				
-lmp	limbum (southern)	southern	d				
-lmp	limbum (southern)	southern	k				
-lmp	limbum (southern)	southern	ɡ				
-lmp	limbum (southern)	southern	ʔ				
-lmp	limbum (southern)	southern	mb				
-lmp	limbum (southern)	southern	nt				
-lmp	limbum (southern)	southern	nd				
-lmp	limbum (southern)	southern	ts				
-lmp	limbum (southern)	southern	dz				
-lmp	limbum (southern)	southern	t̠ʃ				
-lmp	limbum (southern)	southern	d̠ʒ				
-lmp	limbum (southern)	southern	f				
-lmp	limbum (southern)	southern	s				
-lmp	limbum (southern)	southern	ʃ				
-lmp	limbum (southern)	southern	v				
-lmp	limbum (southern)	southern	z				
-lmp	limbum (southern)	southern	ʒ				
-lmp	limbum (southern)	southern	ɣ				
-lmp	limbum (southern)	southern	h				
-lmp	limbum (southern)	southern	ɱf				
-lmp	limbum (southern)	southern	m				
-lmp	limbum (southern)	southern	n				
-lmp	limbum (southern)	southern	ɲ				
-lmp	limbum (southern)	southern	ŋ				
-lmp	limbum (southern)	southern	l				
-lmp	limbum (southern)	southern	nl	suspicious?			
-lmp	limbum (southern)	southern	r				
-lmp	limbum (southern)	southern	nr	suspicious?			
-lmp	limbum (southern)	southern	w				
-lmp	limbum (southern)	southern	ŋʷ				
-lmp	limbum (southern)	southern	kʷ				
-lmp	limbum (southern)	southern	ɡʷ				
-lmp	limbum (southern)	southern	ŋkʷ				
-lmp	limbum (southern)	southern	ŋɡʷ				
-lmp	limbum (southern)	southern	j				
-lmp	limbum (southern)	southern	i				
-lmp	limbum (southern)	southern	u				
-lmp	limbum (southern)	southern	a				
-lmp	limbum (southern)	southern	ɛ				
-lmp	limbum (southern)	southern	ɔ				
-lmp	limbum (southern)	southern	ɨ				
-lmp	limbum (southern)	southern	iː				
-lmp	limbum (southern)	southern	uː				
-lmp	limbum (southern)	southern	aː				
-lmp	limbum (southern)	southern	ɛː				
-lmp	limbum (southern)	southern	ɔː				
-lmp	limbum (southern)	southern	ɨː				
-lmp	limbum (southern)	southern	ũ				
-lmp	limbum (southern)	southern	ɨ̃				
-lmp	limbum (southern)	southern	ɛ̃				
-							
+lmp	limbum (southern)	southern	b		[p]	before vls consonants and word final
+lmp	limbum (southern)	southern	t
+lmp	limbum (southern)	southern	d
+lmp	limbum (southern)	southern	k
+lmp	limbum (southern)	southern	ɡ
+lmp	limbum (southern)	southern	ʔ
+lmp	limbum (southern)	southern	mb
+lmp	limbum (southern)	southern	nt
+lmp	limbum (southern)	southern	nd
+lmp	limbum (southern)	southern	ts
+lmp	limbum (southern)	southern	dz
+lmp	limbum (southern)	southern	t̠ʃ
+lmp	limbum (southern)	southern	d̠ʒ
+lmp	limbum (southern)	southern	f
+lmp	limbum (southern)	southern	s
+lmp	limbum (southern)	southern	ʃ
+lmp	limbum (southern)	southern	v
+lmp	limbum (southern)	southern	z
+lmp	limbum (southern)	southern	ʒ
+lmp	limbum (southern)	southern	ɣ
+lmp	limbum (southern)	southern	h
+lmp	limbum (southern)	southern	ɱf
+lmp	limbum (southern)	southern	m
+lmp	limbum (southern)	southern	n
+lmp	limbum (southern)	southern	ɲ
+lmp	limbum (southern)	southern	ŋ
+lmp	limbum (southern)	southern	l
+lmp	limbum (southern)	southern	nl	suspicious?
+lmp	limbum (southern)	southern	r
+lmp	limbum (southern)	southern	nr	suspicious?
+lmp	limbum (southern)	southern	w
+lmp	limbum (southern)	southern	ŋʷ
+lmp	limbum (southern)	southern	kʷ
+lmp	limbum (southern)	southern	ɡʷ
+lmp	limbum (southern)	southern	ŋkʷ
+lmp	limbum (southern)	southern	ŋɡʷ
+lmp	limbum (southern)	southern	j
+lmp	limbum (southern)	southern	i
+lmp	limbum (southern)	southern	u
+lmp	limbum (southern)	southern	a
+lmp	limbum (southern)	southern	ɛ
+lmp	limbum (southern)	southern	ɔ
+lmp	limbum (southern)	southern	ɨ
+lmp	limbum (southern)	southern	iː
+lmp	limbum (southern)	southern	uː
+lmp	limbum (southern)	southern	aː
+lmp	limbum (southern)	southern	ɛː
+lmp	limbum (southern)	southern	ɔː
+lmp	limbum (southern)	southern	ɨː
+lmp	limbum (southern)	southern	ũ
+lmp	limbum (southern)	southern	ɨ̃
+lmp	limbum (southern)	southern	ɛ̃
+
 lmp	limbum (central)	central	b		[b]	before vls consonants and word final	limbum_bah2004_o.pdf
-lmp	limbum (central)	central	b		[p]	before vls consonants and word final	
-lmp	limbum (central)	central	b		[bʲ]	before vls consonants and word final	
-lmp	limbum (central)	central	t		[t]		
-lmp	limbum (central)	central	t		[tʲ]		
-lmp	limbum (central)	central	d		[d]		
-lmp	limbum (central)	central	d		[dʲ]		
-lmp	limbum (central)	central	k		[k]		
-lmp	limbum (central)	central	k		[kʲ]		
-lmp	limbum (central)	central	ɡ		[ɡ]		
-lmp	limbum (central)	central	ɡ		[ɡʲ]		
-lmp	limbum (central)	central	ʔ				
-lmp	limbum (central)	central	d̠ʒ				
-lmp	limbum (central)	central	t̠ʃ		[t̠ʃ]		
-lmp	limbum (central)	central	t̠ʃ		[t̠ʃʲ]		
-lmp	limbum (central)	central	f				
-lmp	limbum (central)	central	v				
-lmp	limbum (central)	central	s		[s]		
-lmp	limbum (central)	central	s		[sʲ]		
-lmp	limbum (central)	central	ʃ		[ʃ]		
-lmp	limbum (central)	central	ʃ		[ʃʲ]		
-lmp	limbum (central)	central	ʒ				
-lmp	limbum (central)	central	ɣ		[ɣ]		
-lmp	limbum (central)	central	ɣ		[ɣʲ]		
-lmp	limbum (central)	central	h				
-lmp	limbum (central)	central	m		[m]		
-lmp	limbum (central)	central	m		[mʲ]		
-lmp	limbum (central)	central	n		[n]		
-lmp	limbum (central)	central	n		[nʲ]		
-lmp	limbum (central)	central	ŋ		[ŋ]		
-lmp	limbum (central)	central	ŋ		[ŋʲ]		
-lmp	limbum (central)	central	ɲ		[ɲ]		
-lmp	limbum (central)	central	ɲ		[ɲʲ]		
-lmp	limbum (central)	central	l		[l]		
-lmp	limbum (central)	central	l		[lʲ]		
-lmp	limbum (central)	central	r		[r]		
-lmp	limbum (central)	central	r		[rʲ]		
-lmp	limbum (central)	central	w				
-lmp	limbum (central)	central	j				
-lmp	limbum (central)	central	ɨ				
-lmp	limbum (central)	central	u				
-lmp	limbum (central)	central	e				
-lmp	limbum (central)	central	ɛ				
-lmp	limbum (central)	central	ɔ				
-lmp	limbum (central)	central	o				
-lmp	limbum (central)	central	a				
-lmp	limbum (central)	central	uː				
-lmp	limbum (central)	central	iː				
-lmp	limbum (central)	central	eː				
-lmp	limbum (central)	central	ɛː				
-lmp	limbum (central)	central	ɔː				
-lmp	limbum (central)	central	oː				
-lmp	limbum (central)	central	aː				
-lmp	limbum (central)	central	ɨ̃				
-lmp	limbum (central)	central	ɛ̃				
-lmp	limbum (central)	central	ɔ̃				
-lmp	limbum (central)	central	ũ				
-							
+lmp	limbum (central)	central	b		[p]	before vls consonants and word final
+lmp	limbum (central)	central	b		[bʲ]	before vls consonants and word final
+lmp	limbum (central)	central	t		[t]
+lmp	limbum (central)	central	t		[tʲ]
+lmp	limbum (central)	central	d		[d]
+lmp	limbum (central)	central	d		[dʲ]
+lmp	limbum (central)	central	k		[k]
+lmp	limbum (central)	central	k		[kʲ]
+lmp	limbum (central)	central	ɡ		[ɡ]
+lmp	limbum (central)	central	ɡ		[ɡʲ]
+lmp	limbum (central)	central	ʔ
+lmp	limbum (central)	central	d̠ʒ
+lmp	limbum (central)	central	t̠ʃ		[t̠ʃ]
+lmp	limbum (central)	central	t̠ʃ		[t̠ʃʲ]
+lmp	limbum (central)	central	f
+lmp	limbum (central)	central	v
+lmp	limbum (central)	central	s		[s]
+lmp	limbum (central)	central	s		[sʲ]
+lmp	limbum (central)	central	ʃ		[ʃ]
+lmp	limbum (central)	central	ʃ		[ʃʲ]
+lmp	limbum (central)	central	ʒ
+lmp	limbum (central)	central	ɣ		[ɣ]
+lmp	limbum (central)	central	ɣ		[ɣʲ]
+lmp	limbum (central)	central	h
+lmp	limbum (central)	central	m		[m]
+lmp	limbum (central)	central	m		[mʲ]
+lmp	limbum (central)	central	n		[n]
+lmp	limbum (central)	central	n		[nʲ]
+lmp	limbum (central)	central	ŋ		[ŋ]
+lmp	limbum (central)	central	ŋ		[ŋʲ]
+lmp	limbum (central)	central	ɲ		[ɲ]
+lmp	limbum (central)	central	ɲ		[ɲʲ]
+lmp	limbum (central)	central	l		[l]
+lmp	limbum (central)	central	l		[lʲ]
+lmp	limbum (central)	central	r		[r]
+lmp	limbum (central)	central	r		[rʲ]
+lmp	limbum (central)	central	w
+lmp	limbum (central)	central	j
+lmp	limbum (central)	central	ɨ
+lmp	limbum (central)	central	u
+lmp	limbum (central)	central	e
+lmp	limbum (central)	central	ɛ
+lmp	limbum (central)	central	ɔ
+lmp	limbum (central)	central	o
+lmp	limbum (central)	central	a
+lmp	limbum (central)	central	uː
+lmp	limbum (central)	central	iː
+lmp	limbum (central)	central	eː
+lmp	limbum (central)	central	ɛː
+lmp	limbum (central)	central	ɔː
+lmp	limbum (central)	central	oː
+lmp	limbum (central)	central	aː
+lmp	limbum (central)	central	ɨ̃
+lmp	limbum (central)	central	ɛ̃
+lmp	limbum (central)	central	ɔ̃
+lmp	limbum (central)	central	ũ
+
 lmp	limbum (northern)	northern	b		[b]	before vls consonants and word final	limbum_bah2004_o.pdf
-lmp	limbum (northern)	northern	b		[p]	before vls consonants and word final	
-lmp	limbum (northern)	northern	b		[bʲ]	before vls consonants and word final	
-lmp	limbum (northern)	northern	t		[t]		
-lmp	limbum (northern)	northern	t		[tʲ]		
-lmp	limbum (northern)	northern	d		[d]		
-lmp	limbum (northern)	northern	d		[dʲ]		
-lmp	limbum (northern)	northern	k		[k]		
-lmp	limbum (northern)	northern	k		[kʲ]		
-lmp	limbum (northern)	northern	ɡ		[ɡ]		
-lmp	limbum (northern)	northern	ɡ		[ɡʲ]		
-lmp	limbum (northern)	northern	ʔ				
-lmp	limbum (northern)	northern	t̠ʃ		[t̠ʃ]		
-lmp	limbum (northern)	northern	t̠ʃ		[t̠ʃʲ]		
-lmp	limbum (northern)	northern	d̠ʒ				
-lmp	limbum (northern)	northern	f		[f]		
-lmp	limbum (northern)	northern	f		[fʲ]		
-lmp	limbum (northern)	northern	s		[s]		
-lmp	limbum (northern)	northern	s		[sʲ]		
-lmp	limbum (northern)	northern	ʃ				
-lmp	limbum (northern)	northern	v		[v]		
-lmp	limbum (northern)	northern	v		[vʲ]		
-lmp	limbum (northern)	northern	ʒ				
-lmp	limbum (northern)	northern	ɣ				
-lmp	limbum (northern)	northern	h				
-lmp	limbum (northern)	northern	m				
-lmp	limbum (northern)	northern	n		[n]		
-lmp	limbum (northern)	northern	n		[nʲ]		
-lmp	limbum (northern)	northern	ɲ				
-lmp	limbum (northern)	northern	ŋ		[ŋ]		
-lmp	limbum (northern)	northern	ŋ		[ŋʲ]		
-lmp	limbum (northern)	northern	l				
-lmp	limbum (northern)	northern	r		[r]		
-lmp	limbum (northern)	northern	r		[rʲ]		
-lmp	limbum (northern)	northern	w				
-lmp	limbum (northern)	northern	j				
-lmp	limbum (northern)	northern	i				
-lmp	limbum (northern)	northern	u				
-lmp	limbum (northern)	northern	a				
-lmp	limbum (northern)	northern	e				
-lmp	limbum (northern)	northern	o				
-lmp	limbum (northern)	northern	iː				
-lmp	limbum (northern)	northern	uː				
-lmp	limbum (northern)	northern	aː				
-lmp	limbum (northern)	northern	eː				
-lmp	limbum (northern)	northern	oː				
-							
+lmp	limbum (northern)	northern	b		[p]	before vls consonants and word final
+lmp	limbum (northern)	northern	b		[bʲ]	before vls consonants and word final
+lmp	limbum (northern)	northern	t		[t]
+lmp	limbum (northern)	northern	t		[tʲ]
+lmp	limbum (northern)	northern	d		[d]
+lmp	limbum (northern)	northern	d		[dʲ]
+lmp	limbum (northern)	northern	k		[k]
+lmp	limbum (northern)	northern	k		[kʲ]
+lmp	limbum (northern)	northern	ɡ		[ɡ]
+lmp	limbum (northern)	northern	ɡ		[ɡʲ]
+lmp	limbum (northern)	northern	ʔ
+lmp	limbum (northern)	northern	t̠ʃ		[t̠ʃ]
+lmp	limbum (northern)	northern	t̠ʃ		[t̠ʃʲ]
+lmp	limbum (northern)	northern	d̠ʒ
+lmp	limbum (northern)	northern	f		[f]
+lmp	limbum (northern)	northern	f		[fʲ]
+lmp	limbum (northern)	northern	s		[s]
+lmp	limbum (northern)	northern	s		[sʲ]
+lmp	limbum (northern)	northern	ʃ
+lmp	limbum (northern)	northern	v		[v]
+lmp	limbum (northern)	northern	v		[vʲ]
+lmp	limbum (northern)	northern	ʒ
+lmp	limbum (northern)	northern	ɣ
+lmp	limbum (northern)	northern	h
+lmp	limbum (northern)	northern	m
+lmp	limbum (northern)	northern	n		[n]
+lmp	limbum (northern)	northern	n		[nʲ]
+lmp	limbum (northern)	northern	ɲ
+lmp	limbum (northern)	northern	ŋ		[ŋ]
+lmp	limbum (northern)	northern	ŋ		[ŋʲ]
+lmp	limbum (northern)	northern	l
+lmp	limbum (northern)	northern	r		[r]
+lmp	limbum (northern)	northern	r		[rʲ]
+lmp	limbum (northern)	northern	w
+lmp	limbum (northern)	northern	j
+lmp	limbum (northern)	northern	i
+lmp	limbum (northern)	northern	u
+lmp	limbum (northern)	northern	a
+lmp	limbum (northern)	northern	e
+lmp	limbum (northern)	northern	o
+lmp	limbum (northern)	northern	iː
+lmp	limbum (northern)	northern	uː
+lmp	limbum (northern)	northern	aː
+lmp	limbum (northern)	northern	eː
+lmp	limbum (northern)	northern	oː
+
 mye	myene		p				mye.pdf
-mye	myene		ɓ				
-mye	myene		mp				
-mye	myene		s				
-mye	myene		f				
-mye	myene		w		[w]		
-mye	myene		w		[ɥ]		
-mye	myene		j				
-mye	myene		m				
-mye	myene		t				
-mye	myene		ɗ				
-mye	myene		nt				
-mye	myene		n		[n]		
-mye	myene		n		[ɲ]		
-mye	myene		l				
-mye	myene		r				
-mye	myene		z				
-mye	myene		n̠t̠ʃ	updated from ɲtʃ			
-mye	myene		ɲ				
-mye	myene		t̠ʃ				
-mye	myene		k		[k]		
-mye	myene		k		[kʷ]		
-mye	myene		k		[kʲ]		
-mye	myene		ŋɡ				
-mye	myene		ŋ				
-mye	myene		ɡ		[ɡ]		
-mye	myene		ɡ		[ɣ]		
-mye	myene		ŋk				
-mye	myene		mb				
-mye	myene		β				
-mye	myene		nd				
-mye	myene		d̠ʒ		[d̠ʒ]		
-mye	myene		d̠ʒ		[ɟ]		
-mye	myene		d̠ʒ		[ɗʲ]		
-mye	myene		d̠ʒ		[ɗ]		
-mye	myene		n̠d̠ʒ	updated from ɲdʒ			
-mye	myene		ʙ	Ce phonème est realisé comme une consonne fricative bilabiale nasale'			
-mye	myene		i		[i]		
-mye	myene		i		[ĩ]		
-mye	myene		e		[e]		
-mye	myene		e		[ẽ]		
-mye	myene		ɛ		[ɛ]		
-mye	myene		ɛ		[ɛ̃]		
-mye	myene		o		[o]		
-mye	myene		o		[õ]		
-mye	myene		u		[u]		
-mye	myene		u		[ũ]		
-mye	myene		a		[a]		
-mye	myene		a		[ã]		
-mye	myene		ɔ		[ɔ]		
-mye	myene		ɔ		[ɔ̃]		
-							
+mye	myene		ɓ
+mye	myene		mp
+mye	myene		s
+mye	myene		f
+mye	myene		w		[w]
+mye	myene		w		[ɥ]
+mye	myene		j
+mye	myene		m
+mye	myene		t
+mye	myene		ɗ
+mye	myene		nt
+mye	myene		n		[n]
+mye	myene		n		[ɲ]
+mye	myene		l
+mye	myene		r
+mye	myene		z
+mye	myene		n̠t̠ʃ	updated from ɲtʃ
+mye	myene		ɲ
+mye	myene		t̠ʃ
+mye	myene		k		[k]
+mye	myene		k		[kʷ]
+mye	myene		k		[kʲ]
+mye	myene		ŋɡ
+mye	myene		ŋ
+mye	myene		ɡ		[ɡ]
+mye	myene		ɡ		[ɣ]
+mye	myene		ŋk
+mye	myene		mb
+mye	myene		β
+mye	myene		nd
+mye	myene		d̠ʒ		[d̠ʒ]
+mye	myene		d̠ʒ		[ɟ]
+mye	myene		d̠ʒ		[ɗʲ]
+mye	myene		d̠ʒ		[ɗ]
+mye	myene		n̠d̠ʒ	updated from ɲdʒ
+mye	myene		ʙ	Ce phonème est realisé comme une consonne fricative bilabiale nasale'
+mye	myene		i		[i]
+mye	myene		i		[ĩ]
+mye	myene		e		[e]
+mye	myene		e		[ẽ]
+mye	myene		ɛ		[ɛ]
+mye	myene		ɛ		[ɛ̃]
+mye	myene		o		[o]
+mye	myene		o		[õ]
+mye	myene		u		[u]
+mye	myene		u		[ũ]
+mye	myene		a		[a]
+mye	myene		a		[ã]
+mye	myene		ɔ		[ɔ]
+mye	myene		ɔ		[ɔ̃]
+
 bud	N'cam		i				ncam_badie1995_o.pdf
-bud	N'cam		e				
-bud	N'cam		o				
-bud	N'cam		u				
-bud	N'cam		a				
-bud	N'cam		ɔ				
-bud	N'cam		iː				
-bud	N'cam		aː				
-bud	N'cam		uː				
-bud	N'cam		ɔː				
-bud	N'cam		eː				
-bud	N'cam		oː				
-bud	N'cam		ĩː				
-bud	N'cam		ãː				
-bud	N'cam		ũː				
-bud	N'cam		ɔ̃ː				
-bud	N'cam		ẽː				
-bud	N'cam		õː				
-bud	N'cam		ĩ				
-bud	N'cam		p				
-bud	N'cam		b				
-bud	N'cam		t				
-bud	N'cam		d				
-bud	N'cam		c				
-bud	N'cam		ɟ				
-bud	N'cam		k				
-bud	N'cam		ɡ				
-bud	N'cam		kp				
-bud	N'cam		ɡb				
-bud	N'cam		f				
-bud	N'cam		s				
-bud	N'cam		m				
-bud	N'cam		ɱ				
-bud	N'cam		n				
-bud	N'cam		ɲ				
-bud	N'cam		ŋ				
-bud	N'cam		ŋm				
-bud	N'cam		j				
-bud	N'cam		w				
-bud	N'cam		l		[l]		
-bud	N'cam		l		[r]		
-bud	N'cam		˦				
-bud	N'cam		˧				
-bud	N'cam		˨				
-							
+bud	N'cam		e
+bud	N'cam		o
+bud	N'cam		u
+bud	N'cam		a
+bud	N'cam		ɔ
+bud	N'cam		iː
+bud	N'cam		aː
+bud	N'cam		uː
+bud	N'cam		ɔː
+bud	N'cam		eː
+bud	N'cam		oː
+bud	N'cam		ĩː
+bud	N'cam		ãː
+bud	N'cam		ũː
+bud	N'cam		ɔ̃ː
+bud	N'cam		ẽː
+bud	N'cam		õː
+bud	N'cam		ĩ
+bud	N'cam		p
+bud	N'cam		b
+bud	N'cam		t
+bud	N'cam		d
+bud	N'cam		c
+bud	N'cam		ɟ
+bud	N'cam		k
+bud	N'cam		ɡ
+bud	N'cam		kp
+bud	N'cam		ɡb
+bud	N'cam		f
+bud	N'cam		s
+bud	N'cam		m
+bud	N'cam		ɱ
+bud	N'cam		n
+bud	N'cam		ɲ
+bud	N'cam		ŋ
+bud	N'cam		ŋm
+bud	N'cam		j
+bud	N'cam		w
+bud	N'cam		l		[l]
+bud	N'cam		l		[r]
+bud	N'cam		˦
+bud	N'cam		˧
+bud	N'cam		˨
+
 tvu	Nen		b		[b]	before schwa	nen.pdf
-tvu	Nen		b		[bʷ]	before schwa	
-tvu	Nen		f				
-tvu	Nen		t				
-tvu	Nen		s				
-tvu	Nen		k				
-tvu	Nen		x	never word initial	[x]	between vowels, after front vowels	
-tvu	Nen		x	never word initial	[h]	between vowels, after front vowels	
-tvu	Nen		x	never word initial	[xʲ]	between vowels, after front vowels	
-tvu	Nen		m				
-tvu	Nen		n				
-tvu	Nen		ɲ				
-tvu	Nen		ŋ				
-tvu	Nen		mb				
-tvu	Nen		nd				
-tvu	Nen		n̠d̠ʒ	updated from ɲdʒ			
-tvu	Nen		ŋɡ				
-tvu	Nen		w				
-tvu	Nen		j				
-tvu	Nen		l				
-tvu	Nen		i				
-tvu	Nen		ə				
-tvu	Nen		o				
-tvu	Nen		u				
-tvu	Nen		a				
-tvu	Nen		o				
-tvu	Nen		ɛ				
-tvu	Nen		ɔ				
-tvu	Nen		˦				
-tvu	Nen		˨				
-							
+tvu	Nen		b		[bʷ]	before schwa
+tvu	Nen		f
+tvu	Nen		t
+tvu	Nen		s
+tvu	Nen		k
+tvu	Nen		x	never word initial	[x]	between vowels, after front vowels
+tvu	Nen		x	never word initial	[h]	between vowels, after front vowels
+tvu	Nen		x	never word initial	[xʲ]	between vowels, after front vowels
+tvu	Nen		m
+tvu	Nen		n
+tvu	Nen		ɲ
+tvu	Nen		ŋ
+tvu	Nen		mb
+tvu	Nen		nd
+tvu	Nen		n̠d̠ʒ	updated from ɲdʒ
+tvu	Nen		ŋɡ
+tvu	Nen		w
+tvu	Nen		j
+tvu	Nen		l
+tvu	Nen		i
+tvu	Nen		ə
+tvu	Nen		o
+tvu	Nen		u
+tvu	Nen		a
+tvu	Nen		o
+tvu	Nen		ɛ
+tvu	Nen		ɔ
+tvu	Nen		˦
+tvu	Nen		˨
+
 mgw	matuumbi		i				rufiji.pdf
-mgw	matuumbi		e				
-mgw	matuumbi		a				
-mgw	matuumbi		o				
-mgw	matuumbi		u				
-mgw	matuumbi		p				
-mgw	matuumbi		t				
-mgw	matuumbi		t̠ʃ				
-mgw	matuumbi		<s>	rare			
-mgw	matuumbi		b				
-mgw	matuumbi		d				
-mgw	matuumbi		d̠ʒ				
-mgw	matuumbi		ɡ				
-mgw	matuumbi		m				
-mgw	matuumbi		n				
-mgw	matuumbi		ɲ				
-mgw	matuumbi		ŋ				
-mgw	matuumbi		w				
-mgw	matuumbi		l				
-mgw	matuumbi		j				
-mgw	matuumbi		˨				
-mgw	matuumbi		˨˦				
-mgw	matuumbi		˦˨				
-							
+mgw	matuumbi		e
+mgw	matuumbi		a
+mgw	matuumbi		o
+mgw	matuumbi		u
+mgw	matuumbi		p
+mgw	matuumbi		t
+mgw	matuumbi		t̠ʃ
+mgw	matuumbi		<s>	rare
+mgw	matuumbi		b
+mgw	matuumbi		d
+mgw	matuumbi		d̠ʒ
+mgw	matuumbi		ɡ
+mgw	matuumbi		m
+mgw	matuumbi		n
+mgw	matuumbi		ɲ
+mgw	matuumbi		ŋ
+mgw	matuumbi		w
+mgw	matuumbi		l
+mgw	matuumbi		j
+mgw	matuumbi		˨
+mgw	matuumbi		˨˦
+mgw	matuumbi		˦˨
+
 yao	yao		i		[i]		rufiji.pdf
-yao	yao		i		[iː]		
-yao	yao		ɪ		[ɪ]		
-yao	yao		ɪ		[ɪː]		
-yao	yao		e		[e]		
-yao	yao		e		[eː]		
-yao	yao		a		[a]		
-yao	yao		a		[aː]		
-yao	yao		o		[o]		
-yao	yao		o		[oː]		
-yao	yao		u		[u]		
-yao	yao		u		[uː]		
-yao	yao		ʊ		[ʊ]		
-yao	yao		ʊ		[ʊː]		
-yao	yao		p				
-yao	yao		t				
-yao	yao		t̠ʃ				
-yao	yao		k				
-yao	yao		s				
-yao	yao		<f>	rare			
-yao	yao		b				
-yao	yao		d				
-yao	yao		d̠ʒ				
-yao	yao		ɡ				
-yao	yao		m				
-yao	yao		n				
-yao	yao		ɲ				
-yao	yao		ŋ				
-yao	yao		β				
-yao	yao		w				
-yao	yao		l				
-yao	yao		j				
-yao	yao		˦				
-yao	yao		˨				
-yao	yao		˦˨				
-yao	yao		˨˦				
-							
+yao	yao		i		[iː]
+yao	yao		ɪ		[ɪ]
+yao	yao		ɪ		[ɪː]
+yao	yao		e		[e]
+yao	yao		e		[eː]
+yao	yao		a		[a]
+yao	yao		a		[aː]
+yao	yao		o		[o]
+yao	yao		o		[oː]
+yao	yao		u		[u]
+yao	yao		u		[uː]
+yao	yao		ʊ		[ʊ]
+yao	yao		ʊ		[ʊː]
+yao	yao		p
+yao	yao		t
+yao	yao		t̠ʃ
+yao	yao		k
+yao	yao		s
+yao	yao		<f>	rare
+yao	yao		b
+yao	yao		d
+yao	yao		d̠ʒ
+yao	yao		ɡ
+yao	yao		m
+yao	yao		n
+yao	yao		ɲ
+yao	yao		ŋ
+yao	yao		β
+yao	yao		w
+yao	yao		l
+yao	yao		j
+yao	yao		˦
+yao	yao		˨
+yao	yao		˦˨
+yao	yao		˨˦
+
 umb	umbundu		p				western-savanna.pdf
-umb	umbundu		t				
-umb	umbundu		c				
-umb	umbundu		k				
-umb	umbundu		f				
-umb	umbundu		s				
-umb	umbundu		h				
-umb	umbundu		v				
-umb	umbundu		l				
-umb	umbundu		w				
-umb	umbundu		j				
-umb	umbundu		m				
-umb	umbundu		n				
-umb	umbundu		ɲ				
-umb	umbundu		ŋ				
-umb	umbundu		h̃				
-umb	umbundu		ṽ				
-umb	umbundu		l̃				
-umb	umbundu		w̃				
-umb	umbundu		j̃				
-umb	umbundu		i				
-umb	umbundu		e				
-umb	umbundu		a				
-umb	umbundu		u				
-umb	umbundu		o				
-umb	umbundu		ĩ				
-umb	umbundu		ẽ				
-umb	umbundu		ã				
-umb	umbundu		ũ				
-umb	umbundu		õ				
-							
+umb	umbundu		t
+umb	umbundu		c
+umb	umbundu		k
+umb	umbundu		f
+umb	umbundu		s
+umb	umbundu		h
+umb	umbundu		v
+umb	umbundu		l
+umb	umbundu		w
+umb	umbundu		j
+umb	umbundu		m
+umb	umbundu		n
+umb	umbundu		ɲ
+umb	umbundu		ŋ
+umb	umbundu		h̃
+umb	umbundu		ṽ
+umb	umbundu		l̃
+umb	umbundu		w̃
+umb	umbundu		j̃
+umb	umbundu		i
+umb	umbundu		e
+umb	umbundu		a
+umb	umbundu		u
+umb	umbundu		o
+umb	umbundu		ĩ
+umb	umbundu		ẽ
+umb	umbundu		ã
+umb	umbundu		ũ
+umb	umbundu		õ
+
 ndo	ndonga		i				western-savanna.pdf
-ndo	ndonga		e				
-ndo	ndonga		a				
-ndo	ndonga		o				
-ndo	ndonga		u				
-ndo	ndonga		p				
-ndo	ndonga		t				
-ndo	ndonga		k				
-ndo	ndonga		ʔ				
-ndo	ndonga		b				
-ndo	ndonga		d				
-ndo	ndonga		ɡ				
-ndo	ndonga		f				
-ndo	ndonga		θ				
-ndo	ndonga		s				
-ndo	ndonga		ʃ				
-ndo	ndonga		x				
-ndo	ndonga		h				
-ndo	ndonga		v				
-ndo	ndonga		ð				
-ndo	ndonga		z				
-ndo	ndonga		ʒ				
-ndo	ndonga		ɣ				
-ndo	ndonga		ts				
-ndo	ndonga		l				
-ndo	ndonga		w				
-ndo	ndonga		j				
-ndo	ndonga		m				
-ndo	ndonga		n				
-ndo	ndonga		ɲ				
-							
+ndo	ndonga		e
+ndo	ndonga		a
+ndo	ndonga		o
+ndo	ndonga		u
+ndo	ndonga		p
+ndo	ndonga		t
+ndo	ndonga		k
+ndo	ndonga		ʔ
+ndo	ndonga		b
+ndo	ndonga		d
+ndo	ndonga		ɡ
+ndo	ndonga		f
+ndo	ndonga		θ
+ndo	ndonga		s
+ndo	ndonga		ʃ
+ndo	ndonga		x
+ndo	ndonga		h
+ndo	ndonga		v
+ndo	ndonga		ð
+ndo	ndonga		z
+ndo	ndonga		ʒ
+ndo	ndonga		ɣ
+ndo	ndonga		ts
+ndo	ndonga		l
+ndo	ndonga		w
+ndo	ndonga		j
+ndo	ndonga		m
+ndo	ndonga		n
+ndo	ndonga		ɲ
+
 mhw	mbukushu		i				western-savanna.pdf
-mhw	mbukushu		u				
-mhw	mbukushu		e				
-mhw	mbukushu		a				
-mhw	mbukushu		o				
-mhw	mbukushu		ɔ				
-mhw	mbukushu		ɛ				
-mhw	mbukushu		p				
-mhw	mbukushu		t				
-mhw	mbukushu		k				
-mhw	mbukushu		t̪				
-mhw	mbukushu		b				
-mhw	mbukushu		d				
-mhw	mbukushu		f				
-mhw	mbukushu		h				
-mhw	mbukushu		θ				
-mhw	mbukushu		ʃ				
-mhw	mbukushu		v				
-mhw	mbukushu		ð				
-mhw	mbukushu		ɣ				
-mhw	mbukushu		t̠ʃ				
-mhw	mbukushu		d̠ʒ				
-mhw	mbukushu		r				
-mhw	mbukushu		w				
-mhw	mbukushu		j				
-mhw	mbukushu		m				
-mhw	mbukushu		n				
-mhw	mbukushu		ɲ				
-mhw	mbukushu		ŋ				
-							
+mhw	mbukushu		u
+mhw	mbukushu		e
+mhw	mbukushu		a
+mhw	mbukushu		o
+mhw	mbukushu		ɔ
+mhw	mbukushu		ɛ
+mhw	mbukushu		p
+mhw	mbukushu		t
+mhw	mbukushu		k
+mhw	mbukushu		t̪
+mhw	mbukushu		b
+mhw	mbukushu		d
+mhw	mbukushu		f
+mhw	mbukushu		h
+mhw	mbukushu		θ
+mhw	mbukushu		ʃ
+mhw	mbukushu		v
+mhw	mbukushu		ð
+mhw	mbukushu		ɣ
+mhw	mbukushu		t̠ʃ
+mhw	mbukushu		d̠ʒ
+mhw	mbukushu		r
+mhw	mbukushu		w
+mhw	mbukushu		j
+mhw	mbukushu		m
+mhw	mbukushu		n
+mhw	mbukushu		ɲ
+mhw	mbukushu		ŋ
+
 diu	diriku		ɛ				western-savanna.pdf
-diu	diriku		ɔ				
-diu	diriku		ʊ				
-diu	diriku		ɪ				
-diu	diriku		a				
-diu	diriku		p				
-diu	diriku		t				
-diu	diriku		k				
-diu	diriku		t̪				
-diu	diriku		b				
-diu	diriku		d				
-diu	diriku		ɡ				
-diu	diriku		f				
-diu	diriku		h				
-diu	diriku		ʃ				
-diu	diriku		v				
-diu	diriku		β				
-diu	diriku		ɣ				
-diu	diriku		t̠ʃ				
-diu	diriku		d̠ʒ				
-diu	diriku		r				
-diu	diriku		l				
-diu	diriku		w				
-diu	diriku		j				
-diu	diriku		m				
-diu	diriku		n				
-diu	diriku		ɲ				
-diu	diriku		ŋ				
-							
+diu	diriku		ɔ
+diu	diriku		ʊ
+diu	diriku		ɪ
+diu	diriku		a
+diu	diriku		p
+diu	diriku		t
+diu	diriku		k
+diu	diriku		t̪
+diu	diriku		b
+diu	diriku		d
+diu	diriku		ɡ
+diu	diriku		f
+diu	diriku		h
+diu	diriku		ʃ
+diu	diriku		v
+diu	diriku		β
+diu	diriku		ɣ
+diu	diriku		t̠ʃ
+diu	diriku		d̠ʒ
+diu	diriku		r
+diu	diriku		l
+diu	diriku		w
+diu	diriku		j
+diu	diriku		m
+diu	diriku		n
+diu	diriku		ɲ
+diu	diriku		ŋ
+
 kwn	kwangari		ɛ				western-savanna.pdf
-kwn	kwangari		ɔ				
-kwn	kwangari		ʊ				
-kwn	kwangari		ɪ				
-kwn	kwangari		a				
-kwn	kwangari		p				
-kwn	kwangari		t				
-kwn	kwangari		k				
-kwn	kwangari		b				
-kwn	kwangari		d				
-kwn	kwangari		ɡ				
-kwn	kwangari		f				
-kwn	kwangari		s				
-kwn	kwangari		h				
-kwn	kwangari		ʃ				
-kwn	kwangari		v				
-kwn	kwangari		β				
-kwn	kwangari		t̠ʃ				
-kwn	kwangari		d̠ʒ				
-kwn	kwangari		r				
-kwn	kwangari		l				
-kwn	kwangari		w				
-kwn	kwangari		j				
-kwn	kwangari		m				
-kwn	kwangari		n				
-kwn	kwangari		ɲ				
-kwn	kwangari		ŋ				
-							
+kwn	kwangari		ɔ
+kwn	kwangari		ʊ
+kwn	kwangari		ɪ
+kwn	kwangari		a
+kwn	kwangari		p
+kwn	kwangari		t
+kwn	kwangari		k
+kwn	kwangari		b
+kwn	kwangari		d
+kwn	kwangari		ɡ
+kwn	kwangari		f
+kwn	kwangari		s
+kwn	kwangari		h
+kwn	kwangari		ʃ
+kwn	kwangari		v
+kwn	kwangari		β
+kwn	kwangari		t̠ʃ
+kwn	kwangari		d̠ʒ
+kwn	kwangari		r
+kwn	kwangari		l
+kwn	kwangari		w
+kwn	kwangari		j
+kwn	kwangari		m
+kwn	kwangari		n
+kwn	kwangari		ɲ
+kwn	kwangari		ŋ
+
 snk	soninke (kaedi (MRT))	kaedi (MRT)	p				snk-1.pdf
-snk	soninke (kaedi (MRT))	kaedi (MRT)	b				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	t				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	d				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	c				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	j				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	k				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ɡ				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	q				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	m				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	n				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ɲ				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ŋ				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	x				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	s				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	l				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	r				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	h				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	bː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	tː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	kː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ɡː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	mː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	nː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	jː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	lː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ɲː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ŋː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	i				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	e				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	a				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	o				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	u				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ĩ				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ẽ				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ã				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	õ				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	ũ				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	iː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	eː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	aː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	oː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	uː				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	˦				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	˨				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	˧				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	˦˨				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	˨˦				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	˦˨˦				
-snk	soninke (kaedi (MRT))	kaedi (MRT)	˨˦˨				
-							
+snk	soninke (kaedi (MRT))	kaedi (MRT)	b
+snk	soninke (kaedi (MRT))	kaedi (MRT)	t
+snk	soninke (kaedi (MRT))	kaedi (MRT)	d
+snk	soninke (kaedi (MRT))	kaedi (MRT)	c
+snk	soninke (kaedi (MRT))	kaedi (MRT)	j
+snk	soninke (kaedi (MRT))	kaedi (MRT)	k
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ɡ
+snk	soninke (kaedi (MRT))	kaedi (MRT)	q
+snk	soninke (kaedi (MRT))	kaedi (MRT)	m
+snk	soninke (kaedi (MRT))	kaedi (MRT)	n
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ɲ
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ŋ
+snk	soninke (kaedi (MRT))	kaedi (MRT)	x
+snk	soninke (kaedi (MRT))	kaedi (MRT)	s
+snk	soninke (kaedi (MRT))	kaedi (MRT)	l
+snk	soninke (kaedi (MRT))	kaedi (MRT)	r
+snk	soninke (kaedi (MRT))	kaedi (MRT)	h
+snk	soninke (kaedi (MRT))	kaedi (MRT)	bː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	tː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	kː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ɡː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	mː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	nː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	jː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	lː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ɲː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ŋː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	i
+snk	soninke (kaedi (MRT))	kaedi (MRT)	e
+snk	soninke (kaedi (MRT))	kaedi (MRT)	a
+snk	soninke (kaedi (MRT))	kaedi (MRT)	o
+snk	soninke (kaedi (MRT))	kaedi (MRT)	u
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ĩ
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ẽ
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ã
+snk	soninke (kaedi (MRT))	kaedi (MRT)	õ
+snk	soninke (kaedi (MRT))	kaedi (MRT)	ũ
+snk	soninke (kaedi (MRT))	kaedi (MRT)	iː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	eː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	aː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	oː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	uː
+snk	soninke (kaedi (MRT))	kaedi (MRT)	˦
+snk	soninke (kaedi (MRT))	kaedi (MRT)	˨
+snk	soninke (kaedi (MRT))	kaedi (MRT)	˧
+snk	soninke (kaedi (MRT))	kaedi (MRT)	˦˨
+snk	soninke (kaedi (MRT))	kaedi (MRT)	˨˦
+snk	soninke (kaedi (MRT))	kaedi (MRT)	˦˨˦
+snk	soninke (kaedi (MRT))	kaedi (MRT)	˨˦˨
+
 ses	Songhay, Koyraboro Senni		<p>	marginal			songhay_heath1999.pdf
-ses	Songhay, Koyraboro Senni		b				
-ses	Songhay, Koyraboro Senni		f				
-ses	Songhay, Koyraboro Senni		m				
-ses	Songhay, Koyraboro Senni		w				
-ses	Songhay, Koyraboro Senni		t				
-ses	Songhay, Koyraboro Senni		d				
-ses	Songhay, Koyraboro Senni		s				
-ses	Songhay, Koyraboro Senni		z				
-ses	Songhay, Koyraboro Senni		n				
-ses	Songhay, Koyraboro Senni		l				
-ses	Songhay, Koyraboro Senni		r				
-ses	Songhay, Koyraboro Senni		t̠ʃ				
-ses	Songhay, Koyraboro Senni		d̠ʒ				
-ses	Songhay, Koyraboro Senni		<ʃ>	marginal			
-ses	Songhay, Koyraboro Senni		<ʒ>	marginal			
-ses	Songhay, Koyraboro Senni		ɲ				
-ses	Songhay, Koyraboro Senni		j				
-ses	Songhay, Koyraboro Senni		k				
-ses	Songhay, Koyraboro Senni		ɡ				
-ses	Songhay, Koyraboro Senni		ŋ				
-ses	Songhay, Koyraboro Senni		h				
-ses	Songhay, Koyraboro Senni		<ʔ>	marginal			
-ses	Songhay, Koyraboro Senni		i				
-ses	Songhay, Koyraboro Senni		e				
-ses	Songhay, Koyraboro Senni		a				
-ses	Songhay, Koyraboro Senni		o				
-ses	Songhay, Koyraboro Senni		u				
-ses	Songhay, Koyraboro Senni		iː				
-ses	Songhay, Koyraboro Senni		eː				
-ses	Songhay, Koyraboro Senni		aː				
-ses	Songhay, Koyraboro Senni		oː				
-ses	Songhay, Koyraboro Senni		uː				
-ses	Songhay, Koyraboro Senni		<ĩ>	rare			
-ses	Songhay, Koyraboro Senni		<ẽ>	rare			
-ses	Songhay, Koyraboro Senni		<ã>	rare			
-ses	Songhay, Koyraboro Senni		<õ>	rare			
-							
+ses	Songhay, Koyraboro Senni		b
+ses	Songhay, Koyraboro Senni		f
+ses	Songhay, Koyraboro Senni		m
+ses	Songhay, Koyraboro Senni		w
+ses	Songhay, Koyraboro Senni		t
+ses	Songhay, Koyraboro Senni		d
+ses	Songhay, Koyraboro Senni		s
+ses	Songhay, Koyraboro Senni		z
+ses	Songhay, Koyraboro Senni		n
+ses	Songhay, Koyraboro Senni		l
+ses	Songhay, Koyraboro Senni		r
+ses	Songhay, Koyraboro Senni		t̠ʃ
+ses	Songhay, Koyraboro Senni		d̠ʒ
+ses	Songhay, Koyraboro Senni		<ʃ>	marginal
+ses	Songhay, Koyraboro Senni		<ʒ>	marginal
+ses	Songhay, Koyraboro Senni		ɲ
+ses	Songhay, Koyraboro Senni		j
+ses	Songhay, Koyraboro Senni		k
+ses	Songhay, Koyraboro Senni		ɡ
+ses	Songhay, Koyraboro Senni		ŋ
+ses	Songhay, Koyraboro Senni		h
+ses	Songhay, Koyraboro Senni		<ʔ>	marginal
+ses	Songhay, Koyraboro Senni		i
+ses	Songhay, Koyraboro Senni		e
+ses	Songhay, Koyraboro Senni		a
+ses	Songhay, Koyraboro Senni		o
+ses	Songhay, Koyraboro Senni		u
+ses	Songhay, Koyraboro Senni		iː
+ses	Songhay, Koyraboro Senni		eː
+ses	Songhay, Koyraboro Senni		aː
+ses	Songhay, Koyraboro Senni		oː
+ses	Songhay, Koyraboro Senni		uː
+ses	Songhay, Koyraboro Senni		<ĩ>	rare
+ses	Songhay, Koyraboro Senni		<ẽ>	rare
+ses	Songhay, Koyraboro Senni		<ã>	rare
+ses	Songhay, Koyraboro Senni		<õ>	rare
+
 lln	Lele		p				lele_frajzyngier.pdf
-lln	Lele		b				
-lln	Lele		ɓ				
-lln	Lele		mb				
-lln	Lele		m				
-lln	Lele		w				
-lln	Lele		t				
-lln	Lele		d				
-lln	Lele		ɗ				
-lln	Lele		nd				
-lln	Lele		s				
-lln	Lele		n				
-lln	Lele		r				
-lln	Lele		l				
-lln	Lele		ɲ				
-lln	Lele		j				
-lln	Lele		k				
-lln	Lele		ɡ				
-lln	Lele		ŋ				
-lln	Lele		kp				
-lln	Lele		ɡb				
-lln	Lele		ŋmɡb				
-lln	Lele		h				
-lln	Lele		˦				
-lln	Lele		˧				
-lln	Lele		˨				
-lln	Lele		i				
-lln	Lele		e				
-lln	Lele		a				
-lln	Lele		o				
-lln	Lele		u				
-lln	Lele		iː				
-lln	Lele		eː				
-lln	Lele		aː				
-lln	Lele		oː				
-lln	Lele		uː				
-							
+lln	Lele		b
+lln	Lele		ɓ
+lln	Lele		mb
+lln	Lele		m
+lln	Lele		w
+lln	Lele		t
+lln	Lele		d
+lln	Lele		ɗ
+lln	Lele		nd
+lln	Lele		s
+lln	Lele		n
+lln	Lele		r
+lln	Lele		l
+lln	Lele		ɲ
+lln	Lele		j
+lln	Lele		k
+lln	Lele		ɡ
+lln	Lele		ŋ
+lln	Lele		kp
+lln	Lele		ɡb
+lln	Lele		ŋmɡb
+lln	Lele		h
+lln	Lele		˦
+lln	Lele		˧
+lln	Lele		˨
+lln	Lele		i
+lln	Lele		e
+lln	Lele		a
+lln	Lele		o
+lln	Lele		u
+lln	Lele		iː
+lln	Lele		eː
+lln	Lele		aː
+lln	Lele		oː
+lln	Lele		uː
+
 kck	Ikalanga		p				kck_mathangwane.pdf
-kck	Ikalanga		b				
-kck	Ikalanga		t̪				
-kck	Ikalanga		d̪				
-kck	Ikalanga		d				
-kck	Ikalanga		d̠ʒ				
-kck	Ikalanga		tʲ				
-kck	Ikalanga		t̠ʃ				
-kck	Ikalanga		<t̠ʃʼ>	marginal			
-kck	Ikalanga		t̠ʃʱ				
-kck	Ikalanga		k				
-kck	Ikalanga		kʰ				
-kck	Ikalanga		ɡ				
-kck	Ikalanga		pkʰ	suspicious?			
-kck	Ikalanga		bɡ				
-kck	Ikalanga		ʔ				
-kck	Ikalanga		pʰ				
-kck	Ikalanga		pʱ				
-kck	Ikalanga		<ps>	marginal and suspicious			
-kck	Ikalanga		<bz>	marginal and suspicious			
-kck	Ikalanga		ts				
-kck	Ikalanga		dz				
-kck	Ikalanga		tsʰ				
-kck	Ikalanga		tsʱ				
-kck	Ikalanga		β				
-kck	Ikalanga		f				
-kck	Ikalanga		v				
-kck	Ikalanga		s				
-kck	Ikalanga		z				
-kck	Ikalanga		ʒ				
-kck	Ikalanga		ʃ				
-kck	Ikalanga		m				
-kck	Ikalanga		n				
-kck	Ikalanga		ŋ				
-kck	Ikalanga		ɲ				
-kck	Ikalanga		l				
-kck	Ikalanga		r				
-kck	Ikalanga		w				
-kck	Ikalanga		j				
-kck	Ikalanga		t̪ʰ				
-kck	Ikalanga		tʰ				
-kck	Ikalanga		tʱ				
-kck	Ikalanga		ɦ				
-kck	Ikalanga		mb				
-kck	Ikalanga		nd				
-kck	Ikalanga		ŋɡ				
-kck	Ikalanga		n̠d̠ʒ	updated from ɲdʒ			
-kck	Ikalanga		dʷ				
-kck	Ikalanga		tʷʰ				
-kck	Ikalanga		kʷ				
-kck	Ikalanga		ɡʷ				
-kck	Ikalanga		kʷʰ				
-kck	Ikalanga		kʷʱ				
-kck	Ikalanga		tsʷʰ				
-kck	Ikalanga		dzʷ				
-kck	Ikalanga		ŋʷ				
-kck	Ikalanga		ŋɡʷ				
-kck	Ikalanga		sʷ				
-kck	Ikalanga		zʷ				
-kck	Ikalanga		ʃʷ				
-kck	Ikalanga		r				
-kck	Ikalanga		l				
-kck	Ikalanga		ʋ				
-kck	Ikalanga		j				
-kck	Ikalanga		w				
-kck	Ikalanga		wʱ				
-kck	Ikalanga		˦				
-kck	Ikalanga		˨				
-kck	Ikalanga		˨˦				
-kck	Ikalanga		˦˨				
-kck	Ikalanga		i				
-kck	Ikalanga		e				
-kck	Ikalanga		a				
-kck	Ikalanga		o				
-kck	Ikalanga		u				
-							
+kck	Ikalanga		b
+kck	Ikalanga		t̪
+kck	Ikalanga		d̪
+kck	Ikalanga		d
+kck	Ikalanga		d̠ʒ
+kck	Ikalanga		tʲ
+kck	Ikalanga		t̠ʃ
+kck	Ikalanga		<t̠ʃʼ>	marginal
+kck	Ikalanga		t̠ʃʱ
+kck	Ikalanga		k
+kck	Ikalanga		kʰ
+kck	Ikalanga		ɡ
+kck	Ikalanga		pkʰ	suspicious?
+kck	Ikalanga		bɡ
+kck	Ikalanga		ʔ
+kck	Ikalanga		pʰ
+kck	Ikalanga		pʱ
+kck	Ikalanga		<ps>	marginal and suspicious
+kck	Ikalanga		<bz>	marginal and suspicious
+kck	Ikalanga		ts
+kck	Ikalanga		dz
+kck	Ikalanga		tsʰ
+kck	Ikalanga		tsʱ
+kck	Ikalanga		β
+kck	Ikalanga		f
+kck	Ikalanga		v
+kck	Ikalanga		s
+kck	Ikalanga		z
+kck	Ikalanga		ʒ
+kck	Ikalanga		ʃ
+kck	Ikalanga		m
+kck	Ikalanga		n
+kck	Ikalanga		ŋ
+kck	Ikalanga		ɲ
+kck	Ikalanga		l
+kck	Ikalanga		r
+kck	Ikalanga		w
+kck	Ikalanga		j
+kck	Ikalanga		t̪ʰ
+kck	Ikalanga		tʰ
+kck	Ikalanga		tʱ
+kck	Ikalanga		ɦ
+kck	Ikalanga		mb
+kck	Ikalanga		nd
+kck	Ikalanga		ŋɡ
+kck	Ikalanga		n̠d̠ʒ	updated from ɲdʒ
+kck	Ikalanga		dʷ
+kck	Ikalanga		tʷʰ
+kck	Ikalanga		kʷ
+kck	Ikalanga		ɡʷ
+kck	Ikalanga		kʷʰ
+kck	Ikalanga		kʷʱ
+kck	Ikalanga		tsʷʰ
+kck	Ikalanga		dzʷ
+kck	Ikalanga		ŋʷ
+kck	Ikalanga		ŋɡʷ
+kck	Ikalanga		sʷ
+kck	Ikalanga		zʷ
+kck	Ikalanga		ʃʷ
+kck	Ikalanga		r
+kck	Ikalanga		l
+kck	Ikalanga		ʋ
+kck	Ikalanga		j
+kck	Ikalanga		w
+kck	Ikalanga		wʱ
+kck	Ikalanga		˦
+kck	Ikalanga		˨
+kck	Ikalanga		˨˦
+kck	Ikalanga		˦˨
+kck	Ikalanga		i
+kck	Ikalanga		e
+kck	Ikalanga		a
+kck	Ikalanga		o
+kck	Ikalanga		u
+
 lol	mongo-nkundu		˦				lol_hulstaert.pdf
-lol	mongo-nkundu		˨				
-lol	mongo-nkundu		˦˨				
-lol	mongo-nkundu		˨˦				
-lol	mongo-nkundu		i				
-lol	mongo-nkundu		e				
-lol	mongo-nkundu		ɛ				
-lol	mongo-nkundu		a				
-lol	mongo-nkundu		ɔ				
-lol	mongo-nkundu		o				
-lol	mongo-nkundu		u				
-lol	mongo-nkundu		b				
-lol	mongo-nkundu		d				
-lol	mongo-nkundu		l		[l]	post nasal	
-lol	mongo-nkundu		l		[d]	post nasal	
-lol	mongo-nkundu		f		[f]	post nasal	
-lol	mongo-nkundu		f		[p]	post nasal	
-lol	mongo-nkundu		ɡ				
-lol	mongo-nkundu		h				
-lol	mongo-nkundu		d̠ʒ				
-lol	mongo-nkundu		k				
-lol	mongo-nkundu		ŋ				
-lol	mongo-nkundu		m				
-lol	mongo-nkundu		ɲ				
-lol	mongo-nkundu		<p>	ideophones only			
-lol	mongo-nkundu		r				
-lol	mongo-nkundu		s				
-lol	mongo-nkundu		t		[t]		
-lol	mongo-nkundu		t		[ts]	before [u]	
-lol	mongo-nkundu		ts				
-lol	mongo-nkundu		w		[w]		
-lol	mongo-nkundu		w		[v]	after b	
-lol	mongo-nkundu		w		[f]	after p	
-lol	mongo-nkundu		j				
-lol	mongo-nkundu		ʔ				
-lol	mongo-nkundu		mb				
-lol	mongo-nkundu		mp				
-lol	mongo-nkundu		mʷ				
-lol	mongo-nkundu		nd				
-lol	mongo-nkundu		ŋɡ				
-lol	mongo-nkundu		ŋk				
-lol	mongo-nkundu		n̠d̠ʒ	updated from ɲdʒ			
-lol	mongo-nkundu		ns				
-lol	mongo-nkundu		nt				
-lol	mongo-nkundu		nts		[nts]		
-lol	mongo-nkundu		nts		[n̠t̠ʃ]		
-lol	mongo-nkundu		nʷ				
-lol	mongo-nkundu		ɲʷ				
-lol	mongo-nkundu		bʷ				
-lol	mongo-nkundu		fʷ				
-lol	mongo-nkundu		d̠ʒʷ				
-lol	mongo-nkundu		kʷ				
-lol	mongo-nkundu		pʷ				
-lol	mongo-nkundu		sʷ				
-lol	mongo-nkundu		tsʷ		[tsʷ]		
-lol	mongo-nkundu		tsʷ		[t̠ʃʷ]		
-lol	mongo-nkundu		jʷ				
-lol	mongo-nkundu		bʲ				
-lol	mongo-nkundu		fʲ				
-lol	mongo-nkundu		kʲ				
-lol	mongo-nkundu		mʲ				
-lol	mongo-nkundu		pʲ				
-lol	mongo-nkundu		sʲ				
-							
+lol	mongo-nkundu		˨
+lol	mongo-nkundu		˦˨
+lol	mongo-nkundu		˨˦
+lol	mongo-nkundu		i
+lol	mongo-nkundu		e
+lol	mongo-nkundu		ɛ
+lol	mongo-nkundu		a
+lol	mongo-nkundu		ɔ
+lol	mongo-nkundu		o
+lol	mongo-nkundu		u
+lol	mongo-nkundu		b
+lol	mongo-nkundu		d
+lol	mongo-nkundu		l		[l]	post nasal
+lol	mongo-nkundu		l		[d]	post nasal
+lol	mongo-nkundu		f		[f]	post nasal
+lol	mongo-nkundu		f		[p]	post nasal
+lol	mongo-nkundu		ɡ
+lol	mongo-nkundu		h
+lol	mongo-nkundu		d̠ʒ
+lol	mongo-nkundu		k
+lol	mongo-nkundu		ŋ
+lol	mongo-nkundu		m
+lol	mongo-nkundu		ɲ
+lol	mongo-nkundu		<p>	ideophones only
+lol	mongo-nkundu		r
+lol	mongo-nkundu		s
+lol	mongo-nkundu		t		[t]
+lol	mongo-nkundu		t		[ts]	before [u]
+lol	mongo-nkundu		ts
+lol	mongo-nkundu		w		[w]
+lol	mongo-nkundu		w		[v]	after b
+lol	mongo-nkundu		w		[f]	after p
+lol	mongo-nkundu		j
+lol	mongo-nkundu		ʔ
+lol	mongo-nkundu		mb
+lol	mongo-nkundu		mp
+lol	mongo-nkundu		mʷ
+lol	mongo-nkundu		nd
+lol	mongo-nkundu		ŋɡ
+lol	mongo-nkundu		ŋk
+lol	mongo-nkundu		n̠d̠ʒ	updated from ɲdʒ
+lol	mongo-nkundu		ns
+lol	mongo-nkundu		nt
+lol	mongo-nkundu		nts		[nts]
+lol	mongo-nkundu		nts		[n̠t̠ʃ]
+lol	mongo-nkundu		nʷ
+lol	mongo-nkundu		ɲʷ
+lol	mongo-nkundu		bʷ
+lol	mongo-nkundu		fʷ
+lol	mongo-nkundu		d̠ʒʷ
+lol	mongo-nkundu		kʷ
+lol	mongo-nkundu		pʷ
+lol	mongo-nkundu		sʷ
+lol	mongo-nkundu		tsʷ		[tsʷ]
+lol	mongo-nkundu		tsʷ		[t̠ʃʷ]
+lol	mongo-nkundu		jʷ
+lol	mongo-nkundu		bʲ
+lol	mongo-nkundu		fʲ
+lol	mongo-nkundu		kʲ
+lol	mongo-nkundu		mʲ
+lol	mongo-nkundu		pʲ
+lol	mongo-nkundu		sʲ
+
 wok	longto		˦				wok_longto.pdf
-wok	longto		˨				
-wok	longto		˨˦				
-wok	longto		˦˨				
-wok	longto		b				
-wok	longto		β				
-wok	longto		ɸ				
-wok	longto		m				
-wok	longto		t				
-wok	longto		d				
-wok	longto		ɽ				
-wok	longto		n				
-wok	longto		c				
-wok	longto		ɟ				
-wok	longto		j				
-wok	longto		ɕ				
-wok	longto		ɲ				
-wok	longto		k				
-wok	longto		ɡ				
-wok	longto		ŋ				
-wok	longto		kp				
-wok	longto		ɡb				
-wok	longto		w				
-wok	longto		ŋm				
-wok	longto		i				
-wok	longto		u				
-wok	longto		ɪ				
-wok	longto		ʊ				
-wok	longto		ɛ				
-wok	longto		ɔ				
-wok	longto		a				
-							
+wok	longto		˨
+wok	longto		˨˦
+wok	longto		˦˨
+wok	longto		b
+wok	longto		β
+wok	longto		ɸ
+wok	longto		m
+wok	longto		t
+wok	longto		d
+wok	longto		ɽ
+wok	longto		n
+wok	longto		c
+wok	longto		ɟ
+wok	longto		j
+wok	longto		ɕ
+wok	longto		ɲ
+wok	longto		k
+wok	longto		ɡ
+wok	longto		ŋ
+wok	longto		kp
+wok	longto		ɡb
+wok	longto		w
+wok	longto		ŋm
+wok	longto		i
+wok	longto		u
+wok	longto		ɪ
+wok	longto		ʊ
+wok	longto		ɛ
+wok	longto		ɔ
+wok	longto		a
+
 xwe	xwela		i				gbe_capo.pdf
-xwe	xwela		e				
-xwe	xwela		ɛ				
-xwe	xwela		ɔ				
-xwe	xwela		o				
-xwe	xwela		u				
-xwe	xwela		a				
-xwe	xwela		ə				
-xwe	xwela		ĩ				
-xwe	xwela		ɛ̃				
-xwe	xwela		ɔ̃				
-xwe	xwela		ũ				
-xwe	xwela		ã				
-xwe	xwela		b				
-xwe	xwela		m				
-xwe	xwela		t				
-xwe	xwela		d				
-xwe	xwela		ɖ				
-xwe	xwela		n				
-xwe	xwela		k				
-xwe	xwela		ɡ				
-xwe	xwela		kp				
-xwe	xwela		ɡb				
-xwe	xwela		ɲ				
-xwe	xwela		f				
-xwe	xwela		v				
-xwe	xwela		s				
-xwe	xwela		z				
-xwe	xwela		χ				
-xwe	xwela		ʁ				
-xwe	xwela		r				
-xwe	xwela		r̃				
-xwe	xwela		l̃				
-xwe	xwela		j				
-xwe	xwela		w				
-xwe	xwela		ɥ				
-xwe	xwela		ɥ̃				
-xwe	xwela		t̠ʃ				
-xwe	xwela		d̠ʒ				
-xwe	xwela		w̃				
-xwe	xwela		χʷ				
-xwe	xwela		ʁʷ				
-xwe	xwela		˦				
-xwe	xwela		˨				
-xwe	xwela		˦˨				
-							
+xwe	xwela		e
+xwe	xwela		ɛ
+xwe	xwela		ɔ
+xwe	xwela		o
+xwe	xwela		u
+xwe	xwela		a
+xwe	xwela		ə
+xwe	xwela		ĩ
+xwe	xwela		ɛ̃
+xwe	xwela		ɔ̃
+xwe	xwela		ũ
+xwe	xwela		ã
+xwe	xwela		b
+xwe	xwela		m
+xwe	xwela		t
+xwe	xwela		d
+xwe	xwela		ɖ
+xwe	xwela		n
+xwe	xwela		k
+xwe	xwela		ɡ
+xwe	xwela		kp
+xwe	xwela		ɡb
+xwe	xwela		ɲ
+xwe	xwela		f
+xwe	xwela		v
+xwe	xwela		s
+xwe	xwela		z
+xwe	xwela		χ
+xwe	xwela		ʁ
+xwe	xwela		r
+xwe	xwela		r̃
+xwe	xwela		l̃
+xwe	xwela		j
+xwe	xwela		w
+xwe	xwela		ɥ
+xwe	xwela		ɥ̃
+xwe	xwela		t̠ʃ
+xwe	xwela		d̠ʒ
+xwe	xwela		w̃
+xwe	xwela		χʷ
+xwe	xwela		ʁʷ
+xwe	xwela		˦
+xwe	xwela		˨
+xwe	xwela		˦˨
+
 xwl	western xwla		i				gbe_capo.pdf
-xwl	western xwla		e				
-xwl	western xwla		ɛ				
-xwl	western xwla		ɔ				
-xwl	western xwla		o				
-xwl	western xwla		u				
-xwl	western xwla		a				
-xwl	western xwla		ə				
-xwl	western xwla		ĩ				
-xwl	western xwla		ɛ̃				
-xwl	western xwla		ɔ̃				
-xwl	western xwla		ũ				
-xwl	western xwla		ã				
-xwl	western xwla		b				
-xwl	western xwla		m				
-xwl	western xwla		t				
-xwl	western xwla		d				
-xwl	western xwla		ɖ				
-xwl	western xwla		n				
-xwl	western xwla		k				
-xwl	western xwla		ɡ				
-xwl	western xwla		kp				
-xwl	western xwla		ɡb				
-xwl	western xwla		ɲ				
-xwl	western xwla		f				
-xwl	western xwla		v				
-xwl	western xwla		s				
-xwl	western xwla		z				
-xwl	western xwla		χ				
-xwl	western xwla		ʁ				
-xwl	western xwla		r				
-xwl	western xwla		r̃				
-xwl	western xwla		l̃				
-xwl	western xwla		j				
-xwl	western xwla		w				
-xwl	western xwla		ɥ				
-xwl	western xwla		ɥ̃				
-xwl	western xwla		t̠ʃ				
-xwl	western xwla		d̠ʒ				
-xwl	western xwla		w̃				
-xwl	western xwla		χʷ				
-xwl	western xwla		ʁʷ				
-xwl	western xwla		˦				
-xwl	western xwla		˨				
-xwl	western xwla		˦˨				
-							
+xwl	western xwla		e
+xwl	western xwla		ɛ
+xwl	western xwla		ɔ
+xwl	western xwla		o
+xwl	western xwla		u
+xwl	western xwla		a
+xwl	western xwla		ə
+xwl	western xwla		ĩ
+xwl	western xwla		ɛ̃
+xwl	western xwla		ɔ̃
+xwl	western xwla		ũ
+xwl	western xwla		ã
+xwl	western xwla		b
+xwl	western xwla		m
+xwl	western xwla		t
+xwl	western xwla		d
+xwl	western xwla		ɖ
+xwl	western xwla		n
+xwl	western xwla		k
+xwl	western xwla		ɡ
+xwl	western xwla		kp
+xwl	western xwla		ɡb
+xwl	western xwla		ɲ
+xwl	western xwla		f
+xwl	western xwla		v
+xwl	western xwla		s
+xwl	western xwla		z
+xwl	western xwla		χ
+xwl	western xwla		ʁ
+xwl	western xwla		r
+xwl	western xwla		r̃
+xwl	western xwla		l̃
+xwl	western xwla		j
+xwl	western xwla		w
+xwl	western xwla		ɥ
+xwl	western xwla		ɥ̃
+xwl	western xwla		t̠ʃ
+xwl	western xwla		d̠ʒ
+xwl	western xwla		w̃
+xwl	western xwla		χʷ
+xwl	western xwla		ʁʷ
+xwl	western xwla		˦
+xwl	western xwla		˨
+xwl	western xwla		˦˨
+
 kqk	kotafon		i				gbe_capo.pdf
-kqk	kotafon		e				
-kqk	kotafon		ɛ				
-kqk	kotafon		ɔ				
-kqk	kotafon		o				
-kqk	kotafon		u				
-kqk	kotafon		a				
-kqk	kotafon		ə				
-kqk	kotafon		ĩ				
-kqk	kotafon		ɛ̃				
-kqk	kotafon		ɔ̃				
-kqk	kotafon		ũ				
-kqk	kotafon		ã				
-kqk	kotafon		b				
-kqk	kotafon		m				
-kqk	kotafon		t				
-kqk	kotafon		d				
-kqk	kotafon		ɖ				
-kqk	kotafon		n				
-kqk	kotafon		k				
-kqk	kotafon		ɡ				
-kqk	kotafon		kp				
-kqk	kotafon		ɡb				
-kqk	kotafon		ɲ				
-kqk	kotafon		f				
-kqk	kotafon		v				
-kqk	kotafon		s				
-kqk	kotafon		z				
-kqk	kotafon		χ				
-kqk	kotafon		ʁ				
-kqk	kotafon		r				
-kqk	kotafon		r̃				
-kqk	kotafon		l̃				
-kqk	kotafon		j				
-kqk	kotafon		w				
-kqk	kotafon		ɥ				
-kqk	kotafon		ɥ̃				
-kqk	kotafon		t̠ʃ				
-kqk	kotafon		d̠ʒ				
-kqk	kotafon		w̃				
-kqk	kotafon		χʷ				
-kqk	kotafon		ʁʷ				
-kqk	kotafon		˦				
-kqk	kotafon		˨				
-kqk	kotafon		˦˨				
-							
+kqk	kotafon		e
+kqk	kotafon		ɛ
+kqk	kotafon		ɔ
+kqk	kotafon		o
+kqk	kotafon		u
+kqk	kotafon		a
+kqk	kotafon		ə
+kqk	kotafon		ĩ
+kqk	kotafon		ɛ̃
+kqk	kotafon		ɔ̃
+kqk	kotafon		ũ
+kqk	kotafon		ã
+kqk	kotafon		b
+kqk	kotafon		m
+kqk	kotafon		t
+kqk	kotafon		d
+kqk	kotafon		ɖ
+kqk	kotafon		n
+kqk	kotafon		k
+kqk	kotafon		ɡ
+kqk	kotafon		kp
+kqk	kotafon		ɡb
+kqk	kotafon		ɲ
+kqk	kotafon		f
+kqk	kotafon		v
+kqk	kotafon		s
+kqk	kotafon		z
+kqk	kotafon		χ
+kqk	kotafon		ʁ
+kqk	kotafon		r
+kqk	kotafon		r̃
+kqk	kotafon		l̃
+kqk	kotafon		j
+kqk	kotafon		w
+kqk	kotafon		ɥ
+kqk	kotafon		ɥ̃
+kqk	kotafon		t̠ʃ
+kqk	kotafon		d̠ʒ
+kqk	kotafon		w̃
+kqk	kotafon		χʷ
+kqk	kotafon		ʁʷ
+kqk	kotafon		˦
+kqk	kotafon		˨
+kqk	kotafon		˦˨
+
 gbs	gbesi		i				gbe_capo.pdf
-gbs	gbesi		e				
-gbs	gbesi		ɛ				
-gbs	gbesi		ɔ				
-gbs	gbesi		o				
-gbs	gbesi		u				
-gbs	gbesi		a				
-gbs	gbesi		ə				
-gbs	gbesi		ĩ				
-gbs	gbesi		ɛ̃				
-gbs	gbesi		ɔ̃				
-gbs	gbesi		ũ				
-gbs	gbesi		ã				
-gbs	gbesi		b				
-gbs	gbesi		m				
-gbs	gbesi		t				
-gbs	gbesi		d				
-gbs	gbesi		ɖ				
-gbs	gbesi		n				
-gbs	gbesi		k				
-gbs	gbesi		ɡ				
-gbs	gbesi		kp				
-gbs	gbesi		ɡb				
-gbs	gbesi		ɲ				
-gbs	gbesi		f				
-gbs	gbesi		v				
-gbs	gbesi		s				
-gbs	gbesi		z				
-gbs	gbesi		χ				
-gbs	gbesi		ʁ				
-gbs	gbesi		r				
-gbs	gbesi		r̃				
-gbs	gbesi		l̃				
-gbs	gbesi		j				
-gbs	gbesi		w				
-gbs	gbesi		ɥ				
-gbs	gbesi		ɥ̃				
-gbs	gbesi		ɸ				
-gbs	gbesi		β				
-gbs	gbesi		w̃				
-gbs	gbesi		χʷ				
-gbs	gbesi		ʁʷ				
-gbs	gbesi		ʃ				
-gbs	gbesi		ʒ				
-gbs	gbesi		˦				
-gbs	gbesi		˨				
-gbs	gbesi		˦˨				
-							
+gbs	gbesi		e
+gbs	gbesi		ɛ
+gbs	gbesi		ɔ
+gbs	gbesi		o
+gbs	gbesi		u
+gbs	gbesi		a
+gbs	gbesi		ə
+gbs	gbesi		ĩ
+gbs	gbesi		ɛ̃
+gbs	gbesi		ɔ̃
+gbs	gbesi		ũ
+gbs	gbesi		ã
+gbs	gbesi		b
+gbs	gbesi		m
+gbs	gbesi		t
+gbs	gbesi		d
+gbs	gbesi		ɖ
+gbs	gbesi		n
+gbs	gbesi		k
+gbs	gbesi		ɡ
+gbs	gbesi		kp
+gbs	gbesi		ɡb
+gbs	gbesi		ɲ
+gbs	gbesi		f
+gbs	gbesi		v
+gbs	gbesi		s
+gbs	gbesi		z
+gbs	gbesi		χ
+gbs	gbesi		ʁ
+gbs	gbesi		r
+gbs	gbesi		r̃
+gbs	gbesi		l̃
+gbs	gbesi		j
+gbs	gbesi		w
+gbs	gbesi		ɥ
+gbs	gbesi		ɥ̃
+gbs	gbesi		ɸ
+gbs	gbesi		β
+gbs	gbesi		w̃
+gbs	gbesi		χʷ
+gbs	gbesi		ʁʷ
+gbs	gbesi		ʃ
+gbs	gbesi		ʒ
+gbs	gbesi		˦
+gbs	gbesi		˨
+gbs	gbesi		˦˨
+
 jmc	machame	bosho	i				jmc_kiwoso.pdf
-jmc	machame	bosho	e				
-jmc	machame	bosho	a				
-jmc	machame	bosho	o				
-jmc	machame	bosho	u				
-jmc	machame	bosho	iː				
-jmc	machame	bosho	eː				
-jmc	machame	bosho	aː				
-jmc	machame	bosho	oː				
-jmc	machame	bosho	uː				
-jmc	machame	bosho	b		[b]		
-jmc	machame	bosho	b		[bʷ]		
-jmc	machame	bosho	b		[bʲ]		
-jmc	machame	bosho	β				
-jmc	machame	bosho	w		[w]		
-jmc	machame	bosho	w		[wʲ]		
-jmc	machame	bosho	t		[t]		
-jmc	machame	bosho	t		[tʲ]		
-jmc	machame	bosho	d		[d]		
-jmc	machame	bosho	d		[dʷ]		
-jmc	machame	bosho	<p>	loans only			
-jmc	machame	bosho	k		[k]		
-jmc	machame	bosho	k		[kʷ]		
-jmc	machame	bosho	k		[kʲ]		
-jmc	machame	bosho	<ɡ>	loans only	[ɡ]		
-jmc	machame	bosho	<ɡ>	loans only	[ɡʲ]		
-jmc	machame	bosho	<ɡ>	loans only	[ɡʷ]		
-jmc	machame	bosho	ɽ				
-jmc	machame	bosho	ɾ				
-jmc	machame	bosho	m		[m]		
-jmc	machame	bosho	m		[mʷ]		
-jmc	machame	bosho	m		[mʲ]		
-jmc	machame	bosho	n		[n]		
-jmc	machame	bosho	n		[nʷ]		
-jmc	machame	bosho	l				
-jmc	machame	bosho	j				
-jmc	machame	bosho	ɲ				
-jmc	machame	bosho	ŋ		[ŋ]		
-jmc	machame	bosho	ŋ		[ŋʲ]		
-jmc	machame	bosho	ŋ		[ŋʷ]		
-jmc	machame	bosho	f		[f]		
-jmc	machame	bosho	f		[fʷ]		
-jmc	machame	bosho	f		[fʲ]		
-jmc	machame	bosho	s		[s]		
-jmc	machame	bosho	s		[sʲ]		
-jmc	machame	bosho	s		[sʷ]		
-jmc	machame	bosho	t̠ʃ		t̠ʃʷ		
-jmc	machame	bosho	t̠ʃ		t̠ʃʷ		
-jmc	machame	bosho	d̠ʒ		d̠ʒʲ		
-jmc	machame	bosho	d̠ʒ		d̠ʒʲ		
-jmc	machame	bosho	ʃ				
-jmc	machame	bosho	<mp>	loan only			
-jmc	machame	bosho	mb				
-jmc	machame	bosho	nt				
-jmc	machame	bosho	nd				
-jmc	machame	bosho	n̠t̠ʃ	updated from ɲtʃ			
-jmc	machame	bosho	n̠d̠ʒ	updated from ɲdʒ			
-jmc	machame	bosho	ŋk				
-jmc	machame	bosho	ŋɡ				
-jmc	machame	bosho	ɱv				
-jmc	machame	bosho	ns				
-jmc	machame	bosho	nz				
-jmc	machame	bosho	lʲ		[lʲ]		
-jmc	machame	bosho	lʲ		[ɮ]		
-jmc	machame	bosho	˨				
-jmc	machame	bosho	˦				
-jmc	machame	bosho	˦˨				
-							
+jmc	machame	bosho	e
+jmc	machame	bosho	a
+jmc	machame	bosho	o
+jmc	machame	bosho	u
+jmc	machame	bosho	iː
+jmc	machame	bosho	eː
+jmc	machame	bosho	aː
+jmc	machame	bosho	oː
+jmc	machame	bosho	uː
+jmc	machame	bosho	b		[b]
+jmc	machame	bosho	b		[bʷ]
+jmc	machame	bosho	b		[bʲ]
+jmc	machame	bosho	β
+jmc	machame	bosho	w		[w]
+jmc	machame	bosho	w		[wʲ]
+jmc	machame	bosho	t		[t]
+jmc	machame	bosho	t		[tʲ]
+jmc	machame	bosho	d		[d]
+jmc	machame	bosho	d		[dʷ]
+jmc	machame	bosho	<p>	loans only
+jmc	machame	bosho	k		[k]
+jmc	machame	bosho	k		[kʷ]
+jmc	machame	bosho	k		[kʲ]
+jmc	machame	bosho	<ɡ>	loans only	[ɡ]
+jmc	machame	bosho	<ɡ>	loans only	[ɡʲ]
+jmc	machame	bosho	<ɡ>	loans only	[ɡʷ]
+jmc	machame	bosho	ɽ
+jmc	machame	bosho	ɾ
+jmc	machame	bosho	m		[m]
+jmc	machame	bosho	m		[mʷ]
+jmc	machame	bosho	m		[mʲ]
+jmc	machame	bosho	n		[n]
+jmc	machame	bosho	n		[nʷ]
+jmc	machame	bosho	l
+jmc	machame	bosho	j
+jmc	machame	bosho	ɲ
+jmc	machame	bosho	ŋ		[ŋ]
+jmc	machame	bosho	ŋ		[ŋʲ]
+jmc	machame	bosho	ŋ		[ŋʷ]
+jmc	machame	bosho	f		[f]
+jmc	machame	bosho	f		[fʷ]
+jmc	machame	bosho	f		[fʲ]
+jmc	machame	bosho	s		[s]
+jmc	machame	bosho	s		[sʲ]
+jmc	machame	bosho	s		[sʷ]
+jmc	machame	bosho	t̠ʃ		t̠ʃʷ
+jmc	machame	bosho	t̠ʃ		t̠ʃʷ
+jmc	machame	bosho	d̠ʒ		d̠ʒʲ
+jmc	machame	bosho	d̠ʒ		d̠ʒʲ
+jmc	machame	bosho	ʃ
+jmc	machame	bosho	<mp>	loan only
+jmc	machame	bosho	mb
+jmc	machame	bosho	nt
+jmc	machame	bosho	nd
+jmc	machame	bosho	n̠t̠ʃ	updated from ɲtʃ
+jmc	machame	bosho	n̠d̠ʒ	updated from ɲdʒ
+jmc	machame	bosho	ŋk
+jmc	machame	bosho	ŋɡ
+jmc	machame	bosho	ɱv
+jmc	machame	bosho	ns
+jmc	machame	bosho	nz
+jmc	machame	bosho	lʲ		[lʲ]
+jmc	machame	bosho	lʲ		[ɮ]
+jmc	machame	bosho	˨
+jmc	machame	bosho	˦
+jmc	machame	bosho	˦˨
+
 mda	mada		pʰ		[pʰ]		mda_price.pdf
-mda	mada		pʰ		[mpʰ]		
-mda	mada		pʰ		[pʲ]		
-mda	mada		pʰ		[pʷ]		
-mda	mada		b		[b]		
-mda	mada		b		[mb]		
-mda	mada		b		[bʲ]		
-mda	mada		b		[bʷ]		
-mda	mada		m				
-mda	mada		f		[f]		
-mda	mada		f		[ɱf]		
-mda	mada		v		[v]		
-mda	mada		v		[ɱv]		
-mda	mada		tʰ		[tʰ]		
-mda	mada		tʰ		[ntʰ]		
-mda	mada		tʰ		[tʲ]		
-mda	mada		d		[d]		
-mda	mada		d		[nd]		
-mda	mada		n				
-mda	mada		ts		[ts]		
-mda	mada		ts		[nts]		
-mda	mada		ts		[t̠ʃ]		
-mda	mada		ts		[tsʷ]		
-mda	mada		dz		[dz]		
-mda	mada		dz		[ndz]		
-mda	mada		dz		[d̠ʒ]		
-mda	mada		dz		[dzʷ]		
-mda	mada		s		[s]		
-mda	mada		s		[ʃ]		
-mda	mada		s		[sʷ]		
-mda	mada		ɽ		[ɽ]		
-mda	mada		ɽ		[ɽ̃]		
-mda	mada		ɾ		[ɾ]		
-mda	mada		ɾ		[r̃]		
-mda	mada		r		[r]		
-mda	mada		r		[rʲ]		
-mda	mada		n				
-mda	mada		l		[l]		
-mda	mada		l		[nl]		
-mda	mada		l		[lʷ]		
-mda	mada		j		[j]		
-mda	mada		j		[ɥ]		
-mda	mada		kʰ		[kʰ]		
-mda	mada		kʰ		[ŋkʰ]		
-mda	mada		kʰ		[kʲ]		
-mda	mada		kʰ		[c]		
-mda	mada		kʰ		[kʷ]		
-mda	mada		ɡ		[ɡ]		
-mda	mada		ɡ		[ŋɡ]		
-mda	mada		ɡ		[ɡʲ]		
-mda	mada		ɡ		[ɟ]		
-mda	mada		ɡ		[ɡʷ]		
-mda	mada		ŋ		[ŋ]		
-mda	mada		ŋ		[ɲ]		
-mda	mada		ŋ		[ŋʷ]		
-mda	mada		kp		[kp]		
-mda	mada		kp		[ŋmkp]		
-mda	mada		kp		[kpʲ]		
-mda	mada		ɡb		[ɡb]		
-mda	mada		ɡb		[ŋmɡb]		
-mda	mada		ɡb		[ɡbʲ]		
-mda	mada		ʍ		[ʍ]		
-mda	mada		ʍ		[ʍʲ]		
-mda	mada		ʍ		[h]		
-mda	mada		w				
-mda	mada		i		[i]		
-mda	mada		i		[ɪ]		
-mda	mada		ĩ				
-mda	mada		eʲ		[eʲ]		
-mda	mada		eʲ		[ẽʲ]		
-mda	mada		ɛ		[ɛ]		
-mda	mada		ɛ		[aʲ]		
-mda	mada		ɛ̃		[ɛ̃]		
-mda	mada		ɛ̃		[ãʲ]		
-mda	mada		ə		[ə]		
-mda	mada		ə		[ɪ]		
-mda	mada		ə		[ɨ]		
-mda	mada		a				
-mda	mada		ã				
-mda	mada		u		[u]		
-mda	mada		u		[ɨ]		
-mda	mada		u		[ʉ]		
-mda	mada		ũ				
-mda	mada		o		[o]		
-mda	mada		o		[õ]		
-mda	mada		ɔ				
-mda	mada		ɔ̃				
-mda	mada		˦				
-mda	mada		˧				
-mda	mada		˨				
-mda	mada		˦˨				
-mda	mada		˨˦				
-							
+mda	mada		pʰ		[mpʰ]
+mda	mada		pʰ		[pʲ]
+mda	mada		pʰ		[pʷ]
+mda	mada		b		[b]
+mda	mada		b		[mb]
+mda	mada		b		[bʲ]
+mda	mada		b		[bʷ]
+mda	mada		m
+mda	mada		f		[f]
+mda	mada		f		[ɱf]
+mda	mada		v		[v]
+mda	mada		v		[ɱv]
+mda	mada		tʰ		[tʰ]
+mda	mada		tʰ		[ntʰ]
+mda	mada		tʰ		[tʲ]
+mda	mada		d		[d]
+mda	mada		d		[nd]
+mda	mada		n
+mda	mada		ts		[ts]
+mda	mada		ts		[nts]
+mda	mada		ts		[t̠ʃ]
+mda	mada		ts		[tsʷ]
+mda	mada		dz		[dz]
+mda	mada		dz		[ndz]
+mda	mada		dz		[d̠ʒ]
+mda	mada		dz		[dzʷ]
+mda	mada		s		[s]
+mda	mada		s		[ʃ]
+mda	mada		s		[sʷ]
+mda	mada		ɽ		[ɽ]
+mda	mada		ɽ		[ɽ̃]
+mda	mada		ɾ		[ɾ]
+mda	mada		ɾ		[r̃]
+mda	mada		r		[r]
+mda	mada		r		[rʲ]
+mda	mada		n
+mda	mada		l		[l]
+mda	mada		l		[nl]
+mda	mada		l		[lʷ]
+mda	mada		j		[j]
+mda	mada		j		[ɥ]
+mda	mada		kʰ		[kʰ]
+mda	mada		kʰ		[ŋkʰ]
+mda	mada		kʰ		[kʲ]
+mda	mada		kʰ		[c]
+mda	mada		kʰ		[kʷ]
+mda	mada		ɡ		[ɡ]
+mda	mada		ɡ		[ŋɡ]
+mda	mada		ɡ		[ɡʲ]
+mda	mada		ɡ		[ɟ]
+mda	mada		ɡ		[ɡʷ]
+mda	mada		ŋ		[ŋ]
+mda	mada		ŋ		[ɲ]
+mda	mada		ŋ		[ŋʷ]
+mda	mada		kp		[kp]
+mda	mada		kp		[ŋmkp]
+mda	mada		kp		[kpʲ]
+mda	mada		ɡb		[ɡb]
+mda	mada		ɡb		[ŋmɡb]
+mda	mada		ɡb		[ɡbʲ]
+mda	mada		ʍ		[ʍ]
+mda	mada		ʍ		[ʍʲ]
+mda	mada		ʍ		[h]
+mda	mada		w
+mda	mada		i		[i]
+mda	mada		i		[ɪ]
+mda	mada		ĩ
+mda	mada		eʲ		[eʲ]
+mda	mada		eʲ		[ẽʲ]
+mda	mada		ɛ		[ɛ]
+mda	mada		ɛ		[aʲ]
+mda	mada		ɛ̃		[ɛ̃]
+mda	mada		ɛ̃		[ãʲ]
+mda	mada		ə		[ə]
+mda	mada		ə		[ɪ]
+mda	mada		ə		[ɨ]
+mda	mada		a
+mda	mada		ã
+mda	mada		u		[u]
+mda	mada		u		[ɨ]
+mda	mada		u		[ʉ]
+mda	mada		ũ
+mda	mada		o		[o]
+mda	mada		o		[õ]
+mda	mada		ɔ
+mda	mada		ɔ̃
+mda	mada		˦
+mda	mada		˧
+mda	mada		˨
+mda	mada		˦˨
+mda	mada		˨˦
+
 mfo	mbe		p		[p]		mfo_bamgbose.pdf
-mfo	mbe		p		[pɸ]	between nasal and [u]	
-mfo	mbe		b		[b]		
-mfo	mbe		b		[b̥]	word-final	
-mfo	mbe		f				
-mfo	mbe		t				
-mfo	mbe		d				
-mfo	mbe		s				
-mfo	mbe		ʃ				
-mfo	mbe		k				
-mfo	mbe		ɡ		[ɡ]		
-mfo	mbe		ɡ		[ɡʷ]	before [u]	
-mfo	mbe		h				
-mfo	mbe		kʷ				
-mfo	mbe		kp				
-mfo	mbe		ɡb				
-mfo	mbe		ts				
-mfo	mbe		dz				
-mfo	mbe		t̠ʃ				
-mfo	mbe		d̠ʒ				
-mfo	mbe		ŋ				
-mfo	mbe		m				
-mfo	mbe		n				
-mfo	mbe		l				
-mfo	mbe		r		[r]		
-mfo	mbe		r		[ɾ]		
-mfo	mbe		r		[ɾ̥]		
-mfo	mbe		j				
-mfo	mbe		w				
-mfo	mbe		ɲ	phonologically a nasalized palatal approximant			
-mfo	mbe		ŋʷ	phonologically a nasalized labial approximant			
-mfo	mbe		i				
-mfo	mbe		e		[e]		
-mfo	mbe		e		[ɨ]		
-mfo	mbe		ɛ				
-mfo	mbe		a				
-mfo	mbe		u		[u]		
-mfo	mbe		u		[y]		
-mfo	mbe		o		[o]		
-mfo	mbe		o		[ɷ̃]		
-mfo	mbe		ɔ				
-mfo	mbe		˦				
-mfo	mbe		˨				
-mfo	mbe		˦˨				
-mfo	mbe		˨˦				
-							
+mfo	mbe		p		[pɸ]	between nasal and [u]
+mfo	mbe		b		[b]
+mfo	mbe		b		[b̥]	word-final
+mfo	mbe		f
+mfo	mbe		t
+mfo	mbe		d
+mfo	mbe		s
+mfo	mbe		ʃ
+mfo	mbe		k
+mfo	mbe		ɡ		[ɡ]
+mfo	mbe		ɡ		[ɡʷ]	before [u]
+mfo	mbe		h
+mfo	mbe		kʷ
+mfo	mbe		kp
+mfo	mbe		ɡb
+mfo	mbe		ts
+mfo	mbe		dz
+mfo	mbe		t̠ʃ
+mfo	mbe		d̠ʒ
+mfo	mbe		ŋ
+mfo	mbe		m
+mfo	mbe		n
+mfo	mbe		l
+mfo	mbe		r		[r]
+mfo	mbe		r		[ɾ]
+mfo	mbe		r		[ɾ̥]
+mfo	mbe		j
+mfo	mbe		w
+mfo	mbe		ɲ	phonologically a nasalized palatal approximant
+mfo	mbe		ŋʷ	phonologically a nasalized labial approximant
+mfo	mbe		i
+mfo	mbe		e		[e]
+mfo	mbe		e		[ɨ]
+mfo	mbe		ɛ
+mfo	mbe		a
+mfo	mbe		u		[u]
+mfo	mbe		u		[y]
+mfo	mbe		o		[o]
+mfo	mbe		o		[ɷ̃]
+mfo	mbe		ɔ
+mfo	mbe		˦
+mfo	mbe		˨
+mfo	mbe		˦˨
+mfo	mbe		˨˦
+
 nwe	ngwe		p		[p]		nwe_dunstan.pdf
-nwe	ngwe		p		[pɸ]	word final	
-nwe	ngwe		t		[t]		
-nwe	ngwe		d		[r]		
-nwe	ngwe		d		[l]		
-nwe	ngwe		t		[ts]	word final	
-nwe	ngwe		d		[d]		
-nwe	ngwe		k				
-nwe	ngwe		ɡ		[ɡ]	intervocalic	
-nwe	ngwe		ɡ		[ɣ]	intervocalic	
-nwe	ngwe		kp				
-nwe	ngwe		ɡb		[ɡb]	intervocalic	
-nwe	ngwe		ɡb		[ɣβ]	intervocalic	
-nwe	ngwe		<ʋ>	marginal			
-nwe	ngwe		ʔ				
-nwe	ngwe		β		[β]		
-nwe	ngwe		β		[b]	post-nasal	
-nwe	ngwe		f				
-nwe	ngwe		v				
-nwe	ngwe		s		[s]		
-nwe	ngwe		s		[ts]	post nasal	
-nwe	ngwe		z		[z]		
-nwe	ngwe		z		[dz]	post nasal	
-nwe	ngwe		m				
-nwe	ngwe		w				
-nwe	ngwe		r		[r]		
-nwe	ngwe		r		[dr]	post nasal	
-nwe	ngwe		n				
-nwe	ngwe		t̠ʃ		[t̠ʃ]		
-nwe	ngwe		t̠ʃ		[c]		
-nwe	ngwe		tr				
-nwe	ngwe		d̠ʒ		[d̠ʒ]		
-nwe	ngwe		d̠ʒ		[ɟ]		
-nwe	ngwe		ɲ				
-nwe	ngwe		ŋ				
-nwe	ngwe		h				
-nwe	ngwe		i				
-nwe	ngwe		e				
-nwe	ngwe		ɛ				
-nwe	ngwe		æ				
-nwe	ngwe		y				
-nwe	ngwe		ø				
-nwe	ngwe		œ				
-nwe	ngwe		ə				
-nwe	ngwe		u				
-nwe	ngwe		ɯ				
-nwe	ngwe		o				
-nwe	ngwe		ɔ				
-nwe	ngwe		a				
-nwe	ngwe		ɤ				
-							
+nwe	ngwe		p		[pɸ]	word final
+nwe	ngwe		t		[t]
+nwe	ngwe		d		[r]
+nwe	ngwe		d		[l]
+nwe	ngwe		t		[ts]	word final
+nwe	ngwe		d		[d]
+nwe	ngwe		k
+nwe	ngwe		ɡ		[ɡ]	intervocalic
+nwe	ngwe		ɡ		[ɣ]	intervocalic
+nwe	ngwe		kp
+nwe	ngwe		ɡb		[ɡb]	intervocalic
+nwe	ngwe		ɡb		[ɣβ]	intervocalic
+nwe	ngwe		<ʋ>	marginal
+nwe	ngwe		ʔ
+nwe	ngwe		β		[β]
+nwe	ngwe		β		[b]	post-nasal
+nwe	ngwe		f
+nwe	ngwe		v
+nwe	ngwe		s		[s]
+nwe	ngwe		s		[ts]	post nasal
+nwe	ngwe		z		[z]
+nwe	ngwe		z		[dz]	post nasal
+nwe	ngwe		m
+nwe	ngwe		w
+nwe	ngwe		r		[r]
+nwe	ngwe		r		[dr]	post nasal
+nwe	ngwe		n
+nwe	ngwe		t̠ʃ		[t̠ʃ]
+nwe	ngwe		t̠ʃ		[c]
+nwe	ngwe		tr
+nwe	ngwe		d̠ʒ		[d̠ʒ]
+nwe	ngwe		d̠ʒ		[ɟ]
+nwe	ngwe		ɲ
+nwe	ngwe		ŋ
+nwe	ngwe		h
+nwe	ngwe		i
+nwe	ngwe		e
+nwe	ngwe		ɛ
+nwe	ngwe		æ
+nwe	ngwe		y
+nwe	ngwe		ø
+nwe	ngwe		œ
+nwe	ngwe		ə
+nwe	ngwe		u
+nwe	ngwe		ɯ
+nwe	ngwe		o
+nwe	ngwe		ɔ
+nwe	ngwe		a
+nwe	ngwe		ɤ
+
 jow	jowulu		p		[p]		jow_carlson.pdf
-jow	jowulu		p		[pʷ]		
-jow	jowulu		p		[pʲ]		
-jow	jowulu		b		[b]		
-jow	jowulu		b		[bʷ]		
-jow	jowulu		b		[bʲ]		
-jow	jowulu		m		[m]		
-jow	jowulu		m		[mʷ]		
-jow	jowulu		m		[mʲ]		
-jow	jowulu		f		[f]		
-jow	jowulu		f		[fʷ]		
-jow	jowulu		f		[fʲ]		
-jow	jowulu		f		[v]	post nasal	
-jow	jowulu		f		[vʷ]	post nasal	
-jow	jowulu		f		[vʲ]	post nasal	
-jow	jowulu		t				
-jow	jowulu		d		[d]		
-jow	jowulu		d		[r]		
-jow	jowulu		n				
-jow	jowulu		s		[s]		
-jow	jowulu		s		[z]	post nasal	
-jow	jowulu		l		[l]		
-jow	jowulu		l		[ʎ]		
-jow	jowulu		c				
-jow	jowulu		ɟ				
-jow	jowulu		ɲ				
-jow	jowulu		ʃ		[ʃ]		
-jow	jowulu		ʃ		[ʒ]	post nasal	
-jow	jowulu		j				
-jow	jowulu		k		[k]		
-jow	jowulu		k		[ɡ]	post nasal	
-jow	jowulu		k		[kf]	post nasal	
-jow	jowulu		kp				
-jow	jowulu		ɡb				
-jow	jowulu		ŋ		[ŋ]		
-jow	jowulu		ŋ		[ŋʷ]		
-jow	jowulu		ŋm				
-jow	jowulu		w				
-jow	jowulu		i				
-jow	jowulu		e				
-jow	jowulu		ɛ				
-jow	jowulu		a				
-jow	jowulu		u				
-jow	jowulu		o				
-jow	jowulu		ɔ				
-jow	jowulu		ĩ				
-jow	jowulu		ẽ				
-jow	jowulu		ɛ̃				
-jow	jowulu		ã				
-jow	jowulu		ũ				
-jow	jowulu		õ				
-jow	jowulu		ɔ̃				
-jow	jowulu		iː				
-jow	jowulu		eː				
-jow	jowulu		ɛː				
-jow	jowulu		aː				
-jow	jowulu		uː				
-jow	jowulu		oː				
-jow	jowulu		ɔː				
-jow	jowulu		˥				
-jow	jowulu		˦				
-jow	jowulu		˧				
-jow	jowulu		˨				
-							
+jow	jowulu		p		[pʷ]
+jow	jowulu		p		[pʲ]
+jow	jowulu		b		[b]
+jow	jowulu		b		[bʷ]
+jow	jowulu		b		[bʲ]
+jow	jowulu		m		[m]
+jow	jowulu		m		[mʷ]
+jow	jowulu		m		[mʲ]
+jow	jowulu		f		[f]
+jow	jowulu		f		[fʷ]
+jow	jowulu		f		[fʲ]
+jow	jowulu		f		[v]	post nasal
+jow	jowulu		f		[vʷ]	post nasal
+jow	jowulu		f		[vʲ]	post nasal
+jow	jowulu		t
+jow	jowulu		d		[d]
+jow	jowulu		d		[r]
+jow	jowulu		n
+jow	jowulu		s		[s]
+jow	jowulu		s		[z]	post nasal
+jow	jowulu		l		[l]
+jow	jowulu		l		[ʎ]
+jow	jowulu		c
+jow	jowulu		ɟ
+jow	jowulu		ɲ
+jow	jowulu		ʃ		[ʃ]
+jow	jowulu		ʃ		[ʒ]	post nasal
+jow	jowulu		j
+jow	jowulu		k		[k]
+jow	jowulu		k		[ɡ]	post nasal
+jow	jowulu		k		[kf]	post nasal
+jow	jowulu		kp
+jow	jowulu		ɡb
+jow	jowulu		ŋ		[ŋ]
+jow	jowulu		ŋ		[ŋʷ]
+jow	jowulu		ŋm
+jow	jowulu		w
+jow	jowulu		i
+jow	jowulu		e
+jow	jowulu		ɛ
+jow	jowulu		a
+jow	jowulu		u
+jow	jowulu		o
+jow	jowulu		ɔ
+jow	jowulu		ĩ
+jow	jowulu		ẽ
+jow	jowulu		ɛ̃
+jow	jowulu		ã
+jow	jowulu		ũ
+jow	jowulu		õ
+jow	jowulu		ɔ̃
+jow	jowulu		iː
+jow	jowulu		eː
+jow	jowulu		ɛː
+jow	jowulu		aː
+jow	jowulu		uː
+jow	jowulu		oː
+jow	jowulu		ɔː
+jow	jowulu		˥
+jow	jowulu		˦
+jow	jowulu		˧
+jow	jowulu		˨
+
 yba	yala	ikom	p				yba_armstrong.pdf
-yba	yala	ikom	t				
-yba	yala	ikom	c				
-yba	yala	ikom	k				
-yba	yala	ikom	kp				
-yba	yala	ikom	kʷ				
-yba	yala	ikom	b				
-yba	yala	ikom	d				
-yba	yala	ikom	ɟ				
-yba	yala	ikom	ɡ				
-yba	yala	ikom	ɡb				
-yba	yala	ikom	ɡʷ				
-yba	yala	ikom	mb				
-yba	yala	ikom	ŋmɡb				
-yba	yala	ikom	f				
-yba	yala	ikom	s				
-yba	yala	ikom	x				
-yba	yala	ikom	ʃ				
-yba	yala	ikom	l				
-yba	yala	ikom	r				
-yba	yala	ikom	m				
-yba	yala	ikom	n				
-yba	yala	ikom	ɲ				
-yba	yala	ikom	ŋ				
-yba	yala	ikom	ŋʷ				
-yba	yala	ikom	w				
-yba	yala	ikom	j				
-yba	yala	ikom	wʲ				
-yba	yala	ikom	i				
-yba	yala	ikom	e				
-yba	yala	ikom	ɛ				
-yba	yala	ikom	a				
-yba	yala	ikom	u				
-yba	yala	ikom	o				
-yba	yala	ikom	ɔ				
-yba	yala	ikom	˦				
-yba	yala	ikom	˧				
-yba	yala	ikom	˨				
-							
+yba	yala	ikom	t
+yba	yala	ikom	c
+yba	yala	ikom	k
+yba	yala	ikom	kp
+yba	yala	ikom	kʷ
+yba	yala	ikom	b
+yba	yala	ikom	d
+yba	yala	ikom	ɟ
+yba	yala	ikom	ɡ
+yba	yala	ikom	ɡb
+yba	yala	ikom	ɡʷ
+yba	yala	ikom	mb
+yba	yala	ikom	ŋmɡb
+yba	yala	ikom	f
+yba	yala	ikom	s
+yba	yala	ikom	x
+yba	yala	ikom	ʃ
+yba	yala	ikom	l
+yba	yala	ikom	r
+yba	yala	ikom	m
+yba	yala	ikom	n
+yba	yala	ikom	ɲ
+yba	yala	ikom	ŋ
+yba	yala	ikom	ŋʷ
+yba	yala	ikom	w
+yba	yala	ikom	j
+yba	yala	ikom	wʲ
+yba	yala	ikom	i
+yba	yala	ikom	e
+yba	yala	ikom	ɛ
+yba	yala	ikom	a
+yba	yala	ikom	u
+yba	yala	ikom	o
+yba	yala	ikom	ɔ
+yba	yala	ikom	˦
+yba	yala	ikom	˧
+yba	yala	ikom	˨
+
 mgr	cilungu		i				mgr_bickmore.pdf
-mgr	cilungu		e				
-mgr	cilungu		u				
-mgr	cilungu		o				
-mgr	cilungu		a				
-mgr	cilungu		iː				
-mgr	cilungu		eː				
-mgr	cilungu		uː				
-mgr	cilungu		oː				
-mgr	cilungu		aː				
-mgr	cilungu		˨				
-mgr	cilungu		˦				
-mgr	cilungu		↓˦				
-mgr	cilungu		˨˦				
-mgr	cilungu		˦˨				
-mgr	cilungu		˦↓˦				
-mgr	cilungu		↓˦↓˦				
-mgr	cilungu		p				
-mgr	cilungu		b				
-mgr	cilungu		d		[d]		
-mgr	cilungu		d		[l]		
-mgr	cilungu		t				
-mgr	cilungu		ɡ				
-mgr	cilungu		k				
-mgr	cilungu		t̠ʃ				
-mgr	cilungu		d̠ʒ				
-mgr	cilungu		v				
-mgr	cilungu		f				
-mgr	cilungu		z				
-mgr	cilungu		s				
-mgr	cilungu		ʃ				
-mgr	cilungu		m				
-mgr	cilungu		n				
-mgr	cilungu		ɲ				
-mgr	cilungu		ŋ				
-mgr	cilungu		j				
-mgr	cilungu		w				
-							
+mgr	cilungu		e
+mgr	cilungu		u
+mgr	cilungu		o
+mgr	cilungu		a
+mgr	cilungu		iː
+mgr	cilungu		eː
+mgr	cilungu		uː
+mgr	cilungu		oː
+mgr	cilungu		aː
+mgr	cilungu		˨
+mgr	cilungu		˦
+mgr	cilungu		↓˦
+mgr	cilungu		˨˦
+mgr	cilungu		˦˨
+mgr	cilungu		˦↓˦
+mgr	cilungu		↓˦↓˦
+mgr	cilungu		p
+mgr	cilungu		b
+mgr	cilungu		d		[d]
+mgr	cilungu		d		[l]
+mgr	cilungu		t
+mgr	cilungu		ɡ
+mgr	cilungu		k
+mgr	cilungu		t̠ʃ
+mgr	cilungu		d̠ʒ
+mgr	cilungu		v
+mgr	cilungu		f
+mgr	cilungu		z
+mgr	cilungu		s
+mgr	cilungu		ʃ
+mgr	cilungu		m
+mgr	cilungu		n
+mgr	cilungu		ɲ
+mgr	cilungu		ŋ
+mgr	cilungu		j
+mgr	cilungu		w
+
 kcv	kete		i		[i]		kcv_muzenga.pdf
-kcv	kete		i		[ɪ]		
-kcv	kete		i		[ɨ]		
-kcv	kete		i		[iː]		
-kcv	kete		e		[e]		
-kcv	kete		e		[ɛ]		
-kcv	kete		e		[ɛ̃]		
-kcv	kete		a		[a]		
-kcv	kete		a		[ã]		
-kcv	kete		o		[o]		
-kcv	kete		o		[ɔ]		
-kcv	kete		o		[ɔ̃]		
-kcv	kete		o		[ə]		
-kcv	kete		u		[u]		
-kcv	kete		u		[ʊ]		
-kcv	kete		u		[uː]		
-kcv	kete		u		[ũ]		
-kcv	kete		j				
-kcv	kete		w				
-kcv	kete		m				
-kcv	kete		b				
-kcv	kete		p		[p]		
-kcv	kete		p		[pf]		
-kcv	kete		v				
-kcv	kete		n		[n]		
-kcv	kete		f		[f]		
-kcv	kete		f		[pf]		
-kcv	kete		n		[ŋ]		
-kcv	kete		d		[d]		
-kcv	kete		d		[r]		
-kcv	kete		d		[d̠ʒʷ]		
-kcv	kete		d		[d̠ʒ]		
-kcv	kete		t		[t]		
-kcv	kete		t		[t̠ʃʷ]		
-kcv	kete		t		[t̠ʃ]		
-kcv	kete		t		[ts]		
-kcv	kete		t		[tsʷ]		
-kcv	kete		z		[z]		
-kcv	kete		z		[ʒ]		
-kcv	kete		z		[ʒʷ]		
-kcv	kete		s		[s]		
-kcv	kete		s		[ʃʷ]		
-kcv	kete		s		[ʃ]		
-kcv	kete		s		[ts]		
-kcv	kete		s		[tsʷ]		
-kcv	kete		l				
-kcv	kete		k				
-kcv	kete		ɡ		[ɡ]		
-kcv	kete		ɡ		[ɡˠ		
-kcv	kete		ɡ		[ŋ]		
-kcv	kete		ɲ				
-kcv	kete		˦				
-kcv	kete		˨				
-kcv	kete		˧				
-kcv	kete		˦˨				
-							
+kcv	kete		i		[ɪ]
+kcv	kete		i		[ɨ]
+kcv	kete		i		[iː]
+kcv	kete		e		[e]
+kcv	kete		e		[ɛ]
+kcv	kete		e		[ɛ̃]
+kcv	kete		a		[a]
+kcv	kete		a		[ã]
+kcv	kete		o		[o]
+kcv	kete		o		[ɔ]
+kcv	kete		o		[ɔ̃]
+kcv	kete		o		[ə]
+kcv	kete		u		[u]
+kcv	kete		u		[ʊ]
+kcv	kete		u		[uː]
+kcv	kete		u		[ũ]
+kcv	kete		j
+kcv	kete		w
+kcv	kete		m
+kcv	kete		b
+kcv	kete		p		[p]
+kcv	kete		p		[pf]
+kcv	kete		v
+kcv	kete		n		[n]
+kcv	kete		f		[f]
+kcv	kete		f		[pf]
+kcv	kete		n		[ŋ]
+kcv	kete		d		[d]
+kcv	kete		d		[r]
+kcv	kete		d		[d̠ʒʷ]
+kcv	kete		d		[d̠ʒ]
+kcv	kete		t		[t]
+kcv	kete		t		[t̠ʃʷ]
+kcv	kete		t		[t̠ʃ]
+kcv	kete		t		[ts]
+kcv	kete		t		[tsʷ]
+kcv	kete		z		[z]
+kcv	kete		z		[ʒ]
+kcv	kete		z		[ʒʷ]
+kcv	kete		s		[s]
+kcv	kete		s		[ʃʷ]
+kcv	kete		s		[ʃ]
+kcv	kete		s		[ts]
+kcv	kete		s		[tsʷ]
+kcv	kete		l
+kcv	kete		k
+kcv	kete		ɡ		[ɡ]
+kcv	kete		ɡ		[ɡˠ
+kcv	kete		ɡ		[ŋ]
+kcv	kete		ɲ
+kcv	kete		˦
+kcv	kete		˨
+kcv	kete		˧
+kcv	kete		˦˨
+
 kws	kwezo		i				kws_forges.pdf
-kws	kwezo		e		[e]		
-kws	kwezo		e		[ɛ]		
-kws	kwezo		o		[o]		
-kws	kwezo		o		[ɔ]		
-kws	kwezo		u				
-kws	kwezo		a				
-kws	kwezo		y				
-kws	kwezo		w				
-kws	kwezo		m				
-kws	kwezo		n		[n]		
-kws	kwezo		n		[ŋ]		
-kws	kwezo		b				
-kws	kwezo		pʰ				
-kws	kwezo		tʰ		[tʰ]		
-kws	kwezo		tʰ		[t̠ʃ]		
-kws	kwezo		d				
-kws	kwezo		kʰ				
-kws	kwezo		ɡ				
-kws	kwezo		f				
-kws	kwezo		v				
-kws	kwezo		z		[z]		
-kws	kwezo		z		[ʒ]		
-kws	kwezo		s		[s]		
-kws	kwezo		s		[ʃ]		
-kws	kwezo		h				
-kws	kwezo		d̠ʒ				
-kws	kwezo		l				
-kws	kwezo		˦˨				
-kws	kwezo		˨˦				
-kws	kwezo		˦˨˦				
-							
+kws	kwezo		e		[e]
+kws	kwezo		e		[ɛ]
+kws	kwezo		o		[o]
+kws	kwezo		o		[ɔ]
+kws	kwezo		u
+kws	kwezo		a
+kws	kwezo		y
+kws	kwezo		w
+kws	kwezo		m
+kws	kwezo		n		[n]
+kws	kwezo		n		[ŋ]
+kws	kwezo		b
+kws	kwezo		pʰ
+kws	kwezo		tʰ		[tʰ]
+kws	kwezo		tʰ		[t̠ʃ]
+kws	kwezo		d
+kws	kwezo		kʰ
+kws	kwezo		ɡ
+kws	kwezo		f
+kws	kwezo		v
+kws	kwezo		z		[z]
+kws	kwezo		z		[ʒ]
+kws	kwezo		s		[s]
+kws	kwezo		s		[ʃ]
+kws	kwezo		h
+kws	kwezo		d̠ʒ
+kws	kwezo		l
+kws	kwezo		˦˨
+kws	kwezo		˨˦
+kws	kwezo		˦˨˦
+
 snm	Madi	Lokai	p				snm_blackingsfabb.pdf
-snm	Madi	Lokai	b				
-snm	Madi	Lokai	t				
-snm	Madi	Lokai	d				
-snm	Madi	Lokai	k				
-snm	Madi	Lokai	ɡ				
-snm	Madi	Lokai	ʔ				
-snm	Madi	Lokai	mb				
-snm	Madi	Lokai	nd				
-snm	Madi	Lokai	ŋɡ				
-snm	Madi	Lokai	ɓ				
-snm	Madi	Lokai	ɗ				
-snm	Madi	Lokai	ʄ				
-snm	Madi	Lokai	m				
-snm	Madi	Lokai	n				
-snm	Madi	Lokai	ŋ				
-snm	Madi	Lokai	ɲ				
-snm	Madi	Lokai	f				
-snm	Madi	Lokai	s				
-snm	Madi	Lokai	<h>	interjections and loanwords			
-snm	Madi	Lokai	v				
-snm	Madi	Lokai	z				
-snm	Madi	Lokai	ɱv				
-snm	Madi	Lokai	t̠ʃ				
-snm	Madi	Lokai	d̠ʒ				
-snm	Madi	Lokai	n̠d̠ʒ	updated from ɲdʒ			
-snm	Madi	Lokai	l				
-snm	Madi	Lokai	r				
-snm	Madi	Lokai	j				
-snm	Madi	Lokai	kp				
-snm	Madi	Lokai	ɡb				
-snm	Madi	Lokai	ŋmɡb				
-snm	Madi	Lokai	ɠɓ				
-snm	Madi	Lokai	ŋm				
-snm	Madi	Lokai	w				
-snm	Madi	Lokai	tʷ				
-snm	Madi	Lokai	dʷ				
-snm	Madi	Lokai	ndʷ				
-snm	Madi	Lokai	t̠ʃʷ				
-snm	Madi	Lokai	lʷ				
-snm	Madi	Lokai	rʷ				
-snm	Madi	Lokai	kʷ				
-snm	Madi	Lokai	ɡʷ				
-snm	Madi	Lokai	ŋɡʷ				
-snm	Madi	Lokai	ʔʷ				
-snm	Madi	Lokai	<sʷ>	rare			
-snm	Madi	Lokai	<zʷ>	rare			
-snm	Madi	Lokai	i				
-snm	Madi	Lokai	ɪ				
-snm	Madi	Lokai	e				
-snm	Madi	Lokai	ɛ				
-snm	Madi	Lokai	a		[a]		
-snm	Madi	Lokai	a		[ʌ]		
-snm	Madi	Lokai	u				
-snm	Madi	Lokai	ʊ				
-snm	Madi	Lokai	o				
-snm	Madi	Lokai	ɔ				
-snm	Madi	Lokai	˦				
-snm	Madi	Lokai	˧				
-snm	Madi	Lokai	˨				
-							
+snm	Madi	Lokai	b
+snm	Madi	Lokai	t
+snm	Madi	Lokai	d
+snm	Madi	Lokai	k
+snm	Madi	Lokai	ɡ
+snm	Madi	Lokai	ʔ
+snm	Madi	Lokai	mb
+snm	Madi	Lokai	nd
+snm	Madi	Lokai	ŋɡ
+snm	Madi	Lokai	ɓ
+snm	Madi	Lokai	ɗ
+snm	Madi	Lokai	ʄ
+snm	Madi	Lokai	m
+snm	Madi	Lokai	n
+snm	Madi	Lokai	ŋ
+snm	Madi	Lokai	ɲ
+snm	Madi	Lokai	f
+snm	Madi	Lokai	s
+snm	Madi	Lokai	<h>	interjections and loanwords
+snm	Madi	Lokai	v
+snm	Madi	Lokai	z
+snm	Madi	Lokai	ɱv
+snm	Madi	Lokai	t̠ʃ
+snm	Madi	Lokai	d̠ʒ
+snm	Madi	Lokai	n̠d̠ʒ	updated from ɲdʒ
+snm	Madi	Lokai	l
+snm	Madi	Lokai	r
+snm	Madi	Lokai	j
+snm	Madi	Lokai	kp
+snm	Madi	Lokai	ɡb
+snm	Madi	Lokai	ŋmɡb
+snm	Madi	Lokai	ɠɓ
+snm	Madi	Lokai	ŋm
+snm	Madi	Lokai	w
+snm	Madi	Lokai	tʷ
+snm	Madi	Lokai	dʷ
+snm	Madi	Lokai	ndʷ
+snm	Madi	Lokai	t̠ʃʷ
+snm	Madi	Lokai	lʷ
+snm	Madi	Lokai	rʷ
+snm	Madi	Lokai	kʷ
+snm	Madi	Lokai	ɡʷ
+snm	Madi	Lokai	ŋɡʷ
+snm	Madi	Lokai	ʔʷ
+snm	Madi	Lokai	<sʷ>	rare
+snm	Madi	Lokai	<zʷ>	rare
+snm	Madi	Lokai	i
+snm	Madi	Lokai	ɪ
+snm	Madi	Lokai	e
+snm	Madi	Lokai	ɛ
+snm	Madi	Lokai	a		[a]
+snm	Madi	Lokai	a		[ʌ]
+snm	Madi	Lokai	u
+snm	Madi	Lokai	ʊ
+snm	Madi	Lokai	o
+snm	Madi	Lokai	ɔ
+snm	Madi	Lokai	˦
+snm	Madi	Lokai	˧
+snm	Madi	Lokai	˨
+
 mgd	Moru		p		[p]		tucker.pdf
-mgd	Moru		p		[f]		
-mgd	Moru		b		[b]		
-mgd	Moru		b		[v]		
-mgd	Moru		b		[bʷ]		
-mgd	Moru		t̪				
-mgd	Moru		d̪				
-mgd	Moru		k		[k]		
-mgd	Moru		k		[kʲ]		
-mgd	Moru		ɡ		[ɡ]		
-mgd	Moru		ɡ		[ɡʲ]		
-mgd	Moru		ʔ				
-mgd	Moru		ɓ				
-mgd	Moru		ɗ				
-mgd	Moru		m				
-mgd	Moru		n				
-mgd	Moru		ŋ				
-mgd	Moru		ɲ				
-mgd	Moru		s				
-mgd	Moru		h				
-mgd	Moru		z		[z]		
-mgd	Moru		z		[zʷ]		
-mgd	Moru		ts		[ts]		
-mgd	Moru		ts		[tsʷ]		
-mgd	Moru		dz		[dz]		
-mgd	Moru		dz		[dzʷ]		
-mgd	Moru		l		[l]		
-mgd	Moru		l		[ɺ]		
-mgd	Moru		r				
-mgd	Moru		j				
-mgd	Moru		ʈr				
-mgd	Moru		ɖr		[ɖr]		
-mgd	Moru		ɖr		[ɖrʷ]		
-mgd	Moru		kp				
-mgd	Moru		ɡb				
-mgd	Moru		w				
-mgd	Moru		i				
-mgd	Moru		ɪ				
-mgd	Moru		e				
-mgd	Moru		ɛ				
-mgd	Moru		a				
-mgd	Moru		u				
-mgd	Moru		ʊ				
-mgd	Moru		o				
-mgd	Moru		ɔ				
-mgd	Moru		˦				
-mgd	Moru		˧				
-mgd	Moru		˨				
-							
+mgd	Moru		p		[f]
+mgd	Moru		b		[b]
+mgd	Moru		b		[v]
+mgd	Moru		b		[bʷ]
+mgd	Moru		t̪
+mgd	Moru		d̪
+mgd	Moru		k		[k]
+mgd	Moru		k		[kʲ]
+mgd	Moru		ɡ		[ɡ]
+mgd	Moru		ɡ		[ɡʲ]
+mgd	Moru		ʔ
+mgd	Moru		ɓ
+mgd	Moru		ɗ
+mgd	Moru		m
+mgd	Moru		n
+mgd	Moru		ŋ
+mgd	Moru		ɲ
+mgd	Moru		s
+mgd	Moru		h
+mgd	Moru		z		[z]
+mgd	Moru		z		[zʷ]
+mgd	Moru		ts		[ts]
+mgd	Moru		ts		[tsʷ]
+mgd	Moru		dz		[dz]
+mgd	Moru		dz		[dzʷ]
+mgd	Moru		l		[l]
+mgd	Moru		l		[ɺ]
+mgd	Moru		r
+mgd	Moru		j
+mgd	Moru		ʈr
+mgd	Moru		ɖr		[ɖr]
+mgd	Moru		ɖr		[ɖrʷ]
+mgd	Moru		kp
+mgd	Moru		ɡb
+mgd	Moru		w
+mgd	Moru		i
+mgd	Moru		ɪ
+mgd	Moru		e
+mgd	Moru		ɛ
+mgd	Moru		a
+mgd	Moru		u
+mgd	Moru		ʊ
+mgd	Moru		o
+mgd	Moru		ɔ
+mgd	Moru		˦
+mgd	Moru		˧
+mgd	Moru		˨
+
 log	Logo		p		[p]		tucker.pdf
-log	Logo		p		[pf]		
-log	Logo		b		[v]		
-log	Logo		b		[bv]		
-log	Logo		b		[bʲ]		
-log	Logo		t̪		[t̪]		
-log	Logo		t̪		[t̪ʷ]		
-log	Logo		d̪		[d̪]		
-log	Logo		d̪		[d̪ʲ]		
-log	Logo		k		[k]		
-log	Logo		k		[kʲ]		
-log	Logo		k		[kʷ]		
-log	Logo		ɡ		[ɡ]		
-log	Logo		ɡ		[ɡʲ]		
-log	Logo		ɡ		[ɡʷ]		
-log	Logo		ʔ		[ʔ]		
-log	Logo		ʔ		[ʔʲ]		
-log	Logo		h				
-log	Logo		ɓ				
-log	Logo		ɗ				
-log	Logo		m				
-log	Logo		n				
-log	Logo		ŋ				
-log	Logo		ɲ				
-log	Logo		s		[s]		
-log	Logo		s		[ʃ]		
-log	Logo		z		[z]		
-log	Logo		z		[ʒ]		
-log	Logo		z		[zʲ]		
-log	Logo		ts		[ts]		
-log	Logo		ts		[t̠ʃ]		
-log	Logo		dz		[dz]		
-log	Logo		dz		[d̠ʒ]		
-log	Logo		dz		[d̠ʒʷ]		
-log	Logo		l		[l]		
-log	Logo		l		[lʲ]		
-log	Logo		l		[lʷ]		
-log	Logo		ɺ				
-log	Logo		r		[r]		
-log	Logo		r		[rʲ]		
-log	Logo		j				
-log	Logo		ʈr				
-log	Logo		ɖr		[ɖr]		
-log	Logo		ɖr		[ɖrʲ]		
-log	Logo		kp				
-log	Logo		ɡb				
-log	Logo		w				
-log	Logo		i				
-log	Logo		ɪ				
-log	Logo		e				
-log	Logo		ɛ				
-log	Logo		a				
-log	Logo		u				
-log	Logo		ʊ				
-log	Logo		o				
-log	Logo		ɔ				
-log	Logo		˦				
-log	Logo		˧				
-log	Logo		˨				
-							
+log	Logo		p		[pf]
+log	Logo		b		[v]
+log	Logo		b		[bv]
+log	Logo		b		[bʲ]
+log	Logo		t̪		[t̪]
+log	Logo		t̪		[t̪ʷ]
+log	Logo		d̪		[d̪]
+log	Logo		d̪		[d̪ʲ]
+log	Logo		k		[k]
+log	Logo		k		[kʲ]
+log	Logo		k		[kʷ]
+log	Logo		ɡ		[ɡ]
+log	Logo		ɡ		[ɡʲ]
+log	Logo		ɡ		[ɡʷ]
+log	Logo		ʔ		[ʔ]
+log	Logo		ʔ		[ʔʲ]
+log	Logo		h
+log	Logo		ɓ
+log	Logo		ɗ
+log	Logo		m
+log	Logo		n
+log	Logo		ŋ
+log	Logo		ɲ
+log	Logo		s		[s]
+log	Logo		s		[ʃ]
+log	Logo		z		[z]
+log	Logo		z		[ʒ]
+log	Logo		z		[zʲ]
+log	Logo		ts		[ts]
+log	Logo		ts		[t̠ʃ]
+log	Logo		dz		[dz]
+log	Logo		dz		[d̠ʒ]
+log	Logo		dz		[d̠ʒʷ]
+log	Logo		l		[l]
+log	Logo		l		[lʲ]
+log	Logo		l		[lʷ]
+log	Logo		ɺ
+log	Logo		r		[r]
+log	Logo		r		[rʲ]
+log	Logo		j
+log	Logo		ʈr
+log	Logo		ɖr		[ɖr]
+log	Logo		ɖr		[ɖrʲ]
+log	Logo		kp
+log	Logo		ɡb
+log	Logo		w
+log	Logo		i
+log	Logo		ɪ
+log	Logo		e
+log	Logo		ɛ
+log	Logo		a
+log	Logo		u
+log	Logo		ʊ
+log	Logo		o
+log	Logo		ɔ
+log	Logo		˦
+log	Logo		˧
+log	Logo		˨
+
 aft	Afitti		b		[b]		aft_voogt.pdf
-aft	Afitti		b		[p]		
-aft	Afitti		d		[d]		
-aft	Afitti		d		[t]		
-aft	Afitti		ɟ		[ɟ]		
-aft	Afitti		ɟ		[c]		
-aft	Afitti		c				
-aft	Afitti		ɡ		[ɡ]		
-aft	Afitti		ɡ		[k]		
-aft	Afitti		t				
-aft	Afitti		c				
-aft	Afitti		k				
-aft	Afitti		f				
-aft	Afitti		s		[s]		
-aft	Afitti		s		[ʃ]		
-aft	Afitti		m				
-aft	Afitti		n				
-aft	Afitti		ɲ				
-aft	Afitti		ŋ				
-aft	Afitti		r		[r]		
-aft	Afitti		r		[r̥]		
-aft	Afitti		r		[ɽ]		
-aft	Afitti		l		[l]		
-aft	Afitti		l		[l̥]		
-aft	Afitti		w				
-aft	Afitti		j				
-aft	Afitti		i		[i]		
-aft	Afitti		i		[ɪ]		
-aft	Afitti		i		[ɨ]		
-aft	Afitti		e		[e]		
-aft	Afitti		e		[ɛ]		
-aft	Afitti		ə				
-aft	Afitti		ɑ		[a]		
-aft	Afitti		ɑ		[ɑ]		
-aft	Afitti		u		[u]		
-aft	Afitti		u		[ʊ]		
-aft	Afitti		o		[o]		
-aft	Afitti		o		[ɔ]		
-aft	Afitti		˦				
-aft	Afitti		˧				
-aft	Afitti		˨				
-							
+aft	Afitti		b		[p]
+aft	Afitti		d		[d]
+aft	Afitti		d		[t]
+aft	Afitti		ɟ		[ɟ]
+aft	Afitti		ɟ		[c]
+aft	Afitti		c
+aft	Afitti		ɡ		[ɡ]
+aft	Afitti		ɡ		[k]
+aft	Afitti		t
+aft	Afitti		c
+aft	Afitti		k
+aft	Afitti		f
+aft	Afitti		s		[s]
+aft	Afitti		s		[ʃ]
+aft	Afitti		m
+aft	Afitti		n
+aft	Afitti		ɲ
+aft	Afitti		ŋ
+aft	Afitti		r		[r]
+aft	Afitti		r		[r̥]
+aft	Afitti		r		[ɽ]
+aft	Afitti		l		[l]
+aft	Afitti		l		[l̥]
+aft	Afitti		w
+aft	Afitti		j
+aft	Afitti		i		[i]
+aft	Afitti		i		[ɪ]
+aft	Afitti		i		[ɨ]
+aft	Afitti		e		[e]
+aft	Afitti		e		[ɛ]
+aft	Afitti		ə
+aft	Afitti		ɑ		[a]
+aft	Afitti		ɑ		[ɑ]
+aft	Afitti		u		[u]
+aft	Afitti		u		[ʊ]
+aft	Afitti		o		[o]
+aft	Afitti		o		[ɔ]
+aft	Afitti		˦
+aft	Afitti		˧
+aft	Afitti		˨
+
 avn	Avatime		p				avatime_schuh.pdf
-avn	Avatime		b				
-avn	Avatime		t				
-avn	Avatime		d				
-avn	Avatime		k				
-avn	Avatime		ɡ				
-avn	Avatime		kp				
-avn	Avatime		ɡb				
-avn	Avatime		<ɸ>	loanwords only			
-avn	Avatime		β				
-avn	Avatime		f				
-avn	Avatime		v				
-avn	Avatime		s				
-avn	Avatime		z				
-avn	Avatime		h				
-avn	Avatime		ɦ				
-avn	Avatime		hʷ				
-avn	Avatime		ɦʷ				
-avn	Avatime		ts				
-avn	Avatime		dz				
-avn	Avatime		m				
-avn	Avatime		n				
-avn	Avatime		ɲ				
-avn	Avatime		ŋ				
-avn	Avatime		ŋʷ				
-avn	Avatime		l		[l]		
-avn	Avatime		l		[r]		
-avn	Avatime		w				
-avn	Avatime		j				
-avn	Avatime		i				
-avn	Avatime		ɪ				
-avn	Avatime		e				
-avn	Avatime		ɛ				
-avn	Avatime		a				
-avn	Avatime		u				
-avn	Avatime		ʊ				
-avn	Avatime		o				
-avn	Avatime		ɔ				
-avn	Avatime		ĩ				
-avn	Avatime		ɪ̃				
-avn	Avatime		ẽ				
-avn	Avatime		ɛ̃				
-avn	Avatime		ã				
-avn	Avatime		ũ				
-avn	Avatime		ʊ̃				
-avn	Avatime		õ				
-avn	Avatime		ɔ̃				
-avn	Avatime		˦				
-avn	Avatime		˧	M tone 1			
-avn	Avatime		˨	M tone 2			
-avn	Avatime		˥	H tone			
-							
+avn	Avatime		b
+avn	Avatime		t
+avn	Avatime		d
+avn	Avatime		k
+avn	Avatime		ɡ
+avn	Avatime		kp
+avn	Avatime		ɡb
+avn	Avatime		<ɸ>	loanwords only
+avn	Avatime		β
+avn	Avatime		f
+avn	Avatime		v
+avn	Avatime		s
+avn	Avatime		z
+avn	Avatime		h
+avn	Avatime		ɦ
+avn	Avatime		hʷ
+avn	Avatime		ɦʷ
+avn	Avatime		ts
+avn	Avatime		dz
+avn	Avatime		m
+avn	Avatime		n
+avn	Avatime		ɲ
+avn	Avatime		ŋ
+avn	Avatime		ŋʷ
+avn	Avatime		l		[l]
+avn	Avatime		l		[r]
+avn	Avatime		w
+avn	Avatime		j
+avn	Avatime		i
+avn	Avatime		ɪ
+avn	Avatime		e
+avn	Avatime		ɛ
+avn	Avatime		a
+avn	Avatime		u
+avn	Avatime		ʊ
+avn	Avatime		o
+avn	Avatime		ɔ
+avn	Avatime		ĩ
+avn	Avatime		ɪ̃
+avn	Avatime		ẽ
+avn	Avatime		ɛ̃
+avn	Avatime		ã
+avn	Avatime		ũ
+avn	Avatime		ʊ̃
+avn	Avatime		õ
+avn	Avatime		ɔ̃
+avn	Avatime		˦
+avn	Avatime		˧	M tone 1
+avn	Avatime		˨	M tone 2
+avn	Avatime		˥	H tone
+
 abn	Abua		p				abn.pdf
-abn	Abua		b				
-abn	Abua		ɓ				
-abn	Abua		β		[β]		
-abn	Abua		β		[pʰ]		
-abn	Abua		f				
-abn	Abua		v				
-abn	Abua		t				
-abn	Abua		d				
-abn	Abua		ɗ				
-abn	Abua		s		[s]		
-abn	Abua		s		[tɕ]		
-abn	Abua		z		[z]		
-abn	Abua		z		[d̠ʒ]		
-abn	Abua		z		[ʒ]		
-abn	Abua		h				
-abn	Abua		k				
-abn	Abua		ɡ				
-abn	Abua		ɣ		[ɣ]		
-abn	Abua		ɣ		[kʰ]		
-abn	Abua		kp				
-abn	Abua		ɡb				
-abn	Abua		l				
-abn	Abua		ɺ				
-abn	Abua		r		[r]		
-abn	Abua		r		[ʁ]		
-abn	Abua		m				
-abn	Abua		n				
-abn	Abua		ɲ				
-abn	Abua		ŋ				
-abn	Abua		ŋm				
-abn	Abua		w				
-abn	Abua		j				
-abn	Abua		i				
-abn	Abua		ɨ				
-abn	Abua		e				
-abn	Abua		ə				
-abn	Abua		ɛ				
-abn	Abua		a				
-abn	Abua		o				
-abn	Abua		u				
-abn	Abua		ɔ				
-abn	Abua		ʊ				
-abn	Abua		˦				
-abn	Abua		˨				
-abn	Abua		↓˦				
-							
+abn	Abua		b
+abn	Abua		ɓ
+abn	Abua		β		[β]
+abn	Abua		β		[pʰ]
+abn	Abua		f
+abn	Abua		v
+abn	Abua		t
+abn	Abua		d
+abn	Abua		ɗ
+abn	Abua		s		[s]
+abn	Abua		s		[tɕ]
+abn	Abua		z		[z]
+abn	Abua		z		[d̠ʒ]
+abn	Abua		z		[ʒ]
+abn	Abua		h
+abn	Abua		k
+abn	Abua		ɡ
+abn	Abua		ɣ		[ɣ]
+abn	Abua		ɣ		[kʰ]
+abn	Abua		kp
+abn	Abua		ɡb
+abn	Abua		l
+abn	Abua		ɺ
+abn	Abua		r		[r]
+abn	Abua		r		[ʁ]
+abn	Abua		m
+abn	Abua		n
+abn	Abua		ɲ
+abn	Abua		ŋ
+abn	Abua		ŋm
+abn	Abua		w
+abn	Abua		j
+abn	Abua		i
+abn	Abua		ɨ
+abn	Abua		e
+abn	Abua		ə
+abn	Abua		ɛ
+abn	Abua		a
+abn	Abua		o
+abn	Abua		u
+abn	Abua		ɔ
+abn	Abua		ʊ
+abn	Abua		˦
+abn	Abua		˨
+abn	Abua		↓˦
+
 any	Anyi		p		[p]		any.pdf
-any	Anyi		p		[pᶣ]		
-any	Anyi		b				
-any	Anyi		m				
-any	Anyi		w				
-any	Anyi		f		[f]		
-any	Anyi		f		[v]		
-any	Anyi		t				
-any	Anyi		d		[d]		
-any	Anyi		d		[l]		
-any	Anyi		s		[s]		
-any	Anyi		s		[z]		
-any	Anyi		n				
-any	Anyi		t̠ʃ		[t̠ʃ]		
-any	Anyi		t̠ʃ		[tɕᶣ]		
-any	Anyi		d̠ʒ		[d̠ʒ]		
-any	Anyi		d̠ʒ		[dʑᶣ]		
-any	Anyi		<ʃ>	rare	[ʃ]		
-any	Anyi		<ʃ>	rare	[ɕᶣ]		
-any	Anyi		ɲ		[ɲ]		
-any	Anyi		ɲ		[ɲᶣ]		
-any	Anyi		j				
-any	Anyi		k		[k]		
-any	Anyi		k		[ɡ]		
-any	Anyi		ŋ				
-any	Anyi		kp				
-any	Anyi		ɡb				
-any	Anyi		<ɡʷ>	rare			
-any	Anyi		h				
-any	Anyi		ʔ				
-any	Anyi		i				
-any	Anyi		ɪ				
-any	Anyi		e				
-any	Anyi		ɛ				
-any	Anyi		a				
-any	Anyi		o				
-any	Anyi		ɔ				
-any	Anyi		u				
-any	Anyi		ʊ				
-any	Anyi		ĩ				
-any	Anyi		ɪ̃				
-any	Anyi		ũ				
-any	Anyi		ʊ̃				
-any	Anyi		ã				
-any	Anyi		˦				
-any	Anyi		˨				
-any	Anyi		˦˨				
-any	Anyi		˨˦				
-							
+any	Anyi		p		[pᶣ]
+any	Anyi		b
+any	Anyi		m
+any	Anyi		w
+any	Anyi		f		[f]
+any	Anyi		f		[v]
+any	Anyi		t
+any	Anyi		d		[d]
+any	Anyi		d		[l]
+any	Anyi		s		[s]
+any	Anyi		s		[z]
+any	Anyi		n
+any	Anyi		t̠ʃ		[t̠ʃ]
+any	Anyi		t̠ʃ		[tɕᶣ]
+any	Anyi		d̠ʒ		[d̠ʒ]
+any	Anyi		d̠ʒ		[dʑᶣ]
+any	Anyi		<ʃ>	rare	[ʃ]
+any	Anyi		<ʃ>	rare	[ɕᶣ]
+any	Anyi		ɲ		[ɲ]
+any	Anyi		ɲ		[ɲᶣ]
+any	Anyi		j
+any	Anyi		k		[k]
+any	Anyi		k		[ɡ]
+any	Anyi		ŋ
+any	Anyi		kp
+any	Anyi		ɡb
+any	Anyi		<ɡʷ>	rare
+any	Anyi		h
+any	Anyi		ʔ
+any	Anyi		i
+any	Anyi		ɪ
+any	Anyi		e
+any	Anyi		ɛ
+any	Anyi		a
+any	Anyi		o
+any	Anyi		ɔ
+any	Anyi		u
+any	Anyi		ʊ
+any	Anyi		ĩ
+any	Anyi		ɪ̃
+any	Anyi		ũ
+any	Anyi		ʊ̃
+any	Anyi		ã
+any	Anyi		˦
+any	Anyi		˨
+any	Anyi		˦˨
+any	Anyi		˨˦
+
 dgh	Dghwede		p				dgh.pdf
-dgh	Dghwede		b				
-dgh	Dghwede		ɓ				
-dgh	Dghwede		mb				
-dgh	Dghwede		t				
-dgh	Dghwede		d				
-dgh	Dghwede		ɗ				
-dgh	Dghwede		nd				
-dgh	Dghwede		k				
-dgh	Dghwede		ɡ				
-dgh	Dghwede		ŋɡ				
-dgh	Dghwede		kʷ				
-dgh	Dghwede		ɡʷ				
-dgh	Dghwede		ŋɡʷ				
-dgh	Dghwede		c		[c]		
-dgh	Dghwede		c		[t̠ʃ]		
-dgh	Dghwede		ɟ		[ɟ]		
-dgh	Dghwede		ɟ		[d̠ʒ]		
-dgh	Dghwede		ɲɟ		[ɲɟ]		
-dgh	Dghwede		ɲɟ		[n̠d̠ʒ]		
-dgh	Dghwede		f				
-dgh	Dghwede		s		[s]		
-dgh	Dghwede		s		[ʃ]		
-dgh	Dghwede		x				
-dgh	Dghwede		xʷ				
-dgh	Dghwede		v				
-dgh	Dghwede		z		[z]		
-dgh	Dghwede		z		[ʒ]		
-dgh	Dghwede		ɣ				
-dgh	Dghwede		ɣʷ				
-dgh	Dghwede		m				
-dgh	Dghwede		n				
-dgh	Dghwede		l				
-dgh	Dghwede		ɬ				
-dgh	Dghwede		ɮ				
-dgh	Dghwede		r				
-dgh	Dghwede		w				
-dgh	Dghwede		j				
-dgh	Dghwede		i		[i]		
-dgh	Dghwede		i		[e]		
-dgh	Dghwede		i		[ɛ]		
-dgh	Dghwede		a		[a]		
-dgh	Dghwede		a		[ɛ]		
-dgh	Dghwede		a		[ɔ]		
-dgh	Dghwede		u		[u]		
-dgh	Dghwede		u		[o]		
-dgh	Dghwede		˦		[˦]		
-dgh	Dghwede		˦		[˦˨]		
-dgh	Dghwede		˨				
-							
+dgh	Dghwede		b
+dgh	Dghwede		ɓ
+dgh	Dghwede		mb
+dgh	Dghwede		t
+dgh	Dghwede		d
+dgh	Dghwede		ɗ
+dgh	Dghwede		nd
+dgh	Dghwede		k
+dgh	Dghwede		ɡ
+dgh	Dghwede		ŋɡ
+dgh	Dghwede		kʷ
+dgh	Dghwede		ɡʷ
+dgh	Dghwede		ŋɡʷ
+dgh	Dghwede		c		[c]
+dgh	Dghwede		c		[t̠ʃ]
+dgh	Dghwede		ɟ		[ɟ]
+dgh	Dghwede		ɟ		[d̠ʒ]
+dgh	Dghwede		ɲɟ		[ɲɟ]
+dgh	Dghwede		ɲɟ		[n̠d̠ʒ]
+dgh	Dghwede		f
+dgh	Dghwede		s		[s]
+dgh	Dghwede		s		[ʃ]
+dgh	Dghwede		x
+dgh	Dghwede		xʷ
+dgh	Dghwede		v
+dgh	Dghwede		z		[z]
+dgh	Dghwede		z		[ʒ]
+dgh	Dghwede		ɣ
+dgh	Dghwede		ɣʷ
+dgh	Dghwede		m
+dgh	Dghwede		n
+dgh	Dghwede		l
+dgh	Dghwede		ɬ
+dgh	Dghwede		ɮ
+dgh	Dghwede		r
+dgh	Dghwede		w
+dgh	Dghwede		j
+dgh	Dghwede		i		[i]
+dgh	Dghwede		i		[e]
+dgh	Dghwede		i		[ɛ]
+dgh	Dghwede		a		[a]
+dgh	Dghwede		a		[ɛ]
+dgh	Dghwede		a		[ɔ]
+dgh	Dghwede		u		[u]
+dgh	Dghwede		u		[o]
+dgh	Dghwede		˦		[˦]
+dgh	Dghwede		˦		[˦˨]
+dgh	Dghwede		˨
+
 afo	Eloyi		p		[p]		afo.pdf
-afo	Eloyi		p		[ɸ]		
-afo	Eloyi		p		[pʷ]		
-afo	Eloyi		pʷ				
-afo	Eloyi		pʲ				
-afo	Eloyi		t				
-afo	Eloyi		k		[k]		
-afo	Eloyi		k		[kʷ]		
-afo	Eloyi		kp				
-afo	Eloyi		kʷ				
-afo	Eloyi		b		[b]		
-afo	Eloyi		b		[β]		
-afo	Eloyi		b		[bʷ]		
-afo	Eloyi		bʷ				
-afo	Eloyi		bʲ				
-afo	Eloyi		d				
-afo	Eloyi		ɡ		[ɡ]		
-afo	Eloyi		ɡ		[ɡʷ]		
-afo	Eloyi		ɡʷ				
-afo	Eloyi		ɡb				
-afo	Eloyi		f				
-afo	Eloyi		fʲ				
-afo	Eloyi		s				
-afo	Eloyi		ʃ				
-afo	Eloyi		v				
-afo	Eloyi		vʲ				
-afo	Eloyi		z				
-afo	Eloyi		tɕ				
-afo	Eloyi		d̠ʒ		[d̠ʒ]	free variation	
-afo	Eloyi		d̠ʒ		[ʒ]	free variation	
-afo	Eloyi		mʷ				
-afo	Eloyi		m		[m]		
-afo	Eloyi		m		[mʷ]		
-afo	Eloyi		mʲ				
-afo	Eloyi		n				
-afo	Eloyi		ɲ				
-afo	Eloyi		ŋ		[ŋ]		
-afo	Eloyi		ŋ		[ŋʷ]		
-afo	Eloyi		ŋʷ				
-afo	Eloyi		mb				
-afo	Eloyi		mbʷ				
-afo	Eloyi		nd				
-afo	Eloyi		ŋɡ				
-afo	Eloyi		ŋɡʷ				
-afo	Eloyi		ŋmɡb				
-afo	Eloyi		nz				
-afo	Eloyi		n̠d̠ʒ	updated from ɲdʒ			
-afo	Eloyi		w				
-afo	Eloyi		j				
-afo	Eloyi		r				
-afo	Eloyi		i				
-afo	Eloyi		e				
-afo	Eloyi		ɛ				
-afo	Eloyi		a				
-afo	Eloyi		u				
-afo	Eloyi		o				
-afo	Eloyi		ɔ				
-afo	Eloyi		˦				
-afo	Eloyi		˧				
-afo	Eloyi		˨				
-							
+afo	Eloyi		p		[ɸ]
+afo	Eloyi		p		[pʷ]
+afo	Eloyi		pʷ
+afo	Eloyi		pʲ
+afo	Eloyi		t
+afo	Eloyi		k		[k]
+afo	Eloyi		k		[kʷ]
+afo	Eloyi		kp
+afo	Eloyi		kʷ
+afo	Eloyi		b		[b]
+afo	Eloyi		b		[β]
+afo	Eloyi		b		[bʷ]
+afo	Eloyi		bʷ
+afo	Eloyi		bʲ
+afo	Eloyi		d
+afo	Eloyi		ɡ		[ɡ]
+afo	Eloyi		ɡ		[ɡʷ]
+afo	Eloyi		ɡʷ
+afo	Eloyi		ɡb
+afo	Eloyi		f
+afo	Eloyi		fʲ
+afo	Eloyi		s
+afo	Eloyi		ʃ
+afo	Eloyi		v
+afo	Eloyi		vʲ
+afo	Eloyi		z
+afo	Eloyi		tɕ
+afo	Eloyi		d̠ʒ		[d̠ʒ]	free variation
+afo	Eloyi		d̠ʒ		[ʒ]	free variation
+afo	Eloyi		mʷ
+afo	Eloyi		m		[m]
+afo	Eloyi		m		[mʷ]
+afo	Eloyi		mʲ
+afo	Eloyi		n
+afo	Eloyi		ɲ
+afo	Eloyi		ŋ		[ŋ]
+afo	Eloyi		ŋ		[ŋʷ]
+afo	Eloyi		ŋʷ
+afo	Eloyi		mb
+afo	Eloyi		mbʷ
+afo	Eloyi		nd
+afo	Eloyi		ŋɡ
+afo	Eloyi		ŋɡʷ
+afo	Eloyi		ŋmɡb
+afo	Eloyi		nz
+afo	Eloyi		n̠d̠ʒ	updated from ɲdʒ
+afo	Eloyi		w
+afo	Eloyi		j
+afo	Eloyi		r
+afo	Eloyi		i
+afo	Eloyi		e
+afo	Eloyi		ɛ
+afo	Eloyi		a
+afo	Eloyi		u
+afo	Eloyi		o
+afo	Eloyi		ɔ
+afo	Eloyi		˦
+afo	Eloyi		˧
+afo	Eloyi		˨
+
 fuv	Fula (Nigeria)	Nigeria	p				fuv.pdf
-fuv	Fula (Nigeria)	Nigeria	b				
-fuv	Fula (Nigeria)	Nigeria	t				
-fuv	Fula (Nigeria)	Nigeria	d				
-fuv	Fula (Nigeria)	Nigeria	k				
-fuv	Fula (Nigeria)	Nigeria	ɡ				
-fuv	Fula (Nigeria)	Nigeria	ʔ				
-fuv	Fula (Nigeria)	Nigeria	ɓ				
-fuv	Fula (Nigeria)	Nigeria	ɗ				
-fuv	Fula (Nigeria)	Nigeria	mb				
-fuv	Fula (Nigeria)	Nigeria	nd				
-fuv	Fula (Nigeria)	Nigeria	ŋɡ				
-fuv	Fula (Nigeria)	Nigeria	f				
-fuv	Fula (Nigeria)	Nigeria	s				
-fuv	Fula (Nigeria)	Nigeria	ʃ				
-fuv	Fula (Nigeria)	Nigeria	h				
-fuv	Fula (Nigeria)	Nigeria	t̠ʃ				
-fuv	Fula (Nigeria)	Nigeria	d̠ʒ				
-fuv	Fula (Nigeria)	Nigeria	n̠d̠ʒ	updated from ɲdʒ			
-fuv	Fula (Nigeria)	Nigeria	m				
-fuv	Fula (Nigeria)	Nigeria	n				
-fuv	Fula (Nigeria)	Nigeria	ŋ				
-fuv	Fula (Nigeria)	Nigeria	ɲ				
-fuv	Fula (Nigeria)	Nigeria	r				
-fuv	Fula (Nigeria)	Nigeria	l				
-fuv	Fula (Nigeria)	Nigeria	h				
-fuv	Fula (Nigeria)	Nigeria	w				
-fuv	Fula (Nigeria)	Nigeria	j				
-fuv	Fula (Nigeria)	Nigeria	jˀ	updated from ʔʲ			
-fuv	Fula (Nigeria)	Nigeria	a				
-fuv	Fula (Nigeria)	Nigeria	e				
-fuv	Fula (Nigeria)	Nigeria	i				
-fuv	Fula (Nigeria)	Nigeria	o				
-fuv	Fula (Nigeria)	Nigeria	u				
-fuv	Fula (Nigeria)	Nigeria	aː				
-fuv	Fula (Nigeria)	Nigeria	eː				
-fuv	Fula (Nigeria)	Nigeria	iː				
-fuv	Fula (Nigeria)	Nigeria	oː				
-fuv	Fula (Nigeria)	Nigeria	uː				
-							
+fuv	Fula (Nigeria)	Nigeria	b
+fuv	Fula (Nigeria)	Nigeria	t
+fuv	Fula (Nigeria)	Nigeria	d
+fuv	Fula (Nigeria)	Nigeria	k
+fuv	Fula (Nigeria)	Nigeria	ɡ
+fuv	Fula (Nigeria)	Nigeria	ʔ
+fuv	Fula (Nigeria)	Nigeria	ɓ
+fuv	Fula (Nigeria)	Nigeria	ɗ
+fuv	Fula (Nigeria)	Nigeria	mb
+fuv	Fula (Nigeria)	Nigeria	nd
+fuv	Fula (Nigeria)	Nigeria	ŋɡ
+fuv	Fula (Nigeria)	Nigeria	f
+fuv	Fula (Nigeria)	Nigeria	s
+fuv	Fula (Nigeria)	Nigeria	ʃ
+fuv	Fula (Nigeria)	Nigeria	h
+fuv	Fula (Nigeria)	Nigeria	t̠ʃ
+fuv	Fula (Nigeria)	Nigeria	d̠ʒ
+fuv	Fula (Nigeria)	Nigeria	n̠d̠ʒ	updated from ɲdʒ
+fuv	Fula (Nigeria)	Nigeria	m
+fuv	Fula (Nigeria)	Nigeria	n
+fuv	Fula (Nigeria)	Nigeria	ŋ
+fuv	Fula (Nigeria)	Nigeria	ɲ
+fuv	Fula (Nigeria)	Nigeria	r
+fuv	Fula (Nigeria)	Nigeria	l
+fuv	Fula (Nigeria)	Nigeria	h
+fuv	Fula (Nigeria)	Nigeria	w
+fuv	Fula (Nigeria)	Nigeria	j
+fuv	Fula (Nigeria)	Nigeria	jˀ	updated from ʔʲ
+fuv	Fula (Nigeria)	Nigeria	a
+fuv	Fula (Nigeria)	Nigeria	e
+fuv	Fula (Nigeria)	Nigeria	i
+fuv	Fula (Nigeria)	Nigeria	o
+fuv	Fula (Nigeria)	Nigeria	u
+fuv	Fula (Nigeria)	Nigeria	aː
+fuv	Fula (Nigeria)	Nigeria	eː
+fuv	Fula (Nigeria)	Nigeria	iː
+fuv	Fula (Nigeria)	Nigeria	oː
+fuv	Fula (Nigeria)	Nigeria	uː
+
 acd	Gechode		b				acd.pdf
-acd	Gechode		d				
-acd	Gechode		ɡ				
-acd	Gechode		ɡb				
-acd	Gechode		l				
-acd	Gechode		p				
-acd	Gechode		t				
-acd	Gechode		k				
-acd	Gechode		kp				
-acd	Gechode		ɟ				
-acd	Gechode		c				
-acd	Gechode		f				
-acd	Gechode		s				
-acd	Gechode		h				
-acd	Gechode		w				
-acd	Gechode		j				
-acd	Gechode		m				
-acd	Gechode		n				
-acd	Gechode		ɲ				
-acd	Gechode		ŋ				
-acd	Gechode		ŋm				
-acd	Gechode		bʷ				
-acd	Gechode		pʷ				
-acd	Gechode		kʷ				
-acd	Gechode		sʷ				
-acd	Gechode		fʷ				
-acd	Gechode		hʷ				
-acd	Gechode		r				
-acd	Gechode		sᶣ				
-acd	Gechode		i				
-acd	Gechode		ɪ				
-acd	Gechode		e				
-acd	Gechode		ɛ				
-acd	Gechode		o				
-acd	Gechode		u				
-acd	Gechode		ɔ				
-acd	Gechode		ʊ				
-acd	Gechode		a				
-acd	Gechode		ĩ				
-acd	Gechode		ɪ̃				
-acd	Gechode		ẽ				
-acd	Gechode		ɛ̃				
-acd	Gechode		õ				
-acd	Gechode		ũ				
-acd	Gechode		ɔ̃				
-acd	Gechode		ʊ̃				
-acd	Gechode		ã				
-acd	Gechode		ʌ				
-acd	Gechode		ə				
-acd	Gechode		ʌ̃				
-acd	Gechode		ə̃				
-							
+acd	Gechode		d
+acd	Gechode		ɡ
+acd	Gechode		ɡb
+acd	Gechode		l
+acd	Gechode		p
+acd	Gechode		t
+acd	Gechode		k
+acd	Gechode		kp
+acd	Gechode		ɟ
+acd	Gechode		c
+acd	Gechode		f
+acd	Gechode		s
+acd	Gechode		h
+acd	Gechode		w
+acd	Gechode		j
+acd	Gechode		m
+acd	Gechode		n
+acd	Gechode		ɲ
+acd	Gechode		ŋ
+acd	Gechode		ŋm
+acd	Gechode		bʷ
+acd	Gechode		pʷ
+acd	Gechode		kʷ
+acd	Gechode		sʷ
+acd	Gechode		fʷ
+acd	Gechode		hʷ
+acd	Gechode		r
+acd	Gechode		sᶣ
+acd	Gechode		i
+acd	Gechode		ɪ
+acd	Gechode		e
+acd	Gechode		ɛ
+acd	Gechode		o
+acd	Gechode		u
+acd	Gechode		ɔ
+acd	Gechode		ʊ
+acd	Gechode		a
+acd	Gechode		ĩ
+acd	Gechode		ɪ̃
+acd	Gechode		ẽ
+acd	Gechode		ɛ̃
+acd	Gechode		õ
+acd	Gechode		ũ
+acd	Gechode		ɔ̃
+acd	Gechode		ʊ̃
+acd	Gechode		ã
+acd	Gechode		ʌ
+acd	Gechode		ə
+acd	Gechode		ʌ̃
+acd	Gechode		ə̃
+
 ayg	Genyanga		b				ayg.pdf
-ayg	Genyanga		d				
-ayg	Genyanga		ɡ				
-ayg	Genyanga		ɡb				
-ayg	Genyanga		l				
-ayg	Genyanga		d̠ʒ				
-ayg	Genyanga		t̠ʃ				
-ayg	Genyanga		p				
-ayg	Genyanga		t				
-ayg	Genyanga		k				
-ayg	Genyanga		kp				
-ayg	Genyanga		f				
-ayg	Genyanga		s				
-ayg	Genyanga		h				
-ayg	Genyanga		w				
-ayg	Genyanga		j				
-ayg	Genyanga		m				
-ayg	Genyanga		n				
-ayg	Genyanga		ɲ				
-ayg	Genyanga		ŋ				
-ayg	Genyanga		ŋm				
-ayg	Genyanga		bʷ				
-ayg	Genyanga		pʷ				
-ayg	Genyanga		tʷ				
-ayg	Genyanga		kʷ				
-ayg	Genyanga		fʷ				
-ayg	Genyanga		sʷ				
-ayg	Genyanga		lʷ				
-ayg	Genyanga		sʲʷ				
-ayg	Genyanga		wʲ				
-ayg	Genyanga		r				
-ayg	Genyanga		i				
-ayg	Genyanga		ɪ				
-ayg	Genyanga		e				
-ayg	Genyanga		ɛ				
-ayg	Genyanga		o				
-ayg	Genyanga		u				
-ayg	Genyanga		ɔ				
-ayg	Genyanga		ʊ				
-ayg	Genyanga		a				
-ayg	Genyanga		ʌ				
-ayg	Genyanga		ə				
-ayg	Genyanga		ʌ̃				
-ayg	Genyanga		ə̃				
-ayg	Genyanga		ĩ				
-ayg	Genyanga		ɪ̃				
-ayg	Genyanga		ẽ				
-ayg	Genyanga		ɛ̃				
-ayg	Genyanga		õ				
-ayg	Genyanga		ũ				
-ayg	Genyanga		ɔ̃				
-ayg	Genyanga		ʊ̃				
-ayg	Genyanga		ã				
-							
+ayg	Genyanga		d
+ayg	Genyanga		ɡ
+ayg	Genyanga		ɡb
+ayg	Genyanga		l
+ayg	Genyanga		d̠ʒ
+ayg	Genyanga		t̠ʃ
+ayg	Genyanga		p
+ayg	Genyanga		t
+ayg	Genyanga		k
+ayg	Genyanga		kp
+ayg	Genyanga		f
+ayg	Genyanga		s
+ayg	Genyanga		h
+ayg	Genyanga		w
+ayg	Genyanga		j
+ayg	Genyanga		m
+ayg	Genyanga		n
+ayg	Genyanga		ɲ
+ayg	Genyanga		ŋ
+ayg	Genyanga		ŋm
+ayg	Genyanga		bʷ
+ayg	Genyanga		pʷ
+ayg	Genyanga		tʷ
+ayg	Genyanga		kʷ
+ayg	Genyanga		fʷ
+ayg	Genyanga		sʷ
+ayg	Genyanga		lʷ
+ayg	Genyanga		sʲʷ
+ayg	Genyanga		wʲ
+ayg	Genyanga		r
+ayg	Genyanga		i
+ayg	Genyanga		ɪ
+ayg	Genyanga		e
+ayg	Genyanga		ɛ
+ayg	Genyanga		o
+ayg	Genyanga		u
+ayg	Genyanga		ɔ
+ayg	Genyanga		ʊ
+ayg	Genyanga		a
+ayg	Genyanga		ʌ
+ayg	Genyanga		ə
+ayg	Genyanga		ʌ̃
+ayg	Genyanga		ə̃
+ayg	Genyanga		ĩ
+ayg	Genyanga		ɪ̃
+ayg	Genyanga		ẽ
+ayg	Genyanga		ɛ̃
+ayg	Genyanga		õ
+ayg	Genyanga		ũ
+ayg	Genyanga		ɔ̃
+ayg	Genyanga		ʊ̃
+ayg	Genyanga		ã
+
 hbb	Kilba		p				hbb.pdf
-hbb	Kilba		b				
-hbb	Kilba		ɓ				
-hbb	Kilba		t̪		[t̪]		
-hbb	Kilba		t̪		[t]		
-hbb	Kilba		d̪		[d̪]		
-hbb	Kilba		d̪		[d]		
-hbb	Kilba		d̪		[dʷ]		
-hbb	Kilba		ɗ				
-hbb	Kilba		k		[k]		
-hbb	Kilba		k		[c]		
-hbb	Kilba		k		[kʷ]		
-hbb	Kilba		ɡ		[ɡ]		
-hbb	Kilba		ɡ		[ɟ]		
-hbb	Kilba		ts		[ts]		
-hbb	Kilba		ts		[t̠ʃ]		
-hbb	Kilba		ts		[tsʷ]		
-hbb	Kilba		dz		[dz]		
-hbb	Kilba		dz		[d̠ʒ]		
-hbb	Kilba		m				
-hbb	Kilba		n		[n]		
-hbb	Kilba		n		[ɲ]		
-hbb	Kilba		f				
-hbb	Kilba		x		[x]		
-hbb	Kilba		x		[ç]		
-hbb	Kilba		x		[xʷ]		
-hbb	Kilba		v				
-hbb	Kilba		ɣ		[ɣ]		
-hbb	Kilba		ɣ		[j]		
-hbb	Kilba		s		[s]		
-hbb	Kilba		s		[ʃ]		
-hbb	Kilba		z		[z]		
-hbb	Kilba		z		[ʒ]		
-hbb	Kilba		ɬ̪		[ɬ̪]		
-hbb	Kilba		ɬ̪		[ɬ]		
-hbb	Kilba		ɮ̪		[ɮ̪]		
-hbb	Kilba		ɮ̪		[ɮ]		
-hbb	Kilba		l		[l]		
-hbb	Kilba		l		[ʎ]		
-hbb	Kilba		r				
-hbb	Kilba		j				
-hbb	Kilba		w				
-hbb	Kilba		i				
-hbb	Kilba		a				
-hbb	Kilba		ɯ				
-hbb	Kilba		ə				
-hbb	Kilba		ɨ				
-hbb	Kilba		˦				
-hbb	Kilba		˨				
-							
+hbb	Kilba		b
+hbb	Kilba		ɓ
+hbb	Kilba		t̪		[t̪]
+hbb	Kilba		t̪		[t]
+hbb	Kilba		d̪		[d̪]
+hbb	Kilba		d̪		[d]
+hbb	Kilba		d̪		[dʷ]
+hbb	Kilba		ɗ
+hbb	Kilba		k		[k]
+hbb	Kilba		k		[c]
+hbb	Kilba		k		[kʷ]
+hbb	Kilba		ɡ		[ɡ]
+hbb	Kilba		ɡ		[ɟ]
+hbb	Kilba		ts		[ts]
+hbb	Kilba		ts		[t̠ʃ]
+hbb	Kilba		ts		[tsʷ]
+hbb	Kilba		dz		[dz]
+hbb	Kilba		dz		[d̠ʒ]
+hbb	Kilba		m
+hbb	Kilba		n		[n]
+hbb	Kilba		n		[ɲ]
+hbb	Kilba		f
+hbb	Kilba		x		[x]
+hbb	Kilba		x		[ç]
+hbb	Kilba		x		[xʷ]
+hbb	Kilba		v
+hbb	Kilba		ɣ		[ɣ]
+hbb	Kilba		ɣ		[j]
+hbb	Kilba		s		[s]
+hbb	Kilba		s		[ʃ]
+hbb	Kilba		z		[z]
+hbb	Kilba		z		[ʒ]
+hbb	Kilba		ɬ̪		[ɬ̪]
+hbb	Kilba		ɬ̪		[ɬ]
+hbb	Kilba		ɮ̪		[ɮ̪]
+hbb	Kilba		ɮ̪		[ɮ]
+hbb	Kilba		l		[l]
+hbb	Kilba		l		[ʎ]
+hbb	Kilba		r
+hbb	Kilba		j
+hbb	Kilba		w
+hbb	Kilba		i
+hbb	Kilba		a
+hbb	Kilba		ɯ
+hbb	Kilba		ə
+hbb	Kilba		ɨ
+hbb	Kilba		˦
+hbb	Kilba		˨
+
 kwl	Kofyar		p				kwl.pdf
-kwl	Kofyar		t				
-kwl	Kofyar		t̠ʃ				
-kwl	Kofyar		k				
-kwl	Kofyar		b				
-kwl	Kofyar		d				
-kwl	Kofyar		d̠ʒ				
-kwl	Kofyar		ɡ				
-kwl	Kofyar		ɓ				
-kwl	Kofyar		ɗ				
-kwl	Kofyar		f				
-kwl	Kofyar		s				
-kwl	Kofyar		ʃ				
-kwl	Kofyar		v				
-kwl	Kofyar		z				
-kwl	Kofyar		ʒ				
-kwl	Kofyar		m				
-kwl	Kofyar		n				
-kwl	Kofyar		ŋ				
-kwl	Kofyar		w				
-kwl	Kofyar		r				
-kwl	Kofyar		l				
-kwl	Kofyar		j				
-kwl	Kofyar		i				
-kwl	Kofyar		a				
-kwl	Kofyar		u				
-kwl	Kofyar		ɔ				
-kwl	Kofyar		ɛ				
-kwl	Kofyar		iː				
-kwl	Kofyar		aː				
-kwl	Kofyar		uː				
-kwl	Kofyar		ɔː				
-kwl	Kofyar		ɛː				
-kwl	Kofyar		˦				
-kwl	Kofyar		˧				
-kwl	Kofyar		˨				
-							
+kwl	Kofyar		t
+kwl	Kofyar		t̠ʃ
+kwl	Kofyar		k
+kwl	Kofyar		b
+kwl	Kofyar		d
+kwl	Kofyar		d̠ʒ
+kwl	Kofyar		ɡ
+kwl	Kofyar		ɓ
+kwl	Kofyar		ɗ
+kwl	Kofyar		f
+kwl	Kofyar		s
+kwl	Kofyar		ʃ
+kwl	Kofyar		v
+kwl	Kofyar		z
+kwl	Kofyar		ʒ
+kwl	Kofyar		m
+kwl	Kofyar		n
+kwl	Kofyar		ŋ
+kwl	Kofyar		w
+kwl	Kofyar		r
+kwl	Kofyar		l
+kwl	Kofyar		j
+kwl	Kofyar		i
+kwl	Kofyar		a
+kwl	Kofyar		u
+kwl	Kofyar		ɔ
+kwl	Kofyar		ɛ
+kwl	Kofyar		iː
+kwl	Kofyar		aː
+kwl	Kofyar		uː
+kwl	Kofyar		ɔː
+kwl	Kofyar		ɛː
+kwl	Kofyar		˦
+kwl	Kofyar		˧
+kwl	Kofyar		˨
+
 kye	Krache		b		[b]		kye.pdf
-kye	Krache		b		[bʷ]		
-kye	Krache		d		[d]		
-kye	Krache		d		[dʷ]		
-kye	Krache		d		[dʲ]		
-kye	Krache		p		[p]		
-kye	Krache		p		[pʷ]		
-kye	Krache		t		[t]		
-kye	Krache		t		[tʷ]		
-kye	Krache		t		[tʲ]		
-kye	Krache		k		[kʷ]		
-kye	Krache		k		[k]		
-kye	Krache		kp		[kp]		
-kye	Krache		kp		[kpʷ]		
-kye	Krache		f		[f]		
-kye	Krache		f		[fʷ]		
-kye	Krache		s		[s]		
-kye	Krache		s		[sʷ]		
-kye	Krache		s		[sʲ]		
-kye	Krache		t̠ʃ		[t̠ʃ]		
-kye	Krache		t̠ʃ		[t̠ʃʷ]		
-kye	Krache		d̠ʒ		[d̠ʒ]		
-kye	Krache		d̠ʒ		[d̠ʒʷ]		
-kye	Krache		l		[l]		
-kye	Krache		l		[lʷ]		
-kye	Krache		l		[lʲ]		
-kye	Krache		l		[r]		
-kye	Krache		w				
-kye	Krache		j				
-kye	Krache		m		[m]		
-kye	Krache		m		[mʷ]		
-kye	Krache		n		[n]		
-kye	Krache		n		[nʷ]		
-kye	Krache		ɲ		[ɲ]		
-kye	Krache		ɲ		[ɲʷ]		
-kye	Krache		ŋ		[ŋ]		
-kye	Krache		ŋ		[ŋʷ]		
-kye	Krache		ɪ				
-kye	Krache		ɛ				
-kye	Krache		a				
-kye	Krache		ʊ				
-kye	Krache		ɔ				
-kye	Krache		ʌ				
-kye	Krache		ə				
-kye	Krache		i				
-kye	Krache		e				
-kye	Krache		o				
-kye	Krache		u				
-kye	Krache		ɜ				
-kye	Krache		˦				
-kye	Krache		˧				
-kye	Krache		˨				
-kye	Krache		ɪ̃				
-kye	Krache		ɛ̃				
-kye	Krache		ã				
-kye	Krache		ʊ̃				
-kye	Krache		ɔ̃				
-kye	Krache		ʌ̃				
-kye	Krache		ə̃				
-kye	Krache		ĩ				
-kye	Krache		ẽ				
-kye	Krache		õ				
-kye	Krache		ũ				
-kye	Krache		ɜ̃				
-							
+kye	Krache		b		[bʷ]
+kye	Krache		d		[d]
+kye	Krache		d		[dʷ]
+kye	Krache		d		[dʲ]
+kye	Krache		p		[p]
+kye	Krache		p		[pʷ]
+kye	Krache		t		[t]
+kye	Krache		t		[tʷ]
+kye	Krache		t		[tʲ]
+kye	Krache		k		[kʷ]
+kye	Krache		k		[k]
+kye	Krache		kp		[kp]
+kye	Krache		kp		[kpʷ]
+kye	Krache		f		[f]
+kye	Krache		f		[fʷ]
+kye	Krache		s		[s]
+kye	Krache		s		[sʷ]
+kye	Krache		s		[sʲ]
+kye	Krache		t̠ʃ		[t̠ʃ]
+kye	Krache		t̠ʃ		[t̠ʃʷ]
+kye	Krache		d̠ʒ		[d̠ʒ]
+kye	Krache		d̠ʒ		[d̠ʒʷ]
+kye	Krache		l		[l]
+kye	Krache		l		[lʷ]
+kye	Krache		l		[lʲ]
+kye	Krache		l		[r]
+kye	Krache		w
+kye	Krache		j
+kye	Krache		m		[m]
+kye	Krache		m		[mʷ]
+kye	Krache		n		[n]
+kye	Krache		n		[nʷ]
+kye	Krache		ɲ		[ɲ]
+kye	Krache		ɲ		[ɲʷ]
+kye	Krache		ŋ		[ŋ]
+kye	Krache		ŋ		[ŋʷ]
+kye	Krache		ɪ
+kye	Krache		ɛ
+kye	Krache		a
+kye	Krache		ʊ
+kye	Krache		ɔ
+kye	Krache		ʌ
+kye	Krache		ə
+kye	Krache		i
+kye	Krache		e
+kye	Krache		o
+kye	Krache		u
+kye	Krache		ɜ
+kye	Krache		˦
+kye	Krache		˧
+kye	Krache		˨
+kye	Krache		ɪ̃
+kye	Krache		ɛ̃
+kye	Krache		ã
+kye	Krache		ʊ̃
+kye	Krache		ɔ̃
+kye	Krache		ʌ̃
+kye	Krache		ə̃
+kye	Krache		ĩ
+kye	Krache		ẽ
+kye	Krache		õ
+kye	Krache		ũ
+kye	Krache		ɜ̃
+
 krm	Krim		p		[p]		krm.pdf
-krm	Krim		p		[pʲ]		
-krm	Krim		p		[pfʷ]		
-krm	Krim		t̪				
-krm	Krim		t		[t]		
-krm	Krim		t		[ts]		
-krm	Krim		t		[t̠ʃ]		
-krm	Krim		b		[b]		
-krm	Krim		b		[bʷ]		
-krm	Krim		ɡb		[ɡb]		
-krm	Krim		ɡb		[ɡbʷ]		
-krm	Krim		d				
-krm	Krim		t̠ʃ				
-krm	Krim		d̠ʒ				
-krm	Krim		k		[k]		
-krm	Krim		k		[ɡ]		
-krm	Krim		k		[ɣ]		
-krm	Krim		w		[w]		
-krm	Krim		w		[ʋ]		
-krm	Krim		s		[ʃ]		
-krm	Krim		s		[s]		
-krm	Krim		m				
-krm	Krim		n				
-krm	Krim		ɲ				
-krm	Krim		ŋ				
-krm	Krim		f				
-krm	Krim		h				
-krm	Krim		j				
-krm	Krim		l				
-krm	Krim		mp				
-krm	Krim		n̪t̪				
-krm	Krim		nt				
-krm	Krim		i		[i]		
-krm	Krim		i		[ɪ]		
-krm	Krim		i		[ɨ]		
-krm	Krim		e				
-krm	Krim		ɛ		[ɛ]		
-krm	Krim		ɛ		[ə]		
-krm	Krim		a		[a]		
-krm	Krim		a		[æ]		
-krm	Krim		u		[u]		
-krm	Krim		u		[ʊ]		
-krm	Krim		u		[ʉ]		
-krm	Krim		o				
-krm	Krim		ɔ				
-krm	Krim		iː				
-krm	Krim		eː				
-krm	Krim		ɛː				
-krm	Krim		aː				
-krm	Krim		uː				
-krm	Krim		oː				
-krm	Krim		ɔː				
-krm	Krim		o̝				
-krm	Krim		e̝				
-							
+krm	Krim		p		[pʲ]
+krm	Krim		p		[pfʷ]
+krm	Krim		t̪
+krm	Krim		t		[t]
+krm	Krim		t		[ts]
+krm	Krim		t		[t̠ʃ]
+krm	Krim		b		[b]
+krm	Krim		b		[bʷ]
+krm	Krim		ɡb		[ɡb]
+krm	Krim		ɡb		[ɡbʷ]
+krm	Krim		d
+krm	Krim		t̠ʃ
+krm	Krim		d̠ʒ
+krm	Krim		k		[k]
+krm	Krim		k		[ɡ]
+krm	Krim		k		[ɣ]
+krm	Krim		w		[w]
+krm	Krim		w		[ʋ]
+krm	Krim		s		[ʃ]
+krm	Krim		s		[s]
+krm	Krim		m
+krm	Krim		n
+krm	Krim		ɲ
+krm	Krim		ŋ
+krm	Krim		f
+krm	Krim		h
+krm	Krim		j
+krm	Krim		l
+krm	Krim		mp
+krm	Krim		n̪t̪
+krm	Krim		nt
+krm	Krim		i		[i]
+krm	Krim		i		[ɪ]
+krm	Krim		i		[ɨ]
+krm	Krim		e
+krm	Krim		ɛ		[ɛ]
+krm	Krim		ɛ		[ə]
+krm	Krim		a		[a]
+krm	Krim		a		[æ]
+krm	Krim		u		[u]
+krm	Krim		u		[ʊ]
+krm	Krim		u		[ʉ]
+krm	Krim		o
+krm	Krim		ɔ
+krm	Krim		iː
+krm	Krim		eː
+krm	Krim		ɛː
+krm	Krim		aː
+krm	Krim		uː
+krm	Krim		oː
+krm	Krim		ɔː
+krm	Krim		o̝
+krm	Krim		e̝
+
 bbp	Banda, West Central	Tangbago	p				banda_sampson.pdf
-bbp	Banda, West Central	Tangbago	t				
-bbp	Banda, West Central	Tangbago	c				
-bbp	Banda, West Central	Tangbago	ɟ				
-bbp	Banda, West Central	Tangbago	k				
-bbp	Banda, West Central	Tangbago	ɡ				
-bbp	Banda, West Central	Tangbago	kp				
-bbp	Banda, West Central	Tangbago	ɡb				
-bbp	Banda, West Central	Tangbago	ʔ				
-bbp	Banda, West Central	Tangbago	mb				
-bbp	Banda, West Central	Tangbago	nd				
-bbp	Banda, West Central	Tangbago	ɲɟ				
-bbp	Banda, West Central	Tangbago	ŋɡ				
-bbp	Banda, West Central	Tangbago	ŋmɡb				
-bbp	Banda, West Central	Tangbago	f				
-bbp	Banda, West Central	Tangbago	s				
-bbp	Banda, West Central	Tangbago	ʃ				
-bbp	Banda, West Central	Tangbago	h				
-bbp	Banda, West Central	Tangbago	v				
-bbp	Banda, West Central	Tangbago	z				
-bbp	Banda, West Central	Tangbago	ʒ				
-bbp	Banda, West Central	Tangbago	ɱv				
-bbp	Banda, West Central	Tangbago	nz				
-bbp	Banda, West Central	Tangbago	m				
-bbp	Banda, West Central	Tangbago	n				
-bbp	Banda, West Central	Tangbago	ɲ				
-bbp	Banda, West Central	Tangbago	l				
-bbp	Banda, West Central	Tangbago	ɾ				
-bbp	Banda, West Central	Tangbago	ⱱ				
-bbp	Banda, West Central	Tangbago	j				
-bbp	Banda, West Central	Tangbago	w				
-bbp	Banda, West Central	Tangbago	i				
-bbp	Banda, West Central	Tangbago	e		[e]	before nasals and prenasalized stops	
-bbp	Banda, West Central	Tangbago	e		[i]	before nasals and prenasalized stops	
-bbp	Banda, West Central	Tangbago	ea				
-bbp	Banda, West Central	Tangbago	ɨ				
-bbp	Banda, West Central	Tangbago	ə				
-bbp	Banda, West Central	Tangbago	a				
-bbp	Banda, West Central	Tangbago	u				
-bbp	Banda, West Central	Tangbago	o		[o]	before nasals and prenasalized stops	
-bbp	Banda, West Central	Tangbago	o		[u]	before nasals and prenasalized stops	
-bbp	Banda, West Central	Tangbago	oa				
-bbp	Banda, West Central	Tangbago	ɔ				
-bbp	Banda, West Central	Tangbago	˦				
-bbp	Banda, West Central	Tangbago	˧				
-bbp	Banda, West Central	Tangbago	˨		[˨]		
-bbp	Banda, West Central	Tangbago	˨		[˩]		
-bbp	Banda, West Central	Tangbago	˦˨				
-bbp	Banda, West Central	Tangbago	˨˦				
-							
+bbp	Banda, West Central	Tangbago	t
+bbp	Banda, West Central	Tangbago	c
+bbp	Banda, West Central	Tangbago	ɟ
+bbp	Banda, West Central	Tangbago	k
+bbp	Banda, West Central	Tangbago	ɡ
+bbp	Banda, West Central	Tangbago	kp
+bbp	Banda, West Central	Tangbago	ɡb
+bbp	Banda, West Central	Tangbago	ʔ
+bbp	Banda, West Central	Tangbago	mb
+bbp	Banda, West Central	Tangbago	nd
+bbp	Banda, West Central	Tangbago	ɲɟ
+bbp	Banda, West Central	Tangbago	ŋɡ
+bbp	Banda, West Central	Tangbago	ŋmɡb
+bbp	Banda, West Central	Tangbago	f
+bbp	Banda, West Central	Tangbago	s
+bbp	Banda, West Central	Tangbago	ʃ
+bbp	Banda, West Central	Tangbago	h
+bbp	Banda, West Central	Tangbago	v
+bbp	Banda, West Central	Tangbago	z
+bbp	Banda, West Central	Tangbago	ʒ
+bbp	Banda, West Central	Tangbago	ɱv
+bbp	Banda, West Central	Tangbago	nz
+bbp	Banda, West Central	Tangbago	m
+bbp	Banda, West Central	Tangbago	n
+bbp	Banda, West Central	Tangbago	ɲ
+bbp	Banda, West Central	Tangbago	l
+bbp	Banda, West Central	Tangbago	ɾ
+bbp	Banda, West Central	Tangbago	ⱱ
+bbp	Banda, West Central	Tangbago	j
+bbp	Banda, West Central	Tangbago	w
+bbp	Banda, West Central	Tangbago	i
+bbp	Banda, West Central	Tangbago	e		[e]	before nasals and prenasalized stops
+bbp	Banda, West Central	Tangbago	e		[i]	before nasals and prenasalized stops
+bbp	Banda, West Central	Tangbago	ea
+bbp	Banda, West Central	Tangbago	ɨ
+bbp	Banda, West Central	Tangbago	ə
+bbp	Banda, West Central	Tangbago	a
+bbp	Banda, West Central	Tangbago	u
+bbp	Banda, West Central	Tangbago	o		[o]	before nasals and prenasalized stops
+bbp	Banda, West Central	Tangbago	o		[u]	before nasals and prenasalized stops
+bbp	Banda, West Central	Tangbago	oa
+bbp	Banda, West Central	Tangbago	ɔ
+bbp	Banda, West Central	Tangbago	˦
+bbp	Banda, West Central	Tangbago	˧
+bbp	Banda, West Central	Tangbago	˨		[˨]
+bbp	Banda, West Central	Tangbago	˨		[˩]
+bbp	Banda, West Central	Tangbago	˦˨
+bbp	Banda, West Central	Tangbago	˨˦
+
 dib	Dinka, South Central		p		[p]		dib.pdf
-dib	Dinka, South Central		p		[b]		
-dib	Dinka, South Central		b				
-dib	Dinka, South Central		m				
-dib	Dinka, South Central		w				
-dib	Dinka, South Central		θ		[θ]		
-dib	Dinka, South Central		θ		[ð]		
-dib	Dinka, South Central		ð				
-dib	Dinka, South Central		ɱ				
-dib	Dinka, South Central		t		[t]		
-dib	Dinka, South Central		t		[d]		
-dib	Dinka, South Central		d				
-dib	Dinka, South Central		n				
-dib	Dinka, South Central		r				
-dib	Dinka, South Central		l				
-dib	Dinka, South Central		j				
-dib	Dinka, South Central		c		[c]		
-dib	Dinka, South Central		c		[ɟ]		
-dib	Dinka, South Central		ɟ				
-dib	Dinka, South Central		ɲ				
-dib	Dinka, South Central		k		[k]		
-dib	Dinka, South Central		k		[ɡ]		
-dib	Dinka, South Central		ɡ				
-dib	Dinka, South Central		ŋ				
-dib	Dinka, South Central		ɣ				
-dib	Dinka, South Central		i̤				
-dib	Dinka, South Central		e̤				
-dib	Dinka, South Central		a̤				
-dib	Dinka, South Central		ṳ				
-dib	Dinka, South Central		o̤				
-dib	Dinka, South Central		ɔ̤				
-dib	Dinka, South Central		ḭ				
-dib	Dinka, South Central		ḛ				
-dib	Dinka, South Central		a̰				
-dib	Dinka, South Central		o̰				
-dib	Dinka, South Central		ɔ̰				
-dib	Dinka, South Central		i̤ˑ				
-dib	Dinka, South Central		e̤ˑ				
-dib	Dinka, South Central		ɛ̤ˑ				
-dib	Dinka, South Central		a̤ˑ				
-dib	Dinka, South Central		ṳˑ				
-dib	Dinka, South Central		o̤ˑ				
-dib	Dinka, South Central		ɔ̤ˑ				
-dib	Dinka, South Central		i̤ː				
-dib	Dinka, South Central		e̤ː				
-dib	Dinka, South Central		a̤ː				
-dib	Dinka, South Central		ṳː				
-dib	Dinka, South Central		o̤ː				
-dib	Dinka, South Central		ɔ̤ː				
-dib	Dinka, South Central		ɛ̤ː				
-dib	Dinka, South Central		ḭː				
-dib	Dinka, South Central		ḛː				
-dib	Dinka, South Central		ɛ̰ː				
-dib	Dinka, South Central		a̰ː				
-dib	Dinka, South Central		o̰ː				
-dib	Dinka, South Central		ɔ̰ː				
-dib	Dinka, South Central		ḭˑ				
-dib	Dinka, South Central		ḛˑ				
-dib	Dinka, South Central		ɛ̰ˑ				
-dib	Dinka, South Central		a̰ˑ				
-dib	Dinka, South Central		o̰ˑ				
-dib	Dinka, South Central		ɔ̰ˑ				
-dib	Dinka, South Central		˦				
-dib	Dinka, South Central		˨				
-dib	Dinka, South Central		˦˨				
-							
+dib	Dinka, South Central		p		[b]
+dib	Dinka, South Central		b
+dib	Dinka, South Central		m
+dib	Dinka, South Central		w
+dib	Dinka, South Central		θ		[θ]
+dib	Dinka, South Central		θ		[ð]
+dib	Dinka, South Central		ð
+dib	Dinka, South Central		ɱ
+dib	Dinka, South Central		t		[t]
+dib	Dinka, South Central		t		[d]
+dib	Dinka, South Central		d
+dib	Dinka, South Central		n
+dib	Dinka, South Central		r
+dib	Dinka, South Central		l
+dib	Dinka, South Central		j
+dib	Dinka, South Central		c		[c]
+dib	Dinka, South Central		c		[ɟ]
+dib	Dinka, South Central		ɟ
+dib	Dinka, South Central		ɲ
+dib	Dinka, South Central		k		[k]
+dib	Dinka, South Central		k		[ɡ]
+dib	Dinka, South Central		ɡ
+dib	Dinka, South Central		ŋ
+dib	Dinka, South Central		ɣ
+dib	Dinka, South Central		i̤
+dib	Dinka, South Central		e̤
+dib	Dinka, South Central		a̤
+dib	Dinka, South Central		ṳ
+dib	Dinka, South Central		o̤
+dib	Dinka, South Central		ɔ̤
+dib	Dinka, South Central		ḭ
+dib	Dinka, South Central		ḛ
+dib	Dinka, South Central		a̰
+dib	Dinka, South Central		o̰
+dib	Dinka, South Central		ɔ̰
+dib	Dinka, South Central		i̤ˑ
+dib	Dinka, South Central		e̤ˑ
+dib	Dinka, South Central		ɛ̤ˑ
+dib	Dinka, South Central		a̤ˑ
+dib	Dinka, South Central		ṳˑ
+dib	Dinka, South Central		o̤ˑ
+dib	Dinka, South Central		ɔ̤ˑ
+dib	Dinka, South Central		i̤ː
+dib	Dinka, South Central		e̤ː
+dib	Dinka, South Central		a̤ː
+dib	Dinka, South Central		ṳː
+dib	Dinka, South Central		o̤ː
+dib	Dinka, South Central		ɔ̤ː
+dib	Dinka, South Central		ɛ̤ː
+dib	Dinka, South Central		ḭː
+dib	Dinka, South Central		ḛː
+dib	Dinka, South Central		ɛ̰ː
+dib	Dinka, South Central		a̰ː
+dib	Dinka, South Central		o̰ː
+dib	Dinka, South Central		ɔ̰ː
+dib	Dinka, South Central		ḭˑ
+dib	Dinka, South Central		ḛˑ
+dib	Dinka, South Central		ɛ̰ˑ
+dib	Dinka, South Central		a̰ˑ
+dib	Dinka, South Central		o̰ˑ
+dib	Dinka, South Central		ɔ̰ˑ
+dib	Dinka, South Central		˦
+dib	Dinka, South Central		˨
+dib	Dinka, South Central		˦˨
+
 fod	Foodo		˦				foodo.pdf
-fod	Foodo		˨				
-fod	Foodo		˦˨				
-fod	Foodo		p				
-fod	Foodo		b				
-fod	Foodo		f				
-fod	Foodo		<v>	loanwords only			
-fod	Foodo		m				
-fod	Foodo		t				
-fod	Foodo		d				
-fod	Foodo		s				
-fod	Foodo		<z>	loanwords only			
-fod	Foodo		n				
-fod	Foodo		l				
-fod	Foodo		<r>	loanwords only			
-fod	Foodo		t̠ʃ				
-fod	Foodo		d̠ʒ				
-fod	Foodo		ŋm				
-fod	Foodo		j				
-fod	Foodo		k				
-fod	Foodo		ɡ				
-fod	Foodo		ŋ				
-fod	Foodo		w				
-fod	Foodo		kp				
-fod	Foodo		ɡb				
-fod	Foodo		<h>	loanwords only			
-fod	Foodo		i				
-fod	Foodo		e				
-fod	Foodo		u				
-fod	Foodo		o				
-fod	Foodo		ɪ				
-fod	Foodo		ɛ				
-fod	Foodo		ɔ				
-fod	Foodo		ʊ				
-fod	Foodo		a				
-fod	Foodo		iː				
-fod	Foodo		eː				
-fod	Foodo		uː				
-fod	Foodo		oː				
-fod	Foodo		ɪː				
-fod	Foodo		ɛː				
-fod	Foodo		ɔː				
-fod	Foodo		ʊː				
-fod	Foodo		aː				
-							
+fod	Foodo		˨
+fod	Foodo		˦˨
+fod	Foodo		p
+fod	Foodo		b
+fod	Foodo		f
+fod	Foodo		<v>	loanwords only
+fod	Foodo		m
+fod	Foodo		t
+fod	Foodo		d
+fod	Foodo		s
+fod	Foodo		<z>	loanwords only
+fod	Foodo		n
+fod	Foodo		l
+fod	Foodo		<r>	loanwords only
+fod	Foodo		t̠ʃ
+fod	Foodo		d̠ʒ
+fod	Foodo		ŋm
+fod	Foodo		j
+fod	Foodo		k
+fod	Foodo		ɡ
+fod	Foodo		ŋ
+fod	Foodo		w
+fod	Foodo		kp
+fod	Foodo		ɡb
+fod	Foodo		<h>	loanwords only
+fod	Foodo		i
+fod	Foodo		e
+fod	Foodo		u
+fod	Foodo		o
+fod	Foodo		ɪ
+fod	Foodo		ɛ
+fod	Foodo		ɔ
+fod	Foodo		ʊ
+fod	Foodo		a
+fod	Foodo		iː
+fod	Foodo		eː
+fod	Foodo		uː
+fod	Foodo		oː
+fod	Foodo		ɪː
+fod	Foodo		ɛː
+fod	Foodo		ɔː
+fod	Foodo		ʊː
+fod	Foodo		aː
+
 csk	Joola Huluf		b				joola_huluf.pdf
-csk	Joola Huluf		m				
-csk	Joola Huluf		f				
-csk	Joola Huluf		w				
-csk	Joola Huluf		t		[t]		
-csk	Joola Huluf		t		[tʰ]	pre-pause	
-csk	Joola Huluf		<d>	rare			
-csk	Joola Huluf		n				
-csk	Joola Huluf		s				
-csk	Joola Huluf		l̥				
-csk	Joola Huluf		l				
-csk	Joola Huluf		d̠ʒ				
-csk	Joola Huluf		ɲ				
-csk	Joola Huluf		ʃ				
-csk	Joola Huluf		j				
-csk	Joola Huluf		k		[k]		
-csk	Joola Huluf		k		[kʰ]	pre-pause	
-csk	Joola Huluf		ɡ				
-csk	Joola Huluf		ŋ				
-csk	Joola Huluf		h				
-csk	Joola Huluf		ʔ				
-csk	Joola Huluf		bː				
-csk	Joola Huluf		ɡː				
-csk	Joola Huluf		tː				
-csk	Joola Huluf		kː				
-csk	Joola Huluf		mː				
-csk	Joola Huluf		nː				
-csk	Joola Huluf		ɲː				
-csk	Joola Huluf		ŋː				
-csk	Joola Huluf		sː				
-csk	Joola Huluf		ʃː				
-csk	Joola Huluf		l̥ː				
-csk	Joola Huluf		lː				
-csk	Joola Huluf		ɪ				
-csk	Joola Huluf		ɛ				
-csk	Joola Huluf		a				
-csk	Joola Huluf		ʊ				
-csk	Joola Huluf		ɔ				
-csk	Joola Huluf		i				
-csk	Joola Huluf		e				
-csk	Joola Huluf		o				
-csk	Joola Huluf		u				
-csk	Joola Huluf		ə				
-csk	Joola Huluf		ɪː				
-csk	Joola Huluf		ɛː				
-csk	Joola Huluf		aː				
-csk	Joola Huluf		ʊː				
-csk	Joola Huluf		ɔː				
-csk	Joola Huluf		iː				
-csk	Joola Huluf		eː				
-csk	Joola Huluf		oː				
-csk	Joola Huluf		uː				
-csk	Joola Huluf		əː				
-							
+csk	Joola Huluf		m
+csk	Joola Huluf		f
+csk	Joola Huluf		w
+csk	Joola Huluf		t		[t]
+csk	Joola Huluf		t		[tʰ]	pre-pause
+csk	Joola Huluf		<d>	rare
+csk	Joola Huluf		n
+csk	Joola Huluf		s
+csk	Joola Huluf		l̥
+csk	Joola Huluf		l
+csk	Joola Huluf		d̠ʒ
+csk	Joola Huluf		ɲ
+csk	Joola Huluf		ʃ
+csk	Joola Huluf		j
+csk	Joola Huluf		k		[k]
+csk	Joola Huluf		k		[kʰ]	pre-pause
+csk	Joola Huluf		ɡ
+csk	Joola Huluf		ŋ
+csk	Joola Huluf		h
+csk	Joola Huluf		ʔ
+csk	Joola Huluf		bː
+csk	Joola Huluf		ɡː
+csk	Joola Huluf		tː
+csk	Joola Huluf		kː
+csk	Joola Huluf		mː
+csk	Joola Huluf		nː
+csk	Joola Huluf		ɲː
+csk	Joola Huluf		ŋː
+csk	Joola Huluf		sː
+csk	Joola Huluf		ʃː
+csk	Joola Huluf		l̥ː
+csk	Joola Huluf		lː
+csk	Joola Huluf		ɪ
+csk	Joola Huluf		ɛ
+csk	Joola Huluf		a
+csk	Joola Huluf		ʊ
+csk	Joola Huluf		ɔ
+csk	Joola Huluf		i
+csk	Joola Huluf		e
+csk	Joola Huluf		o
+csk	Joola Huluf		u
+csk	Joola Huluf		ə
+csk	Joola Huluf		ɪː
+csk	Joola Huluf		ɛː
+csk	Joola Huluf		aː
+csk	Joola Huluf		ʊː
+csk	Joola Huluf		ɔː
+csk	Joola Huluf		iː
+csk	Joola Huluf		eː
+csk	Joola Huluf		oː
+csk	Joola Huluf		uː
+csk	Joola Huluf		əː
+
 jum	Jumjum		ɪ				jumjum.pdf
-jum	Jumjum		ɛ		[ɛ]		
-jum	Jumjum		ɛ		[e]		
-jum	Jumjum		a				
-jum	Jumjum		ʊ				
-jum	Jumjum		ɔ		[ɔ]		
-jum	Jumjum		ɔ		[o]		
-jum	Jumjum		i				
-jum	Jumjum		u				
-jum	Jumjum		ʌ				
-jum	Jumjum		ɪː				
-jum	Jumjum		ɛː				
-jum	Jumjum		aː				
-jum	Jumjum		ʊː				
-jum	Jumjum		ɔː				
-jum	Jumjum		iː				
-jum	Jumjum		uː				
-jum	Jumjum		ʌː				
-jum	Jumjum		p				
-jum	Jumjum		b	no word final			
-jum	Jumjum		m				
-jum	Jumjum		w				
-jum	Jumjum		ð				
-jum	Jumjum		θ				
-jum	Jumjum		ɱ	only in clusters			
-jum	Jumjum		t	no word final			
-jum	Jumjum		d	no word final			
-jum	Jumjum		n				
-jum	Jumjum		l				
-jum	Jumjum		r				
-jum	Jumjum		c				
-jum	Jumjum		ɟ				
-jum	Jumjum		ɲ				
-jum	Jumjum		j				
-jum	Jumjum		k				
-jum	Jumjum		ɡ	no word final			
-jum	Jumjum		ŋ				
-jum	Jumjum		ʔ	word-initial only			
-jum	Jumjum		˦				
-jum	Jumjum		˨				
-jum	Jumjum		˦˨				
-							
+jum	Jumjum		ɛ		[ɛ]
+jum	Jumjum		ɛ		[e]
+jum	Jumjum		a
+jum	Jumjum		ʊ
+jum	Jumjum		ɔ		[ɔ]
+jum	Jumjum		ɔ		[o]
+jum	Jumjum		i
+jum	Jumjum		u
+jum	Jumjum		ʌ
+jum	Jumjum		ɪː
+jum	Jumjum		ɛː
+jum	Jumjum		aː
+jum	Jumjum		ʊː
+jum	Jumjum		ɔː
+jum	Jumjum		iː
+jum	Jumjum		uː
+jum	Jumjum		ʌː
+jum	Jumjum		p
+jum	Jumjum		b	no word final
+jum	Jumjum		m
+jum	Jumjum		w
+jum	Jumjum		ð
+jum	Jumjum		θ
+jum	Jumjum		ɱ	only in clusters
+jum	Jumjum		t	no word final
+jum	Jumjum		d	no word final
+jum	Jumjum		n
+jum	Jumjum		l
+jum	Jumjum		r
+jum	Jumjum		c
+jum	Jumjum		ɟ
+jum	Jumjum		ɲ
+jum	Jumjum		j
+jum	Jumjum		k
+jum	Jumjum		ɡ	no word final
+jum	Jumjum		ŋ
+jum	Jumjum		ʔ	word-initial only
+jum	Jumjum		˦
+jum	Jumjum		˨
+jum	Jumjum		˦˨
+
 bdi	Burun	Kurmuk	ɪ				Kurmuk.pdf
-bdi	Burun	Kurmuk	ɛ		[ɛ]		
-bdi	Burun	Kurmuk	ɛ		[e]		
-bdi	Burun	Kurmuk	a				
-bdi	Burun	Kurmuk	ʊ				
-bdi	Burun	Kurmuk	ɔ		[ɔ]		
-bdi	Burun	Kurmuk	ɔ		[o]		
-bdi	Burun	Kurmuk	i				
-bdi	Burun	Kurmuk	u				
-bdi	Burun	Kurmuk	ʌ				
-bdi	Burun	Kurmuk	ɪː				
-bdi	Burun	Kurmuk	ɛː				
-bdi	Burun	Kurmuk	aː				
-bdi	Burun	Kurmuk	ʊː				
-bdi	Burun	Kurmuk	ɔː				
-bdi	Burun	Kurmuk	iː				
-bdi	Burun	Kurmuk	uː				
-bdi	Burun	Kurmuk	ʌː				
-bdi	Burun	Kurmuk	p				
-bdi	Burun	Kurmuk	b				
-bdi	Burun	Kurmuk	m				
-bdi	Burun	Kurmuk	θ				
-bdi	Burun	Kurmuk	ð				
-bdi	Burun	Kurmuk	t				
-bdi	Burun	Kurmuk	ɗ				
-bdi	Burun	Kurmuk	z				
-bdi	Burun	Kurmuk	n				
-bdi	Burun	Kurmuk	l				
-bdi	Burun	Kurmuk	r				
-bdi	Burun	Kurmuk	ʃ				
-bdi	Burun	Kurmuk	ɲ	never word-initial			
-bdi	Burun	Kurmuk	j				
-bdi	Burun	Kurmuk	k				
-bdi	Burun	Kurmuk	ɡ				
-bdi	Burun	Kurmuk	ŋ				
-bdi	Burun	Kurmuk	ʔ	word-initial only			
-bdi	Burun	Kurmuk	w				
-bdi	Burun	Kurmuk	˦				
-bdi	Burun	Kurmuk	˨				
-bdi	Burun	Kurmuk	˦˨				
-							
+bdi	Burun	Kurmuk	ɛ		[ɛ]
+bdi	Burun	Kurmuk	ɛ		[e]
+bdi	Burun	Kurmuk	a
+bdi	Burun	Kurmuk	ʊ
+bdi	Burun	Kurmuk	ɔ		[ɔ]
+bdi	Burun	Kurmuk	ɔ		[o]
+bdi	Burun	Kurmuk	i
+bdi	Burun	Kurmuk	u
+bdi	Burun	Kurmuk	ʌ
+bdi	Burun	Kurmuk	ɪː
+bdi	Burun	Kurmuk	ɛː
+bdi	Burun	Kurmuk	aː
+bdi	Burun	Kurmuk	ʊː
+bdi	Burun	Kurmuk	ɔː
+bdi	Burun	Kurmuk	iː
+bdi	Burun	Kurmuk	uː
+bdi	Burun	Kurmuk	ʌː
+bdi	Burun	Kurmuk	p
+bdi	Burun	Kurmuk	b
+bdi	Burun	Kurmuk	m
+bdi	Burun	Kurmuk	θ
+bdi	Burun	Kurmuk	ð
+bdi	Burun	Kurmuk	t
+bdi	Burun	Kurmuk	ɗ
+bdi	Burun	Kurmuk	z
+bdi	Burun	Kurmuk	n
+bdi	Burun	Kurmuk	l
+bdi	Burun	Kurmuk	r
+bdi	Burun	Kurmuk	ʃ
+bdi	Burun	Kurmuk	ɲ	never word-initial
+bdi	Burun	Kurmuk	j
+bdi	Burun	Kurmuk	k
+bdi	Burun	Kurmuk	ɡ
+bdi	Burun	Kurmuk	ŋ
+bdi	Burun	Kurmuk	ʔ	word-initial only
+bdi	Burun	Kurmuk	w
+bdi	Burun	Kurmuk	˦
+bdi	Burun	Kurmuk	˨
+bdi	Burun	Kurmuk	˦˨
+
 lul	Lulubo		ɪ				Lulubo.pdf
-lul	Lulubo		ɛ				
-lul	Lulubo		a				
-lul	Lulubo		ʊ				
-lul	Lulubo		ɔ				
-lul	Lulubo		i				
-lul	Lulubo		u				
-lul	Lulubo		e				
-lul	Lulubo		o				
-lul	Lulubo		p				
-lul	Lulubo		b				
-lul	Lulubo		mb				
-lul	Lulubo		ɓ				
-lul	Lulubo		θ				
-lul	Lulubo		ð				
-lul	Lulubo		ɱð				
-lul	Lulubo		ɗ				
-lul	Lulubo		ʈ				
-lul	Lulubo		ɖ				
-lul	Lulubo		ɳɖ				
-lul	Lulubo		ʄ				
-lul	Lulubo		k				
-lul	Lulubo		ɡ		[ɡ]		
-lul	Lulubo		ɡ		[ɡʲ]		
-lul	Lulubo		ŋɡ		[ŋɡ]		
-lul	Lulubo		ŋɡ		[ŋɡʲ]		
-lul	Lulubo		kp				
-lul	Lulubo		ɡb				
-lul	Lulubo		ŋmɡb				
-lul	Lulubo		ʔ				
-lul	Lulubo		t̠ʃ				
-lul	Lulubo		d̠ʒ				
-lul	Lulubo		n̠d̠ʒ	updated from ɲdʒ			
-lul	Lulubo		f				
-lul	Lulubo		v				
-lul	Lulubo		s				
-lul	Lulubo		z				
-lul	Lulubo		m				
-lul	Lulubo		n				
-lul	Lulubo		ɲ				
-lul	Lulubo		ŋ		[ŋ]		
-lul	Lulubo		ŋ		[ŋʲ]		
-lul	Lulubo		l				
-lul	Lulubo		r				
-lul	Lulubo		j				
-lul	Lulubo		w				
-lul	Lulubo		˦				
-lul	Lulubo		˨				
-lul	Lulubo		˧				
-							
+lul	Lulubo		ɛ
+lul	Lulubo		a
+lul	Lulubo		ʊ
+lul	Lulubo		ɔ
+lul	Lulubo		i
+lul	Lulubo		u
+lul	Lulubo		e
+lul	Lulubo		o
+lul	Lulubo		p
+lul	Lulubo		b
+lul	Lulubo		mb
+lul	Lulubo		ɓ
+lul	Lulubo		θ
+lul	Lulubo		ð
+lul	Lulubo		ɱð
+lul	Lulubo		ɗ
+lul	Lulubo		ʈ
+lul	Lulubo		ɖ
+lul	Lulubo		ɳɖ
+lul	Lulubo		ʄ
+lul	Lulubo		k
+lul	Lulubo		ɡ		[ɡ]
+lul	Lulubo		ɡ		[ɡʲ]
+lul	Lulubo		ŋɡ		[ŋɡ]
+lul	Lulubo		ŋɡ		[ŋɡʲ]
+lul	Lulubo		kp
+lul	Lulubo		ɡb
+lul	Lulubo		ŋmɡb
+lul	Lulubo		ʔ
+lul	Lulubo		t̠ʃ
+lul	Lulubo		d̠ʒ
+lul	Lulubo		n̠d̠ʒ	updated from ɲdʒ
+lul	Lulubo		f
+lul	Lulubo		v
+lul	Lulubo		s
+lul	Lulubo		z
+lul	Lulubo		m
+lul	Lulubo		n
+lul	Lulubo		ɲ
+lul	Lulubo		ŋ		[ŋ]
+lul	Lulubo		ŋ		[ŋʲ]
+lul	Lulubo		l
+lul	Lulubo		r
+lul	Lulubo		j
+lul	Lulubo		w
+lul	Lulubo		˦
+lul	Lulubo		˨
+lul	Lulubo		˧
+
 ymm	Maay	Lower Jubba	<p>	rare			Maay.pdf
-ymm	Maay	Lower Jubba	b		[b]		
-ymm	Maay	Lower Jubba	b		[β]	intervocalic	
-ymm	Maay	Lower Jubba	f				
-ymm	Maay	Lower Jubba	m		[m]		
-ymm	Maay	Lower Jubba	m		[ŋ]	pre-nasal	
-ymm	Maay	Lower Jubba	w				
-ymm	Maay	Lower Jubba	t				
-ymm	Maay	Lower Jubba	d		[d]		
-ymm	Maay	Lower Jubba	d		[ð]	intervocalic	
-ymm	Maay	Lower Jubba	n				
-ymm	Maay	Lower Jubba	ɗ				
-ymm	Maay	Lower Jubba	s				
-ymm	Maay	Lower Jubba	l				
-ymm	Maay	Lower Jubba	r				
-ymm	Maay	Lower Jubba	d̠ʒ				
-ymm	Maay	Lower Jubba	ʃ				
-ymm	Maay	Lower Jubba	ʄ				
-ymm	Maay	Lower Jubba	ɲ				
-ymm	Maay	Lower Jubba	j				
-ymm	Maay	Lower Jubba	ɠ				
-ymm	Maay	Lower Jubba	k		[k]		
-ymm	Maay	Lower Jubba	k		[ɣ]	intervocalic	
-ymm	Maay	Lower Jubba	ɡ		[ɡ]		
-ymm	Maay	Lower Jubba	ɡ		[ɣ]	intervocalic	
-ymm	Maay	Lower Jubba	ʔ				
-ymm	Maay	Lower Jubba	h				
-ymm	Maay	Lower Jubba	i				
-ymm	Maay	Lower Jubba	e				
-ymm	Maay	Lower Jubba	a				
-ymm	Maay	Lower Jubba	u				
-ymm	Maay	Lower Jubba	o				
-ymm	Maay	Lower Jubba	iː				
-ymm	Maay	Lower Jubba	eː				
-ymm	Maay	Lower Jubba	aː				
-ymm	Maay	Lower Jubba	uː				
-ymm	Maay	Lower Jubba	oː				
-							
+ymm	Maay	Lower Jubba	b		[b]
+ymm	Maay	Lower Jubba	b		[β]	intervocalic
+ymm	Maay	Lower Jubba	f
+ymm	Maay	Lower Jubba	m		[m]
+ymm	Maay	Lower Jubba	m		[ŋ]	pre-nasal
+ymm	Maay	Lower Jubba	w
+ymm	Maay	Lower Jubba	t
+ymm	Maay	Lower Jubba	d		[d]
+ymm	Maay	Lower Jubba	d		[ð]	intervocalic
+ymm	Maay	Lower Jubba	n
+ymm	Maay	Lower Jubba	ɗ
+ymm	Maay	Lower Jubba	s
+ymm	Maay	Lower Jubba	l
+ymm	Maay	Lower Jubba	r
+ymm	Maay	Lower Jubba	d̠ʒ
+ymm	Maay	Lower Jubba	ʃ
+ymm	Maay	Lower Jubba	ʄ
+ymm	Maay	Lower Jubba	ɲ
+ymm	Maay	Lower Jubba	j
+ymm	Maay	Lower Jubba	ɠ
+ymm	Maay	Lower Jubba	k		[k]
+ymm	Maay	Lower Jubba	k		[ɣ]	intervocalic
+ymm	Maay	Lower Jubba	ɡ		[ɡ]
+ymm	Maay	Lower Jubba	ɡ		[ɣ]	intervocalic
+ymm	Maay	Lower Jubba	ʔ
+ymm	Maay	Lower Jubba	h
+ymm	Maay	Lower Jubba	i
+ymm	Maay	Lower Jubba	e
+ymm	Maay	Lower Jubba	a
+ymm	Maay	Lower Jubba	u
+ymm	Maay	Lower Jubba	o
+ymm	Maay	Lower Jubba	iː
+ymm	Maay	Lower Jubba	eː
+ymm	Maay	Lower Jubba	aː
+ymm	Maay	Lower Jubba	uː
+ymm	Maay	Lower Jubba	oː
+
 mfz	Mabaan		p				Mabaan.pdf
-mfz	Mabaan		b				
-mfz	Mabaan		m				
-mfz	Mabaan		ð				
-mfz	Mabaan		θ				
-mfz	Mabaan		n		[n]		
-mfz	Mabaan		n		[ɱ]		
-mfz	Mabaan		t				
-mfz	Mabaan		d				
-mfz	Mabaan		n				
-mfz	Mabaan		c		[c]		
-mfz	Mabaan		c		[t̠ʃ]		
-mfz	Mabaan		c		[ʃ]		
-mfz	Mabaan		ɟ		[ɟ]		
-mfz	Mabaan		ɟ		[d̠ʒ]		
-mfz	Mabaan		ɲ				
-mfz	Mabaan		k				
-mfz	Mabaan		ɡ				
-mfz	Mabaan		ŋ				
-mfz	Mabaan		ʔ				
-mfz	Mabaan		l				
-mfz	Mabaan		r	may be allophone of /d/			
-mfz	Mabaan		j				
-mfz	Mabaan		w				
-mfz	Mabaan		i				
-mfz	Mabaan		e				
-mfz	Mabaan		ɛ				
-mfz	Mabaan		a				
-mfz	Mabaan		ʌ				
-mfz	Mabaan		u				
-mfz	Mabaan		ɔ				
-mfz	Mabaan		ie				
-mfz	Mabaan		iɛ				
-mfz	Mabaan		uʌ				
-mfz	Mabaan		ua				
-mfz	Mabaan		iː				
-mfz	Mabaan		eː				
-mfz	Mabaan		ɛː				
-mfz	Mabaan		aː				
-mfz	Mabaan		ʌː				
-mfz	Mabaan		uː				
-mfz	Mabaan		ɔː				
-mfz	Mabaan		iːe				
-mfz	Mabaan		iːɛ				
-mfz	Mabaan		uːʌ				
-mfz	Mabaan		uːa				
-mfz	Mabaan		˦				
-mfz	Mabaan		˨				
-mfz	Mabaan		˦˨				
-mfz	Mabaan		˨˦				
-							
+mfz	Mabaan		b
+mfz	Mabaan		m
+mfz	Mabaan		ð
+mfz	Mabaan		θ
+mfz	Mabaan		n		[n]
+mfz	Mabaan		n		[ɱ]
+mfz	Mabaan		t
+mfz	Mabaan		d
+mfz	Mabaan		n
+mfz	Mabaan		c		[c]
+mfz	Mabaan		c		[t̠ʃ]
+mfz	Mabaan		c		[ʃ]
+mfz	Mabaan		ɟ		[ɟ]
+mfz	Mabaan		ɟ		[d̠ʒ]
+mfz	Mabaan		ɲ
+mfz	Mabaan		k
+mfz	Mabaan		ɡ
+mfz	Mabaan		ŋ
+mfz	Mabaan		ʔ
+mfz	Mabaan		l
+mfz	Mabaan		r	may be allophone of /d/
+mfz	Mabaan		j
+mfz	Mabaan		w
+mfz	Mabaan		i
+mfz	Mabaan		e
+mfz	Mabaan		ɛ
+mfz	Mabaan		a
+mfz	Mabaan		ʌ
+mfz	Mabaan		u
+mfz	Mabaan		ɔ
+mfz	Mabaan		ie
+mfz	Mabaan		iɛ
+mfz	Mabaan		uʌ
+mfz	Mabaan		ua
+mfz	Mabaan		iː
+mfz	Mabaan		eː
+mfz	Mabaan		ɛː
+mfz	Mabaan		aː
+mfz	Mabaan		ʌː
+mfz	Mabaan		uː
+mfz	Mabaan		ɔː
+mfz	Mabaan		iːe
+mfz	Mabaan		iːɛ
+mfz	Mabaan		uːʌ
+mfz	Mabaan		uːa
+mfz	Mabaan		˦
+mfz	Mabaan		˨
+mfz	Mabaan		˦˨
+mfz	Mabaan		˨˦
+
 sgi	Nizaa		ɪ		[ɪ]		nizaa.pdf
-sgi	Nizaa		ɪ		[ɯ]		
-sgi	Nizaa		e		[e]		
-sgi	Nizaa		e		[ɤ]		
-sgi	Nizaa		a				
-sgi	Nizaa		ʊ		[ʊ]		
-sgi	Nizaa		ʊ		[ʏ]		
-sgi	Nizaa		o		[o]		
-sgi	Nizaa		o		[ø]		
-sgi	Nizaa		iː				
-sgi	Nizaa		eː				
-sgi	Nizaa		ɛː				
-sgi	Nizaa		aː				
-sgi	Nizaa		ɯː				
-sgi	Nizaa		ɤː				
-sgi	Nizaa		ʌː				
-sgi	Nizaa		uː				
-sgi	Nizaa		oː				
-sgi	Nizaa		ɔː				
-sgi	Nizaa		ĩː				
-sgi	Nizaa		ɛ̃ː				
-sgi	Nizaa		ãː				
-sgi	Nizaa		ɯ̃ː				
-sgi	Nizaa		ɤ̃ː				
-sgi	Nizaa		ʌ̃ː				
-sgi	Nizaa		ũː				
-sgi	Nizaa		ɔ̃ː				
-sgi	Nizaa		p				
-sgi	Nizaa		b				
-sgi	Nizaa		ɓ				
-sgi	Nizaa		ɓʷ				
-sgi	Nizaa		mb				
-sgi	Nizaa		m				
-sgi	Nizaa		mʷ				
-sgi	Nizaa		ɱv				
-sgi	Nizaa		f				
-sgi	Nizaa		v				
-sgi	Nizaa		t				
-sgi	Nizaa		tʷ				
-sgi	Nizaa		d				
-sgi	Nizaa		dʷ				
-sgi	Nizaa		ɗ				
-sgi	Nizaa		ɗʷ				
-sgi	Nizaa		nd				
-sgi	Nizaa		ndʷ				
-sgi	Nizaa		n				
-sgi	Nizaa		nʷ				
-sgi	Nizaa		l				
-sgi	Nizaa		lʷ				
-sgi	Nizaa		ɾ				
-sgi	Nizaa		ɾʷ				
-sgi	Nizaa		t̠ʃ				
-sgi	Nizaa		t̠ʃʷ				
-sgi	Nizaa		d̠ʒ				
-sgi	Nizaa		d̠ʒʷ				
-sgi	Nizaa		n̠d̠ʒ	updated from ɲdʒ			
-sgi	Nizaa		n̠d̠ʒʷ	updated from ɲdʒʷ			
-sgi	Nizaa		ɲ				
-sgi	Nizaa		ɲʷ				
-sgi	Nizaa		nz				
-sgi	Nizaa		nzʷ				
-sgi	Nizaa		s				
-sgi	Nizaa		sʷ				
-sgi	Nizaa		ʃ				
-sgi	Nizaa		ʃʷ				
-sgi	Nizaa		z				
-sgi	Nizaa		zʷ				
-sgi	Nizaa		k				
-sgi	Nizaa		kʷ				
-sgi	Nizaa		ɡ				
-sgi	Nizaa		ɡʷ				
-sgi	Nizaa		ŋɡ				
-sgi	Nizaa		ŋɡʷ				
-sgi	Nizaa		ɰ̃				
-sgi	Nizaa		w̃				
-sgi	Nizaa		x				
-sgi	Nizaa		j				
-sgi	Nizaa		ɥ				
-sgi	Nizaa		kp				
-sgi	Nizaa		ɡb				
-sgi	Nizaa		ŋmɡb				
-sgi	Nizaa		w				
-sgi	Nizaa		ʔ				
-sgi	Nizaa		ʔʷ				
-sgi	Nizaa		h				
-sgi	Nizaa		˦				
-sgi	Nizaa		˨				
-sgi	Nizaa		˧				
-sgi	Nizaa		˦˧				
-sgi	Nizaa		˨˦				
-sgi	Nizaa		˦˨				
-sgi	Nizaa		˨˧				
-sgi	Nizaa		˧˨				
-sgi	Nizaa		˨˦˧				
-							
+sgi	Nizaa		ɪ		[ɯ]
+sgi	Nizaa		e		[e]
+sgi	Nizaa		e		[ɤ]
+sgi	Nizaa		a
+sgi	Nizaa		ʊ		[ʊ]
+sgi	Nizaa		ʊ		[ʏ]
+sgi	Nizaa		o		[o]
+sgi	Nizaa		o		[ø]
+sgi	Nizaa		iː
+sgi	Nizaa		eː
+sgi	Nizaa		ɛː
+sgi	Nizaa		aː
+sgi	Nizaa		ɯː
+sgi	Nizaa		ɤː
+sgi	Nizaa		ʌː
+sgi	Nizaa		uː
+sgi	Nizaa		oː
+sgi	Nizaa		ɔː
+sgi	Nizaa		ĩː
+sgi	Nizaa		ɛ̃ː
+sgi	Nizaa		ãː
+sgi	Nizaa		ɯ̃ː
+sgi	Nizaa		ɤ̃ː
+sgi	Nizaa		ʌ̃ː
+sgi	Nizaa		ũː
+sgi	Nizaa		ɔ̃ː
+sgi	Nizaa		p
+sgi	Nizaa		b
+sgi	Nizaa		ɓ
+sgi	Nizaa		ɓʷ
+sgi	Nizaa		mb
+sgi	Nizaa		m
+sgi	Nizaa		mʷ
+sgi	Nizaa		ɱv
+sgi	Nizaa		f
+sgi	Nizaa		v
+sgi	Nizaa		t
+sgi	Nizaa		tʷ
+sgi	Nizaa		d
+sgi	Nizaa		dʷ
+sgi	Nizaa		ɗ
+sgi	Nizaa		ɗʷ
+sgi	Nizaa		nd
+sgi	Nizaa		ndʷ
+sgi	Nizaa		n
+sgi	Nizaa		nʷ
+sgi	Nizaa		l
+sgi	Nizaa		lʷ
+sgi	Nizaa		ɾ
+sgi	Nizaa		ɾʷ
+sgi	Nizaa		t̠ʃ
+sgi	Nizaa		t̠ʃʷ
+sgi	Nizaa		d̠ʒ
+sgi	Nizaa		d̠ʒʷ
+sgi	Nizaa		n̠d̠ʒ	updated from ɲdʒ
+sgi	Nizaa		n̠d̠ʒʷ	updated from ɲdʒʷ
+sgi	Nizaa		ɲ
+sgi	Nizaa		ɲʷ
+sgi	Nizaa		nz
+sgi	Nizaa		nzʷ
+sgi	Nizaa		s
+sgi	Nizaa		sʷ
+sgi	Nizaa		ʃ
+sgi	Nizaa		ʃʷ
+sgi	Nizaa		z
+sgi	Nizaa		zʷ
+sgi	Nizaa		k
+sgi	Nizaa		kʷ
+sgi	Nizaa		ɡ
+sgi	Nizaa		ɡʷ
+sgi	Nizaa		ŋɡ
+sgi	Nizaa		ŋɡʷ
+sgi	Nizaa		ɰ̃
+sgi	Nizaa		w̃
+sgi	Nizaa		x
+sgi	Nizaa		j
+sgi	Nizaa		ɥ
+sgi	Nizaa		kp
+sgi	Nizaa		ɡb
+sgi	Nizaa		ŋmɡb
+sgi	Nizaa		w
+sgi	Nizaa		ʔ
+sgi	Nizaa		ʔʷ
+sgi	Nizaa		h
+sgi	Nizaa		˦
+sgi	Nizaa		˨
+sgi	Nizaa		˧
+sgi	Nizaa		˦˧
+sgi	Nizaa		˨˦
+sgi	Nizaa		˦˨
+sgi	Nizaa		˨˧
+sgi	Nizaa		˧˨
+sgi	Nizaa		˨˦˧
+
 cce	Copi		i				zone-s.pdf
-cce	Copi		e				
-cce	Copi		a				
-cce	Copi		o				
-cce	Copi		u				
-cce	Copi		p				
-cce	Copi		pʰ				
-cce	Copi		b̤				
-cce	Copi		ɓ				
-cce	Copi		w				
-cce	Copi		m				
-cce	Copi		<m̤>	loanwords only			
-cce	Copi		mb				
-cce	Copi		m̤b̤				
-cce	Copi		pf				
-cce	Copi		pfʰ				
-cce	Copi		b̤v̤				
-cce	Copi		f				
-cce	Copi		ʋ				
-cce	Copi		mbv				
-cce	Copi		ps				
-cce	Copi		psʰ				
-cce	Copi		b̤z̤				
-cce	Copi		sʷ				
-cce	Copi		mbz				
-cce	Copi		t				
-cce	Copi		tʰ				
-cce	Copi		d̤				
-cce	Copi		ɗ				
-cce	Copi		r̤				
-cce	Copi		l				
-cce	Copi		n				
-cce	Copi		<n̤>	loanwords only			
-cce	Copi		<nd>	loanwords only			
-cce	Copi		<n̤d̤>	loanwords only			
-cce	Copi		<tl>	loanwords only			
-cce	Copi		<tlʱ>	loanwords only			
-cce	Copi		<d̤ɮ̤>	loanwords only			
-cce	Copi		<ɬ>	loanwords only			
-cce	Copi		<ndl>	loanwords only			
-cce	Copi		<n̤d̤ɮ̤>	loanwords only			
-cce	Copi		ts				
-cce	Copi		tsʰ				
-cce	Copi		d̤z̤				
-cce	Copi		s				
-cce	Copi		nz				
-cce	Copi		t̠ʃ				
-cce	Copi		t̠ʃʰ				
-cce	Copi		d̤ʒ̤				
-cce	Copi		ʄ				
-cce	Copi		<ʃ>	loanwords only			
-cce	Copi		j				
-cce	Copi		ɲ				
-cce	Copi		n̠̩d̠ʒ	updated from ̩ɲdʒ			
-cce	Copi		k				
-cce	Copi		kʰ				
-cce	Copi		ɡ̤				
-cce	Copi		ɦ̤				
-cce	Copi		ŋ				
-cce	Copi		nɡ				
-cce	Copi		n̤ɡ̤				
-cce	Copi		kǃ	updated from ǃ			
-cce	Copi		kǃʰ	updated from ǃʰ			
-cce	Copi		ɡ̤ǃ				
-cce	Copi		ŋǃ				
-cce	Copi		ŋ̤ɡǃ				
-cce	Copi		˦				
-cce	Copi		˨				
-							
+cce	Copi		e
+cce	Copi		a
+cce	Copi		o
+cce	Copi		u
+cce	Copi		p
+cce	Copi		pʰ
+cce	Copi		b̤
+cce	Copi		ɓ
+cce	Copi		w
+cce	Copi		m
+cce	Copi		<m̤>	loanwords only
+cce	Copi		mb
+cce	Copi		m̤b̤
+cce	Copi		pf
+cce	Copi		pfʰ
+cce	Copi		b̤v̤
+cce	Copi		f
+cce	Copi		ʋ
+cce	Copi		mbv
+cce	Copi		ps
+cce	Copi		psʰ
+cce	Copi		b̤z̤
+cce	Copi		sʷ
+cce	Copi		mbz
+cce	Copi		t
+cce	Copi		tʰ
+cce	Copi		d̤
+cce	Copi		ɗ
+cce	Copi		r̤
+cce	Copi		l
+cce	Copi		n
+cce	Copi		<n̤>	loanwords only
+cce	Copi		<nd>	loanwords only
+cce	Copi		<n̤d̤>	loanwords only
+cce	Copi		<tl>	loanwords only
+cce	Copi		<tlʱ>	loanwords only
+cce	Copi		<d̤ɮ̤>	loanwords only
+cce	Copi		<ɬ>	loanwords only
+cce	Copi		<ndl>	loanwords only
+cce	Copi		<n̤d̤ɮ̤>	loanwords only
+cce	Copi		ts
+cce	Copi		tsʰ
+cce	Copi		d̤z̤
+cce	Copi		s
+cce	Copi		nz
+cce	Copi		t̠ʃ
+cce	Copi		t̠ʃʰ
+cce	Copi		d̤ʒ̤
+cce	Copi		ʄ
+cce	Copi		<ʃ>	loanwords only
+cce	Copi		j
+cce	Copi		ɲ
+cce	Copi		n̠̩d̠ʒ	updated from ̩ɲdʒ
+cce	Copi		k
+cce	Copi		kʰ
+cce	Copi		ɡ̤
+cce	Copi		ɦ̤
+cce	Copi		ŋ
+cce	Copi		nɡ
+cce	Copi		n̤ɡ̤
+cce	Copi		kǃ	updated from ǃ
+cce	Copi		kǃʰ	updated from ǃʰ
+cce	Copi		ɡ̤ǃ
+cce	Copi		ŋǃ
+cce	Copi		ŋ̤ɡǃ
+cce	Copi		˦
+cce	Copi		˨
+
 xho	Xhosa		i				zone-s.pdf
-xho	Xhosa		e				
-xho	Xhosa		ɛ				
-xho	Xhosa		o				
-xho	Xhosa		ɔ				
-xho	Xhosa		u				
-xho	Xhosa		a				
-xho	Xhosa		pʼ				
-xho	Xhosa		pʰ				
-xho	Xhosa		b̤				
-xho	Xhosa		ɓ				
-xho	Xhosa		f				
-xho	Xhosa		v̤				
-xho	Xhosa		m				
-xho	Xhosa		m̤				
-xho	Xhosa		mpʼ				
-xho	Xhosa		m̤b̤				
-xho	Xhosa		mpfʼ				
-xho	Xhosa		m̤b̤v̤				
-xho	Xhosa		tʼ				
-xho	Xhosa		tʰ				
-xho	Xhosa		d̤				
-xho	Xhosa		n				
-xho	Xhosa		n̤				
-xho	Xhosa		ntʼ				
-xho	Xhosa		n̤d̤				
-xho	Xhosa		ɬ				
-xho	Xhosa		ɮ̤				
-xho	Xhosa		l				
-xho	Xhosa		ntlʼ				
-xho	Xhosa		n̤d̤ɮ̤				
-xho	Xhosa		tsʼ				
-xho	Xhosa		tsʰ				
-xho	Xhosa		s				
-xho	Xhosa		z̤				
-xho	Xhosa		ntsʼ				
-xho	Xhosa		n̤d̤z̤	TODO			
-xho	Xhosa		t̠ʃʼ	updated from tʃʼ			
-xho	Xhosa		t̠ʃʰ	updated from tʃʰ			
-xho	Xhosa		d̠̤ʒ̤	updated from d̤ʒ̤			
-xho	Xhosa		ʃ				
-xho	Xhosa		n̠t̠ʃʼ	updated from ɲtʃʼ			
-xho	Xhosa		n̠̤d̠̤ʒ	updated from ɲ̤d̤ʒ̤			
-xho	Xhosa		cʼ				
-xho	Xhosa		cʰ				
-xho	Xhosa		ɟ̤				
-xho	Xhosa		j				
-xho	Xhosa		ɲ				
-xho	Xhosa		ɲ̤				
-xho	Xhosa		ɲcʼ				
-xho	Xhosa		ɲ̤ɟ̤				
-xho	Xhosa		kʼ				
-xho	Xhosa		kʰ				
-xho	Xhosa		ɡ̤				
-xho	Xhosa		h				
-xho	Xhosa		ɦ̤				
-xho	Xhosa		w				
-xho	Xhosa		ŋ				
-xho	Xhosa		ŋkʼ				
-xho	Xhosa		ŋ̤ɡ̤				
-xho	Xhosa		kxʼ				
-xho	Xhosa		kxʰ				
-xho	Xhosa		x				
-xho	Xhosa		ɣ̤				
-xho	Xhosa		kǀ	ǀ			
-xho	Xhosa		kǀʰ	ǀʰ			
-xho	Xhosa		ɡ̤ǀ				
-xho	Xhosa		ŋǀ				
-xho	Xhosa		kǀʼ	ǀʼ			
-xho	Xhosa		ŋ̤ǀ				
-xho	Xhosa		kǃ	ǃ			
-xho	Xhosa		kǃʰ	ǃʰ			
-xho	Xhosa		ɡ̤ǃ				
-xho	Xhosa		ŋǃ				
-xho	Xhosa		ŋǃʼ				
-xho	Xhosa		ŋ̤ǃ				
-xho	Xhosa		kǁ	ǁ			
-xho	Xhosa		kǁʰ	ǁʰ			
-xho	Xhosa		ɡ̤ǁ				
-xho	Xhosa		ŋǁ				
-xho	Xhosa		ŋǁʼ				
-xho	Xhosa		ŋ̤ǁ				
-xho	Xhosa		˦				
-xho	Xhosa		˨				
-							
+xho	Xhosa		e
+xho	Xhosa		ɛ
+xho	Xhosa		o
+xho	Xhosa		ɔ
+xho	Xhosa		u
+xho	Xhosa		a
+xho	Xhosa		pʼ
+xho	Xhosa		pʰ
+xho	Xhosa		b̤
+xho	Xhosa		ɓ
+xho	Xhosa		f
+xho	Xhosa		v̤
+xho	Xhosa		m
+xho	Xhosa		m̤
+xho	Xhosa		mpʼ
+xho	Xhosa		m̤b̤
+xho	Xhosa		mpfʼ
+xho	Xhosa		m̤b̤v̤
+xho	Xhosa		tʼ
+xho	Xhosa		tʰ
+xho	Xhosa		d̤
+xho	Xhosa		n
+xho	Xhosa		n̤
+xho	Xhosa		ntʼ
+xho	Xhosa		n̤d̤
+xho	Xhosa		ɬ
+xho	Xhosa		ɮ̤
+xho	Xhosa		l
+xho	Xhosa		ntlʼ
+xho	Xhosa		n̤d̤ɮ̤
+xho	Xhosa		tsʼ
+xho	Xhosa		tsʰ
+xho	Xhosa		s
+xho	Xhosa		z̤
+xho	Xhosa		ntsʼ
+xho	Xhosa		n̤d̤z̤	TODO
+xho	Xhosa		t̠ʃʼ	updated from tʃʼ
+xho	Xhosa		t̠ʃʰ	updated from tʃʰ
+xho	Xhosa		d̠̤ʒ̤	updated from d̤ʒ̤
+xho	Xhosa		ʃ
+xho	Xhosa		n̠t̠ʃʼ	updated from ɲtʃʼ
+xho	Xhosa		n̠̤d̠̤ʒ	updated from ɲ̤d̤ʒ̤
+xho	Xhosa		cʼ
+xho	Xhosa		cʰ
+xho	Xhosa		ɟ̤
+xho	Xhosa		j
+xho	Xhosa		ɲ
+xho	Xhosa		ɲ̤
+xho	Xhosa		ɲcʼ
+xho	Xhosa		ɲ̤ɟ̤
+xho	Xhosa		kʼ
+xho	Xhosa		kʰ
+xho	Xhosa		ɡ̤
+xho	Xhosa		h
+xho	Xhosa		ɦ̤
+xho	Xhosa		w
+xho	Xhosa		ŋ
+xho	Xhosa		ŋkʼ
+xho	Xhosa		ŋ̤ɡ̤
+xho	Xhosa		kxʼ
+xho	Xhosa		kxʰ
+xho	Xhosa		x
+xho	Xhosa		ɣ̤
+xho	Xhosa		kǀ	ǀ
+xho	Xhosa		kǀʰ	ǀʰ
+xho	Xhosa		ɡ̤ǀ
+xho	Xhosa		ŋǀ
+xho	Xhosa		kǀʼ	ǀʼ
+xho	Xhosa		ŋ̤ǀ
+xho	Xhosa		kǃ	ǃ
+xho	Xhosa		kǃʰ	ǃʰ
+xho	Xhosa		ɡ̤ǃ
+xho	Xhosa		ŋǃ
+xho	Xhosa		ŋǃʼ
+xho	Xhosa		ŋ̤ǃ
+xho	Xhosa		kǁ	ǁ
+xho	Xhosa		kǁʰ	ǁʰ
+xho	Xhosa		ɡ̤ǁ
+xho	Xhosa		ŋǁ
+xho	Xhosa		ŋǁʼ
+xho	Xhosa		ŋ̤ǁ
+xho	Xhosa		˦
+xho	Xhosa		˨
+
 akp	Siwu		b				akp.pdf
-akp	Siwu		p				
-akp	Siwu		t				
-akp	Siwu		ɖ				
-akp	Siwu		k				
-akp	Siwu		ɡ				
-akp	Siwu		ɡb				
-akp	Siwu		kp				
-akp	Siwu		f				
-akp	Siwu		s				
-akp	Siwu		d̠ʒ				
-akp	Siwu		t̠ʃ	updated from tʃ			
-akp	Siwu		m				
-akp	Siwu		n				
-akp	Siwu		l				
-akp	Siwu		r				
-akp	Siwu		ɲ				
-akp	Siwu		w				
-akp	Siwu		j				
-akp	Siwu		ʕ		[ʕ]		
-akp	Siwu		ʕ		[ɥ]		
-akp	Siwu		i				
-akp	Siwu		e				
-akp	Siwu		a				
-akp	Siwu		o				
-akp	Siwu		u				
-akp	Siwu		ɔ				
-akp	Siwu		ɛ				
-akp	Siwu		ĩ				
-akp	Siwu		ẽ				
-akp	Siwu		ã				
-akp	Siwu		õ				
-akp	Siwu		ũ				
-akp	Siwu		ɔ̃				
-akp	Siwu		ɛ̃				
-akp	Siwu		˦				
-akp	Siwu		˧				
-akp	Siwu		˨				
-							
+akp	Siwu		p
+akp	Siwu		t
+akp	Siwu		ɖ
+akp	Siwu		k
+akp	Siwu		ɡ
+akp	Siwu		ɡb
+akp	Siwu		kp
+akp	Siwu		f
+akp	Siwu		s
+akp	Siwu		d̠ʒ
+akp	Siwu		t̠ʃ	updated from tʃ
+akp	Siwu		m
+akp	Siwu		n
+akp	Siwu		l
+akp	Siwu		r
+akp	Siwu		ɲ
+akp	Siwu		w
+akp	Siwu		j
+akp	Siwu		ʕ		[ʕ]
+akp	Siwu		ʕ		[ɥ]
+akp	Siwu		i
+akp	Siwu		e
+akp	Siwu		a
+akp	Siwu		o
+akp	Siwu		u
+akp	Siwu		ɔ
+akp	Siwu		ɛ
+akp	Siwu		ĩ
+akp	Siwu		ẽ
+akp	Siwu		ã
+akp	Siwu		õ
+akp	Siwu		ũ
+akp	Siwu		ɔ̃
+akp	Siwu		ɛ̃
+akp	Siwu		˦
+akp	Siwu		˧
+akp	Siwu		˨
+
 bun	Sherbro		p				bun.pdf
-bun	Sherbro		b				
-bun	Sherbro		m				
-bun	Sherbro		t̪				
-bun	Sherbro		d				
-bun	Sherbro		t				
-bun	Sherbro		t̠ʃ				
-bun	Sherbro		d̠ʒ				
-bun	Sherbro		k				
-bun	Sherbro		ɡ		[ɡ]		
-bun	Sherbro		ɡ		[ɣ]		
-bun	Sherbro		ʔ				
-bun	Sherbro		ɡb				
-bun	Sherbro		n				
-bun	Sherbro		ɲ				
-bun	Sherbro		ŋ				
-bun	Sherbro		l				
-bun	Sherbro		ɽ				
-bun	Sherbro		f				
-bun	Sherbro		v		[v]	before front vowels	
-bun	Sherbro		v		[w]	before back vowels	
-bun	Sherbro		s		[s]		
-bun	Sherbro		s		[ʃ]	before [i]	
-bun	Sherbro		z				
-bun	Sherbro		ʃ				
-bun	Sherbro		h		[h]		
-bun	Sherbro		h		[ᵑh]	when followed by a nasal, [h] is prenasalized	
-bun	Sherbro		j				
-bun	Sherbro		i		[i]		
-bun	Sherbro		i		[ɨ]		
-bun	Sherbro		ɪ		[ɪ]		
-bun	Sherbro		ɪ		[e]		
-bun	Sherbro		ɛ		[ɛ]		
-bun	Sherbro		ɛ		[ə]		
-bun	Sherbro		a		[a]		
-bun	Sherbro		a		[æ]		
-bun	Sherbro		ʊ		[ʊ]		
-bun	Sherbro		ʊ		[o]		
-bun	Sherbro		ɔ				
-bun	Sherbro		u				
-							
+bun	Sherbro		b
+bun	Sherbro		m
+bun	Sherbro		t̪
+bun	Sherbro		d
+bun	Sherbro		t
+bun	Sherbro		t̠ʃ
+bun	Sherbro		d̠ʒ
+bun	Sherbro		k
+bun	Sherbro		ɡ		[ɡ]
+bun	Sherbro		ɡ		[ɣ]
+bun	Sherbro		ʔ
+bun	Sherbro		ɡb
+bun	Sherbro		n
+bun	Sherbro		ɲ
+bun	Sherbro		ŋ
+bun	Sherbro		l
+bun	Sherbro		ɽ
+bun	Sherbro		f
+bun	Sherbro		v		[v]	before front vowels
+bun	Sherbro		v		[w]	before back vowels
+bun	Sherbro		s		[s]
+bun	Sherbro		s		[ʃ]	before [i]
+bun	Sherbro		z
+bun	Sherbro		ʃ
+bun	Sherbro		h		[h]
+bun	Sherbro		h		[ᵑh]	when followed by a nasal, [h] is prenasalized
+bun	Sherbro		j
+bun	Sherbro		i		[i]
+bun	Sherbro		i		[ɨ]
+bun	Sherbro		ɪ		[ɪ]
+bun	Sherbro		ɪ		[e]
+bun	Sherbro		ɛ		[ɛ]
+bun	Sherbro		ɛ		[ə]
+bun	Sherbro		a		[a]
+bun	Sherbro		a		[æ]
+bun	Sherbro		ʊ		[ʊ]
+bun	Sherbro		ʊ		[o]
+bun	Sherbro		ɔ
+bun	Sherbro		u
+
 buy	Mmani		p				buy.pdf
-buy	Mmani		b				
-buy	Mmani		m				
-buy	Mmani		t				
-buy	Mmani		d		[d]		
-buy	Mmani		d		[l]		
-buy	Mmani		ts		[ts]		
-buy	Mmani		ts		[t̠ʃ]	before [i]	
-buy	Mmani		t̠ʃ				
-buy	Mmani		d̠ʒ				
-buy	Mmani		k				
-buy	Mmani		ɡ				
-buy	Mmani		ʔ				
-buy	Mmani		ɡbʷ				
-buy	Mmani		n				
-buy	Mmani		ɲ				
-buy	Mmani		ŋ				
-buy	Mmani		ɽ				
-buy	Mmani		v				
-buy	Mmani		s				
-buy	Mmani		z				
-buy	Mmani		ʃ				
-buy	Mmani		f		[f]		
-buy	Mmani		f		[w]	before [o]	
-buy	Mmani		j				
-buy	Mmani		i				
-buy	Mmani		e				
-buy	Mmani		ɛ				
-buy	Mmani		a				
-buy	Mmani		o				
-buy	Mmani		ɔ				
-buy	Mmani		u				
-buy	Mmani		ĩ				
-buy	Mmani		ẽ				
-buy	Mmani		ɛ̃				
-buy	Mmani		ã				
-buy	Mmani		õ				
-buy	Mmani		ɔ̃				
-buy	Mmani		ũ				
-							
+buy	Mmani		b
+buy	Mmani		m
+buy	Mmani		t
+buy	Mmani		d		[d]
+buy	Mmani		d		[l]
+buy	Mmani		ts		[ts]
+buy	Mmani		ts		[t̠ʃ]	before [i]
+buy	Mmani		t̠ʃ
+buy	Mmani		d̠ʒ
+buy	Mmani		k
+buy	Mmani		ɡ
+buy	Mmani		ʔ
+buy	Mmani		ɡbʷ
+buy	Mmani		n
+buy	Mmani		ɲ
+buy	Mmani		ŋ
+buy	Mmani		ɽ
+buy	Mmani		v
+buy	Mmani		s
+buy	Mmani		z
+buy	Mmani		ʃ
+buy	Mmani		f		[f]
+buy	Mmani		f		[w]	before [o]
+buy	Mmani		j
+buy	Mmani		i
+buy	Mmani		e
+buy	Mmani		ɛ
+buy	Mmani		a
+buy	Mmani		o
+buy	Mmani		ɔ
+buy	Mmani		u
+buy	Mmani		ĩ
+buy	Mmani		ẽ
+buy	Mmani		ɛ̃
+buy	Mmani		ã
+buy	Mmani		õ
+buy	Mmani		ɔ̃
+buy	Mmani		ũ
+
 cpn	Hill Guang	Gwa	b				cpn.pdf
-cpn	Hill Guang	Gwa	kp				
-cpn	Hill Guang	Gwa	d̪				
-cpn	Hill Guang	Gwa	t̪ʰ				
-cpn	Hill Guang	Gwa	ɡʲ				
-cpn	Hill Guang	Gwa	kʲ				
-cpn	Hill Guang	Gwa	f				
-cpn	Hill Guang	Gwa	m				
-cpn	Hill Guang	Gwa	ç				
-cpn	Hill Guang	Gwa	ɲ				
-cpn	Hill Guang	Gwa	s̪				
-cpn	Hill Guang	Gwa	n̪				
-cpn	Hill Guang	Gwa	l̪				
-cpn	Hill Guang	Gwa	l̪ʷ				
-cpn	Hill Guang	Gwa	dʷ				
-cpn	Hill Guang	Gwa	tʷ				
-cpn	Hill Guang	Gwa	hʷ				
-cpn	Hill Guang	Gwa	ɲʷ				
-cpn	Hill Guang	Gwa	ɡ				
-cpn	Hill Guang	Gwa	kʰ				
-cpn	Hill Guang	Gwa	h				
-cpn	Hill Guang	Gwa	ŋ				
-cpn	Hill Guang	Gwa	ɡʷ				
-cpn	Hill Guang	Gwa	ŋʷ				
-cpn	Hill Guang	Gwa	kʷ				
-cpn	Hill Guang	Gwa	w				
-cpn	Hill Guang	Gwa	i		[i]		
-cpn	Hill Guang	Gwa	i		[ɪ]		
-cpn	Hill Guang	Gwa	e		[e]		
-cpn	Hill Guang	Gwa	e		[ɛ]		
-cpn	Hill Guang	Gwa	æ		[æ]		
-cpn	Hill Guang	Gwa	æ		[a]		
-cpn	Hill Guang	Gwa	o		[o]		
-cpn	Hill Guang	Gwa	o		[ɔ]		
-cpn	Hill Guang	Gwa	u		[u]		
-cpn	Hill Guang	Gwa	u		[ʊ]		
-cpn	Hill Guang	Gwa	ĩ		[ĩ]		
-cpn	Hill Guang	Gwa	ĩ		[ɪ̃]		
-cpn	Hill Guang	Gwa	ẽ		[ẽ]		
-cpn	Hill Guang	Gwa	ẽ		[ɛ̃]		
-cpn	Hill Guang	Gwa	æ̃		[æ̃]		
-cpn	Hill Guang	Gwa	æ̃		[ã]		
-cpn	Hill Guang	Gwa	õ		[õ]		
-cpn	Hill Guang	Gwa	õ		[ɔ̃]		
-cpn	Hill Guang	Gwa	ũ		[ũ]		
-cpn	Hill Guang	Gwa	ũ		[ʊ̃]		
-cpn	Hill Guang	Gwa	˦				
-cpn	Hill Guang	Gwa	˨				
-							
+cpn	Hill Guang	Gwa	kp
+cpn	Hill Guang	Gwa	d̪
+cpn	Hill Guang	Gwa	t̪ʰ
+cpn	Hill Guang	Gwa	ɡʲ
+cpn	Hill Guang	Gwa	kʲ
+cpn	Hill Guang	Gwa	f
+cpn	Hill Guang	Gwa	m
+cpn	Hill Guang	Gwa	ç
+cpn	Hill Guang	Gwa	ɲ
+cpn	Hill Guang	Gwa	s̪
+cpn	Hill Guang	Gwa	n̪
+cpn	Hill Guang	Gwa	l̪
+cpn	Hill Guang	Gwa	l̪ʷ
+cpn	Hill Guang	Gwa	dʷ
+cpn	Hill Guang	Gwa	tʷ
+cpn	Hill Guang	Gwa	hʷ
+cpn	Hill Guang	Gwa	ɲʷ
+cpn	Hill Guang	Gwa	ɡ
+cpn	Hill Guang	Gwa	kʰ
+cpn	Hill Guang	Gwa	h
+cpn	Hill Guang	Gwa	ŋ
+cpn	Hill Guang	Gwa	ɡʷ
+cpn	Hill Guang	Gwa	ŋʷ
+cpn	Hill Guang	Gwa	kʷ
+cpn	Hill Guang	Gwa	w
+cpn	Hill Guang	Gwa	i		[i]
+cpn	Hill Guang	Gwa	i		[ɪ]
+cpn	Hill Guang	Gwa	e		[e]
+cpn	Hill Guang	Gwa	e		[ɛ]
+cpn	Hill Guang	Gwa	æ		[æ]
+cpn	Hill Guang	Gwa	æ		[a]
+cpn	Hill Guang	Gwa	o		[o]
+cpn	Hill Guang	Gwa	o		[ɔ]
+cpn	Hill Guang	Gwa	u		[u]
+cpn	Hill Guang	Gwa	u		[ʊ]
+cpn	Hill Guang	Gwa	ĩ		[ĩ]
+cpn	Hill Guang	Gwa	ĩ		[ɪ̃]
+cpn	Hill Guang	Gwa	ẽ		[ẽ]
+cpn	Hill Guang	Gwa	ẽ		[ɛ̃]
+cpn	Hill Guang	Gwa	æ̃		[æ̃]
+cpn	Hill Guang	Gwa	æ̃		[ã]
+cpn	Hill Guang	Gwa	õ		[õ]
+cpn	Hill Guang	Gwa	õ		[ɔ̃]
+cpn	Hill Guang	Gwa	ũ		[ũ]
+cpn	Hill Guang	Gwa	ũ		[ʊ̃]
+cpn	Hill Guang	Gwa	˦
+cpn	Hill Guang	Gwa	˨
+
 fap	Ndut-Falor	Falor	p				fap.pdf
-fap	Ndut-Falor	Falor	b				
-fap	Ndut-Falor	Falor	t				
-fap	Ndut-Falor	Falor	d				
-fap	Ndut-Falor	Falor	k				
-fap	Ndut-Falor	Falor	ɡ				
-fap	Ndut-Falor	Falor	ʔ				
-fap	Ndut-Falor	Falor	t̠ʃ				
-fap	Ndut-Falor	Falor	d̠ʒ				
-fap	Ndut-Falor	Falor	m				
-fap	Ndut-Falor	Falor	n				
-fap	Ndut-Falor	Falor	ɲ				
-fap	Ndut-Falor	Falor	ŋ				
-fap	Ndut-Falor	Falor	l				
-fap	Ndut-Falor	Falor	r				
-fap	Ndut-Falor	Falor	f		[f]		
-fap	Ndut-Falor	Falor	f		[v]		
-fap	Ndut-Falor	Falor	s		[s]		
-fap	Ndut-Falor	Falor	s		[z]		
-fap	Ndut-Falor	Falor	x		[x]		
-fap	Ndut-Falor	Falor	x		[h]		
-fap	Ndut-Falor	Falor	w				
-fap	Ndut-Falor	Falor	j				
-fap	Ndut-Falor	Falor	mb				
-fap	Ndut-Falor	Falor	nd				
-fap	Ndut-Falor	Falor	n̠d̠ʒ	updated from ɲdʒ			
-fap	Ndut-Falor	Falor	ɓ				
-fap	Ndut-Falor	Falor	ɗ		[ɗ]	source symbol appears to imply an implosive lateral, but distribution is before hi back vowels, assumed to be palatal implosive here but questionable	
-fap	Ndut-Falor	Falor	ɗ		[ʄ]	source symbol appears to imply an implosive lateral, but distribution is before hi back vowels, assumed to be palatal implosive here but questionable	
-fap	Ndut-Falor	Falor	ɗʒ		[ɗʒ]		
-fap	Ndut-Falor	Falor	ɗʒ		[ʄ]		
-fap	Ndut-Falor	Falor	i		[i]		
-fap	Ndut-Falor	Falor	i		[ɪ]		
-fap	Ndut-Falor	Falor	i		[iə]		
-fap	Ndut-Falor	Falor	i		[ɪə]		
-fap	Ndut-Falor	Falor	u		[u]		
-fap	Ndut-Falor	Falor	u		[ʊ]		
-fap	Ndut-Falor	Falor	ʌ		[ʌ]		
-fap	Ndut-Falor	Falor	ʌ		[ɔ]		
-fap	Ndut-Falor	Falor	e		[e]		
-fap	Ndut-Falor	Falor	e		[ɛ]		
-fap	Ndut-Falor	Falor	o		[o]		
-fap	Ndut-Falor	Falor	o		[ɔ]		
-fap	Ndut-Falor	Falor	a		[a]		
-fap	Ndut-Falor	Falor	a		[ə]		
-fap	Ndut-Falor	Falor	ʉ				
-fap	Ndut-Falor	Falor	iˑ		[iˑ]		
-fap	Ndut-Falor	Falor	iˑ		[ɪˑ]		
-fap	Ndut-Falor	Falor	uˑ		[uˑ]		
-fap	Ndut-Falor	Falor	uˑ		[ʊˑ]		
-fap	Ndut-Falor	Falor	oˑ		[oˑ]		
-fap	Ndut-Falor	Falor	oˑ		[ɔˑ]		
-fap	Ndut-Falor	Falor	eˑ		[eˑ]		
-fap	Ndut-Falor	Falor	eˑ		[ɛˑ]		
-fap	Ndut-Falor	Falor	aˑ		[aˑ]		
-fap	Ndut-Falor	Falor	aˑ		[əˑ]		
-fap	Ndut-Falor	Falor	iː		[iː]		
-fap	Ndut-Falor	Falor	iː		[ɪː]		
-fap	Ndut-Falor	Falor	uː		[uː]		
-fap	Ndut-Falor	Falor	uː		[ʊː]		
-fap	Ndut-Falor	Falor	oː		[oː]		
-fap	Ndut-Falor	Falor	oː		[ɔː]		
-fap	Ndut-Falor	Falor	eː		[eː]		
-fap	Ndut-Falor	Falor	eː		[ɛː]		
-fap	Ndut-Falor	Falor	aː		[aː]		
-fap	Ndut-Falor	Falor	aː		[əː]		
-							
+fap	Ndut-Falor	Falor	b
+fap	Ndut-Falor	Falor	t
+fap	Ndut-Falor	Falor	d
+fap	Ndut-Falor	Falor	k
+fap	Ndut-Falor	Falor	ɡ
+fap	Ndut-Falor	Falor	ʔ
+fap	Ndut-Falor	Falor	t̠ʃ
+fap	Ndut-Falor	Falor	d̠ʒ
+fap	Ndut-Falor	Falor	m
+fap	Ndut-Falor	Falor	n
+fap	Ndut-Falor	Falor	ɲ
+fap	Ndut-Falor	Falor	ŋ
+fap	Ndut-Falor	Falor	l
+fap	Ndut-Falor	Falor	r
+fap	Ndut-Falor	Falor	f		[f]
+fap	Ndut-Falor	Falor	f		[v]
+fap	Ndut-Falor	Falor	s		[s]
+fap	Ndut-Falor	Falor	s		[z]
+fap	Ndut-Falor	Falor	x		[x]
+fap	Ndut-Falor	Falor	x		[h]
+fap	Ndut-Falor	Falor	w
+fap	Ndut-Falor	Falor	j
+fap	Ndut-Falor	Falor	mb
+fap	Ndut-Falor	Falor	nd
+fap	Ndut-Falor	Falor	n̠d̠ʒ	updated from ɲdʒ
+fap	Ndut-Falor	Falor	ɓ
+fap	Ndut-Falor	Falor	ɗ		[ɗ]	source symbol appears to imply an implosive lateral, but distribution is before hi back vowels, assumed to be palatal implosive here but questionable
+fap	Ndut-Falor	Falor	ɗ		[ʄ]	source symbol appears to imply an implosive lateral, but distribution is before hi back vowels, assumed to be palatal implosive here but questionable
+fap	Ndut-Falor	Falor	ɗʒ		[ɗʒ]
+fap	Ndut-Falor	Falor	ɗʒ		[ʄ]
+fap	Ndut-Falor	Falor	i		[i]
+fap	Ndut-Falor	Falor	i		[ɪ]
+fap	Ndut-Falor	Falor	i		[iə]
+fap	Ndut-Falor	Falor	i		[ɪə]
+fap	Ndut-Falor	Falor	u		[u]
+fap	Ndut-Falor	Falor	u		[ʊ]
+fap	Ndut-Falor	Falor	ʌ		[ʌ]
+fap	Ndut-Falor	Falor	ʌ		[ɔ]
+fap	Ndut-Falor	Falor	e		[e]
+fap	Ndut-Falor	Falor	e		[ɛ]
+fap	Ndut-Falor	Falor	o		[o]
+fap	Ndut-Falor	Falor	o		[ɔ]
+fap	Ndut-Falor	Falor	a		[a]
+fap	Ndut-Falor	Falor	a		[ə]
+fap	Ndut-Falor	Falor	ʉ
+fap	Ndut-Falor	Falor	iˑ		[iˑ]
+fap	Ndut-Falor	Falor	iˑ		[ɪˑ]
+fap	Ndut-Falor	Falor	uˑ		[uˑ]
+fap	Ndut-Falor	Falor	uˑ		[ʊˑ]
+fap	Ndut-Falor	Falor	oˑ		[oˑ]
+fap	Ndut-Falor	Falor	oˑ		[ɔˑ]
+fap	Ndut-Falor	Falor	eˑ		[eˑ]
+fap	Ndut-Falor	Falor	eˑ		[ɛˑ]
+fap	Ndut-Falor	Falor	aˑ		[aˑ]
+fap	Ndut-Falor	Falor	aˑ		[əˑ]
+fap	Ndut-Falor	Falor	iː		[iː]
+fap	Ndut-Falor	Falor	iː		[ɪː]
+fap	Ndut-Falor	Falor	uː		[uː]
+fap	Ndut-Falor	Falor	uː		[ʊː]
+fap	Ndut-Falor	Falor	oː		[oː]
+fap	Ndut-Falor	Falor	oː		[ɔː]
+fap	Ndut-Falor	Falor	eː		[eː]
+fap	Ndut-Falor	Falor	eː		[ɛː]
+fap	Ndut-Falor	Falor	aː		[aː]
+fap	Ndut-Falor	Falor	aː		[əː]
+
 gur	Frafra	Gudeni	p				gur.pdf
-gur	Frafra	Gudeni	t				
-gur	Frafra	Gudeni	d				
-gur	Frafra	Gudeni	kp				
-gur	Frafra	Gudeni	b				
-gur	Frafra	Gudeni	d				
-gur	Frafra	Gudeni	ɡ		[ɡ]		
-gur	Frafra	Gudeni	ɡ		[ɣ]	intervocalic	
-gur	Frafra	Gudeni	ʔ				
-gur	Frafra	Gudeni	f				
-gur	Frafra	Gudeni	s				
-gur	Frafra	Gudeni	v				
-gur	Frafra	Gudeni	m				
-gur	Frafra	Gudeni	n				
-gur	Frafra	Gudeni	ŋ		[ŋ]		
-gur	Frafra	Gudeni	ŋ		[ŋm]	word-initial	
-gur	Frafra	Gudeni	l				
-gur	Frafra	Gudeni	r				
-gur	Frafra	Gudeni	w				
-gur	Frafra	Gudeni	j				
-gur	Frafra	Gudeni	h		[h]		
-gur	Frafra	Gudeni	h		[s]	before front vowels	
-gur	Frafra	Gudeni	h		[f]	before back vowels	
-gur	Frafra	Gudeni	ɡb				
-gur	Frafra	Gudeni	ɲ				
-gur	Frafra	Gudeni	i				
-gur	Frafra	Gudeni	ɪ				
-gur	Frafra	Gudeni	<e>	rare			
-gur	Frafra	Gudeni	ɛ				
-gur	Frafra	Gudeni	u				
-gur	Frafra	Gudeni	o				
-gur	Frafra	Gudeni	ɔ				
-gur	Frafra	Gudeni	a				
-gur	Frafra	Gudeni	˦	no tone given, however most Gur languages are considered to have underlying 2 tone distinction			
-gur	Frafra	Gudeni	˨	no tone given, however most Gur languages are considered to have underlying 2 tone distinction			
-							
+gur	Frafra	Gudeni	t
+gur	Frafra	Gudeni	d
+gur	Frafra	Gudeni	kp
+gur	Frafra	Gudeni	b
+gur	Frafra	Gudeni	d
+gur	Frafra	Gudeni	ɡ		[ɡ]
+gur	Frafra	Gudeni	ɡ		[ɣ]	intervocalic
+gur	Frafra	Gudeni	ʔ
+gur	Frafra	Gudeni	f
+gur	Frafra	Gudeni	s
+gur	Frafra	Gudeni	v
+gur	Frafra	Gudeni	m
+gur	Frafra	Gudeni	n
+gur	Frafra	Gudeni	ŋ		[ŋ]
+gur	Frafra	Gudeni	ŋ		[ŋm]	word-initial
+gur	Frafra	Gudeni	l
+gur	Frafra	Gudeni	r
+gur	Frafra	Gudeni	w
+gur	Frafra	Gudeni	j
+gur	Frafra	Gudeni	h		[h]
+gur	Frafra	Gudeni	h		[s]	before front vowels
+gur	Frafra	Gudeni	h		[f]	before back vowels
+gur	Frafra	Gudeni	ɡb
+gur	Frafra	Gudeni	ɲ
+gur	Frafra	Gudeni	i
+gur	Frafra	Gudeni	ɪ
+gur	Frafra	Gudeni	<e>	rare
+gur	Frafra	Gudeni	ɛ
+gur	Frafra	Gudeni	u
+gur	Frafra	Gudeni	o
+gur	Frafra	Gudeni	ɔ
+gur	Frafra	Gudeni	a
+gur	Frafra	Gudeni	˦	no tone given, however most Gur languages are considered to have underlying 2 tone distinction
+gur	Frafra	Gudeni	˨	no tone given, however most Gur languages are considered to have underlying 2 tone distinction
+
 lip	Likpe	Bakwa	˦				lip.pdf
-lip	Likpe	Bakwa	˨				
-lip	Likpe	Bakwa	˧				
-lip	Likpe	Bakwa	<p>	rare			
-lip	Likpe	Bakwa	b				
-lip	Likpe	Bakwa	t				
-lip	Likpe	Bakwa	d				
-lip	Likpe	Bakwa	k				
-lip	Likpe	Bakwa	<ɡ>	rare			
-lip	Likpe	Bakwa	kp				
-lip	Likpe	Bakwa	ɡb				
-lip	Likpe	Bakwa	f				
-lip	Likpe	Bakwa	s				
-lip	Likpe	Bakwa	ʃ				
-lip	Likpe	Bakwa	t̠ʃ				
-lip	Likpe	Bakwa	d̠ʒ				
-lip	Likpe	Bakwa	m				
-lip	Likpe	Bakwa	n				
-lip	Likpe	Bakwa	ɲ				
-lip	Likpe	Bakwa	ŋ				
-lip	Likpe	Bakwa	w				
-lip	Likpe	Bakwa	l				
-lip	Likpe	Bakwa	j				
-lip	Likpe	Bakwa	ʔ				
-lip	Likpe	Bakwa	i				
-lip	Likpe	Bakwa	ĩ				
-lip	Likpe	Bakwa	e				
-lip	Likpe	Bakwa	ɛ				
-lip	Likpe	Bakwa	œ				
-lip	Likpe	Bakwa	ã				
-lip	Likpe	Bakwa	õ				
-lip	Likpe	Bakwa	ũ				
-lip	Likpe	Bakwa	ɔ̃				
-							
+lip	Likpe	Bakwa	˨
+lip	Likpe	Bakwa	˧
+lip	Likpe	Bakwa	<p>	rare
+lip	Likpe	Bakwa	b
+lip	Likpe	Bakwa	t
+lip	Likpe	Bakwa	d
+lip	Likpe	Bakwa	k
+lip	Likpe	Bakwa	<ɡ>	rare
+lip	Likpe	Bakwa	kp
+lip	Likpe	Bakwa	ɡb
+lip	Likpe	Bakwa	f
+lip	Likpe	Bakwa	s
+lip	Likpe	Bakwa	ʃ
+lip	Likpe	Bakwa	t̠ʃ
+lip	Likpe	Bakwa	d̠ʒ
+lip	Likpe	Bakwa	m
+lip	Likpe	Bakwa	n
+lip	Likpe	Bakwa	ɲ
+lip	Likpe	Bakwa	ŋ
+lip	Likpe	Bakwa	w
+lip	Likpe	Bakwa	l
+lip	Likpe	Bakwa	j
+lip	Likpe	Bakwa	ʔ
+lip	Likpe	Bakwa	i
+lip	Likpe	Bakwa	ĩ
+lip	Likpe	Bakwa	e
+lip	Likpe	Bakwa	ɛ
+lip	Likpe	Bakwa	œ
+lip	Likpe	Bakwa	ã
+lip	Likpe	Bakwa	õ
+lip	Likpe	Bakwa	ũ
+lip	Likpe	Bakwa	ɔ̃
+
 maw	Mampruli	Walewale	p				maw.pdf
-maw	Mampruli	Walewale	b				
-maw	Mampruli	Walewale	t				
-maw	Mampruli	Walewale	d				
-maw	Mampruli	Walewale	t̠ʃ				
-maw	Mampruli	Walewale	d̠ʒ				
-maw	Mampruli	Walewale	k		[k]		
-maw	Mampruli	Walewale	k		[ʔ]		
-maw	Mampruli	Walewale	ɡ				
-maw	Mampruli	Walewale	kp		[kp]		
-maw	Mampruli	Walewale	kp		[cp]		
-maw	Mampruli	Walewale	ɡb		[ɡb]		
-maw	Mampruli	Walewale	ɡb		[ɟb]		
-maw	Mampruli	Walewale	f				
-maw	Mampruli	Walewale	v				
-maw	Mampruli	Walewale	s		[s]		
-maw	Mampruli	Walewale	s		[ʃ]		
-maw	Mampruli	Walewale	s		[h]		
-maw	Mampruli	Walewale	z		[z]		
-maw	Mampruli	Walewale	z		[ʒ]		
-maw	Mampruli	Walewale	m				
-maw	Mampruli	Walewale	n				
-maw	Mampruli	Walewale	ɲ				
-maw	Mampruli	Walewale	ŋ				
-maw	Mampruli	Walewale	ŋm				
-maw	Mampruli	Walewale	l				
-maw	Mampruli	Walewale	r				
-maw	Mampruli	Walewale	w				
-maw	Mampruli	Walewale	j				
-maw	Mampruli	Walewale	h				
-maw	Mampruli	Walewale	i		[i]		
-maw	Mampruli	Walewale	i		[ɨ]	before velars	
-maw	Mampruli	Walewale	e				
-maw	Mampruli	Walewale	a				
-maw	Mampruli	Walewale	o				
-maw	Mampruli	Walewale	u				
-maw	Mampruli	Walewale	iː		[iː]		
-maw	Mampruli	Walewale	iː		[ɨː]	before velars	
-maw	Mampruli	Walewale	eː				
-maw	Mampruli	Walewale	aː				
-maw	Mampruli	Walewale	oː				
-maw	Mampruli	Walewale	uː				
-maw	Mampruli	Walewale	˨				
-maw	Mampruli	Walewale	˦				
-							
+maw	Mampruli	Walewale	b
+maw	Mampruli	Walewale	t
+maw	Mampruli	Walewale	d
+maw	Mampruli	Walewale	t̠ʃ
+maw	Mampruli	Walewale	d̠ʒ
+maw	Mampruli	Walewale	k		[k]
+maw	Mampruli	Walewale	k		[ʔ]
+maw	Mampruli	Walewale	ɡ
+maw	Mampruli	Walewale	kp		[kp]
+maw	Mampruli	Walewale	kp		[cp]
+maw	Mampruli	Walewale	ɡb		[ɡb]
+maw	Mampruli	Walewale	ɡb		[ɟb]
+maw	Mampruli	Walewale	f
+maw	Mampruli	Walewale	v
+maw	Mampruli	Walewale	s		[s]
+maw	Mampruli	Walewale	s		[ʃ]
+maw	Mampruli	Walewale	s		[h]
+maw	Mampruli	Walewale	z		[z]
+maw	Mampruli	Walewale	z		[ʒ]
+maw	Mampruli	Walewale	m
+maw	Mampruli	Walewale	n
+maw	Mampruli	Walewale	ɲ
+maw	Mampruli	Walewale	ŋ
+maw	Mampruli	Walewale	ŋm
+maw	Mampruli	Walewale	l
+maw	Mampruli	Walewale	r
+maw	Mampruli	Walewale	w
+maw	Mampruli	Walewale	j
+maw	Mampruli	Walewale	h
+maw	Mampruli	Walewale	i		[i]
+maw	Mampruli	Walewale	i		[ɨ]	before velars
+maw	Mampruli	Walewale	e
+maw	Mampruli	Walewale	a
+maw	Mampruli	Walewale	o
+maw	Mampruli	Walewale	u
+maw	Mampruli	Walewale	iː		[iː]
+maw	Mampruli	Walewale	iː		[ɨː]	before velars
+maw	Mampruli	Walewale	eː
+maw	Mampruli	Walewale	aː
+maw	Mampruli	Walewale	oː
+maw	Mampruli	Walewale	uː
+maw	Mampruli	Walewale	˨
+maw	Mampruli	Walewale	˦
+
 toi	Shanjo		i				Bostoen_Bantu_M.pdf
-toi	Shanjo		e				
-toi	Shanjo		a				
-toi	Shanjo		o				
-toi	Shanjo		u				
-toi	Shanjo		<p>	loanwords only			
-toi	Shanjo		t				
-toi	Shanjo		k				
-toi	Shanjo		ɡ				
-toi	Shanjo		m				
-toi	Shanjo		n				
-toi	Shanjo		ɲ				
-toi	Shanjo		ŋ				
-toi	Shanjo		β				
-toi	Shanjo		f				
-toi	Shanjo		v				
-toi	Shanjo		s				
-toi	Shanjo		z				
-toi	Shanjo		ʃ				
-toi	Shanjo		<h>	loanwords only			
-toi	Shanjo		˦				
-toi	Shanjo		˨				
-toi	Shanjo		˦˨				
-toi	Shanjo		t̠ʃ				
-toi	Shanjo		d̠ʒ				
-toi	Shanjo		l				
-toi	Shanjo		w				
-toi	Shanjo		j				
-toi	Shanjo		mp				
-toi	Shanjo		mb				
-toi	Shanjo		nt				
-toi	Shanjo		nd				
-toi	Shanjo		ŋk				
-toi	Shanjo		ŋɡ				
-toi	Shanjo		ɱf				
-toi	Shanjo		ɱv				
-toi	Shanjo		ns				
-toi	Shanjo		nz				
-toi	Shanjo		n̠ʃ	updated from nʃ			
-toi	Shanjo		n̠t̠ʃ	updated from ɲtʃ			
-toi	Shanjo		n̠d̠ʒ	updated from ɲdʒ			
-							
+toi	Shanjo		e
+toi	Shanjo		a
+toi	Shanjo		o
+toi	Shanjo		u
+toi	Shanjo		<p>	loanwords only
+toi	Shanjo		t
+toi	Shanjo		k
+toi	Shanjo		ɡ
+toi	Shanjo		m
+toi	Shanjo		n
+toi	Shanjo		ɲ
+toi	Shanjo		ŋ
+toi	Shanjo		β
+toi	Shanjo		f
+toi	Shanjo		v
+toi	Shanjo		s
+toi	Shanjo		z
+toi	Shanjo		ʃ
+toi	Shanjo		<h>	loanwords only
+toi	Shanjo		˦
+toi	Shanjo		˨
+toi	Shanjo		˦˨
+toi	Shanjo		t̠ʃ
+toi	Shanjo		d̠ʒ
+toi	Shanjo		l
+toi	Shanjo		w
+toi	Shanjo		j
+toi	Shanjo		mp
+toi	Shanjo		mb
+toi	Shanjo		nt
+toi	Shanjo		nd
+toi	Shanjo		ŋk
+toi	Shanjo		ŋɡ
+toi	Shanjo		ɱf
+toi	Shanjo		ɱv
+toi	Shanjo		ns
+toi	Shanjo		nz
+toi	Shanjo		n̠ʃ	updated from nʃ
+toi	Shanjo		n̠t̠ʃ	updated from ɲtʃ
+toi	Shanjo		n̠d̠ʒ	updated from ɲdʒ
+
 pbp	Pajade	Badiaranke	m				pbp.pdf
-pbp	Pajade	Badiaranke	n				
-pbp	Pajade	Badiaranke	ɲ				
-pbp	Pajade	Badiaranke	ŋ				
-pbp	Pajade	Badiaranke	b				
-pbp	Pajade	Badiaranke	d				
-pbp	Pajade	Badiaranke	d̠ʒ				
-pbp	Pajade	Badiaranke	mb				
-pbp	Pajade	Badiaranke	nd				
-pbp	Pajade	Badiaranke	p				
-pbp	Pajade	Badiaranke	t				
-pbp	Pajade	Badiaranke	k				
-pbp	Pajade	Badiaranke	t̠ʃ				
-pbp	Pajade	Badiaranke	mp				
-pbp	Pajade	Badiaranke	nt				
-pbp	Pajade	Badiaranke	ŋk				
-pbp	Pajade	Badiaranke	f				
-pbp	Pajade	Badiaranke	s				
-pbp	Pajade	Badiaranke	h				
-pbp	Pajade	Badiaranke	ç				
-pbp	Pajade	Badiaranke	β				
-pbp	Pajade	Badiaranke	l				
-pbp	Pajade	Badiaranke	r				
-pbp	Pajade	Badiaranke	h				
-pbp	Pajade	Badiaranke	j				
-pbp	Pajade	Badiaranke	w				
-pbp	Pajade	Badiaranke	i				
-pbp	Pajade	Badiaranke	e				
-pbp	Pajade	Badiaranke	a				
-pbp	Pajade	Badiaranke	o				
-pbp	Pajade	Badiaranke	u				
-pbp	Pajade	Badiaranke	ĩ				
-pbp	Pajade	Badiaranke	ẽ				
-pbp	Pajade	Badiaranke	ã				
-pbp	Pajade	Badiaranke	õ				
-pbp	Pajade	Badiaranke	ũ				
-pbp	Pajade	Badiaranke	ĩː				
-pbp	Pajade	Badiaranke	ẽː				
-pbp	Pajade	Badiaranke	ãː				
-pbp	Pajade	Badiaranke	õː				
-pbp	Pajade	Badiaranke	ũː				
-pbp	Pajade	Badiaranke	ə				
-pbp	Pajade	Badiaranke	ə̃				
-pbp	Pajade	Badiaranke	ə̃ː				
-							
+pbp	Pajade	Badiaranke	n
+pbp	Pajade	Badiaranke	ɲ
+pbp	Pajade	Badiaranke	ŋ
+pbp	Pajade	Badiaranke	b
+pbp	Pajade	Badiaranke	d
+pbp	Pajade	Badiaranke	d̠ʒ
+pbp	Pajade	Badiaranke	mb
+pbp	Pajade	Badiaranke	nd
+pbp	Pajade	Badiaranke	p
+pbp	Pajade	Badiaranke	t
+pbp	Pajade	Badiaranke	k
+pbp	Pajade	Badiaranke	t̠ʃ
+pbp	Pajade	Badiaranke	mp
+pbp	Pajade	Badiaranke	nt
+pbp	Pajade	Badiaranke	ŋk
+pbp	Pajade	Badiaranke	f
+pbp	Pajade	Badiaranke	s
+pbp	Pajade	Badiaranke	h
+pbp	Pajade	Badiaranke	ç
+pbp	Pajade	Badiaranke	β
+pbp	Pajade	Badiaranke	l
+pbp	Pajade	Badiaranke	r
+pbp	Pajade	Badiaranke	h
+pbp	Pajade	Badiaranke	j
+pbp	Pajade	Badiaranke	w
+pbp	Pajade	Badiaranke	i
+pbp	Pajade	Badiaranke	e
+pbp	Pajade	Badiaranke	a
+pbp	Pajade	Badiaranke	o
+pbp	Pajade	Badiaranke	u
+pbp	Pajade	Badiaranke	ĩ
+pbp	Pajade	Badiaranke	ẽ
+pbp	Pajade	Badiaranke	ã
+pbp	Pajade	Badiaranke	õ
+pbp	Pajade	Badiaranke	ũ
+pbp	Pajade	Badiaranke	ĩː
+pbp	Pajade	Badiaranke	ẽː
+pbp	Pajade	Badiaranke	ãː
+pbp	Pajade	Badiaranke	õː
+pbp	Pajade	Badiaranke	ũː
+pbp	Pajade	Badiaranke	ə
+pbp	Pajade	Badiaranke	ə̃
+pbp	Pajade	Badiaranke	ə̃ː
+
 snw	Sele		˦				snw.pdf
-snw	Sele		˧				
-snw	Sele		˨				
-snw	Sele		˨	raised low			
-snw	Sele		pʰ				
-snw	Sele		b				
-snw	Sele		m				
-snw	Sele		f				
-snw	Sele		ɱ				
-snw	Sele		t				
-snw	Sele		ɖ		[ɖ]	before [i] and [u]	
-snw	Sele		ɖ		[l]	elsewhere	
-snw	Sele		s				
-snw	Sele		n				
-snw	Sele		t̠ʃ				
-snw	Sele		ɲ				
-snw	Sele		j				
-snw	Sele		k				
-snw	Sele		ŋ				
-snw	Sele		ŋʷ				
-snw	Sele		kp				
-snw	Sele		ŋm				
-snw	Sele		w				
-snw	Sele		i				
-snw	Sele		ĩ				
-snw	Sele		e				
-snw	Sele		ɛ				
-snw	Sele		ɛ̃				
-snw	Sele		a				
-snw	Sele		ã				
-snw	Sele		u				
-snw	Sele		ũ				
-snw	Sele		o				
-snw	Sele		ɔ				
-snw	Sele		ɔ̃				
-							
+snw	Sele		˧
+snw	Sele		˨
+snw	Sele		˨	raised low
+snw	Sele		pʰ
+snw	Sele		b
+snw	Sele		m
+snw	Sele		f
+snw	Sele		ɱ
+snw	Sele		t
+snw	Sele		ɖ		[ɖ]	before [i] and [u]
+snw	Sele		ɖ		[l]	elsewhere
+snw	Sele		s
+snw	Sele		n
+snw	Sele		t̠ʃ
+snw	Sele		ɲ
+snw	Sele		j
+snw	Sele		k
+snw	Sele		ŋ
+snw	Sele		ŋʷ
+snw	Sele		kp
+snw	Sele		ŋm
+snw	Sele		w
+snw	Sele		i
+snw	Sele		ĩ
+snw	Sele		e
+snw	Sele		ɛ
+snw	Sele		ɛ̃
+snw	Sele		a
+snw	Sele		ã
+snw	Sele		u
+snw	Sele		ũ
+snw	Sele		o
+snw	Sele		ɔ
+snw	Sele		ɔ̃
+
 tiv	Tiv	Central (Standard)	p				tiv.pdf
-tiv	Tiv	Central (Standard)	b				
-tiv	Tiv	Central (Standard)	mb				
-tiv	Tiv	Central (Standard)	t				
-tiv	Tiv	Central (Standard)	d				
-tiv	Tiv	Central (Standard)	nd				
-tiv	Tiv	Central (Standard)	k				
-tiv	Tiv	Central (Standard)	ɡ				
-tiv	Tiv	Central (Standard)	ŋɡ				
-tiv	Tiv	Central (Standard)	kp				
-tiv	Tiv	Central (Standard)	ɡb				
-tiv	Tiv	Central (Standard)	ŋmɡb				
-tiv	Tiv	Central (Standard)	f				
-tiv	Tiv	Central (Standard)	v				
-tiv	Tiv	Central (Standard)	s				
-tiv	Tiv	Central (Standard)	ʃ				
-tiv	Tiv	Central (Standard)	ɣ				
-tiv	Tiv	Central (Standard)	h				
-tiv	Tiv	Central (Standard)	ts				
-tiv	Tiv	Central (Standard)	dz				
-tiv	Tiv	Central (Standard)	t̠ʃ				
-tiv	Tiv	Central (Standard)	d̠ʒ				
-tiv	Tiv	Central (Standard)	ndz				
-tiv	Tiv	Central (Standard)	n̠d̠ʒ	updated from ɲdʒ			
-tiv	Tiv	Central (Standard)	m				
-tiv	Tiv	Central (Standard)	n				
-tiv	Tiv	Central (Standard)	ɲ				
-tiv	Tiv	Central (Standard)	ŋ				
-tiv	Tiv	Central (Standard)	l		[l]		
-tiv	Tiv	Central (Standard)	l		[r]		
-tiv	Tiv	Central (Standard)	j				
-tiv	Tiv	Central (Standard)	w				
-tiv	Tiv	Central (Standard)	i				
-tiv	Tiv	Central (Standard)	e		[e]		
-tiv	Tiv	Central (Standard)	e		[ɛ]	between velar consonants	
-tiv	Tiv	Central (Standard)	a				
-tiv	Tiv	Central (Standard)	u				
-tiv	Tiv	Central (Standard)	o				
-tiv	Tiv	Central (Standard)	ɔ				
-tiv	Tiv	Central (Standard)	˦				
-tiv	Tiv	Central (Standard)	˨				
-tiv	Tiv	Central (Standard)	˦˨				
-							
+tiv	Tiv	Central (Standard)	b
+tiv	Tiv	Central (Standard)	mb
+tiv	Tiv	Central (Standard)	t
+tiv	Tiv	Central (Standard)	d
+tiv	Tiv	Central (Standard)	nd
+tiv	Tiv	Central (Standard)	k
+tiv	Tiv	Central (Standard)	ɡ
+tiv	Tiv	Central (Standard)	ŋɡ
+tiv	Tiv	Central (Standard)	kp
+tiv	Tiv	Central (Standard)	ɡb
+tiv	Tiv	Central (Standard)	ŋmɡb
+tiv	Tiv	Central (Standard)	f
+tiv	Tiv	Central (Standard)	v
+tiv	Tiv	Central (Standard)	s
+tiv	Tiv	Central (Standard)	ʃ
+tiv	Tiv	Central (Standard)	ɣ
+tiv	Tiv	Central (Standard)	h
+tiv	Tiv	Central (Standard)	ts
+tiv	Tiv	Central (Standard)	dz
+tiv	Tiv	Central (Standard)	t̠ʃ
+tiv	Tiv	Central (Standard)	d̠ʒ
+tiv	Tiv	Central (Standard)	ndz
+tiv	Tiv	Central (Standard)	n̠d̠ʒ	updated from ɲdʒ
+tiv	Tiv	Central (Standard)	m
+tiv	Tiv	Central (Standard)	n
+tiv	Tiv	Central (Standard)	ɲ
+tiv	Tiv	Central (Standard)	ŋ
+tiv	Tiv	Central (Standard)	l		[l]
+tiv	Tiv	Central (Standard)	l		[r]
+tiv	Tiv	Central (Standard)	j
+tiv	Tiv	Central (Standard)	w
+tiv	Tiv	Central (Standard)	i
+tiv	Tiv	Central (Standard)	e		[e]
+tiv	Tiv	Central (Standard)	e		[ɛ]	between velar consonants
+tiv	Tiv	Central (Standard)	a
+tiv	Tiv	Central (Standard)	u
+tiv	Tiv	Central (Standard)	o
+tiv	Tiv	Central (Standard)	ɔ
+tiv	Tiv	Central (Standard)	˦
+tiv	Tiv	Central (Standard)	˨
+tiv	Tiv	Central (Standard)	˦˨
+
 byn	Blin		b				byn.pdf
-byn	Blin		f				
-byn	Blin		m				
-byn	Blin		w				
-byn	Blin		t				
-byn	Blin		d				
-byn	Blin		tʼ				
-byn	Blin		s				
-byn	Blin		z				
-byn	Blin		<t̠ʃ>	loanwords only			
-byn	Blin		d̠ʒ				
-byn	Blin		t̠ʃʼ				
-byn	Blin		ʃ				
-byn	Blin		n				
-byn	Blin		l				
-byn	Blin		r				
-byn	Blin		k				
-byn	Blin		ɡ				
-byn	Blin		kʼ				
-byn	Blin		x				
-byn	Blin		ŋ				
-byn	Blin		j				
-byn	Blin		kʷ				
-byn	Blin		ɡʷ				
-byn	Blin		kʷʼ				
-byn	Blin		xʷ				
-byn	Blin		ŋʷ				
-byn	Blin		ʕ				
-byn	Blin		h				
-byn	Blin		ʔ	dubious			
-byn	Blin		ħ				
-byn	Blin		a				
-byn	Blin		ɨ				
-byn	Blin		u				
-byn	Blin		ə				
-byn	Blin		e				
-byn	Blin		i				
-byn	Blin		o				
-							
+byn	Blin		f
+byn	Blin		m
+byn	Blin		w
+byn	Blin		t
+byn	Blin		d
+byn	Blin		tʼ
+byn	Blin		s
+byn	Blin		z
+byn	Blin		<t̠ʃ>	loanwords only
+byn	Blin		d̠ʒ
+byn	Blin		t̠ʃʼ
+byn	Blin		ʃ
+byn	Blin		n
+byn	Blin		l
+byn	Blin		r
+byn	Blin		k
+byn	Blin		ɡ
+byn	Blin		kʼ
+byn	Blin		x
+byn	Blin		ŋ
+byn	Blin		j
+byn	Blin		kʷ
+byn	Blin		ɡʷ
+byn	Blin		kʷʼ
+byn	Blin		xʷ
+byn	Blin		ŋʷ
+byn	Blin		ʕ
+byn	Blin		h
+byn	Blin		ʔ	dubious
+byn	Blin		ħ
+byn	Blin		a
+byn	Blin		ɨ
+byn	Blin		u
+byn	Blin		ə
+byn	Blin		e
+byn	Blin		i
+byn	Blin		o
+
 xan	Xamtanga		f				agaw.pdf
-xan	Xamtanga		s				
-xan	Xamtanga		w				
-xan	Xamtanga		z				
-xan	Xamtanga		b				
-xan	Xamtanga		d				
-xan	Xamtanga		z				
-xan	Xamtanga		ɡ				
-xan	Xamtanga		ɡʷ				
-xan	Xamtanga		t				
-xan	Xamtanga		r				
-xan	Xamtanga		sʼ				
-xan	Xamtanga		t̠ʃʼ				
-xan	Xamtanga		k				
-xan	Xamtanga		q				
-xan	Xamtanga		kʼ				
-xan	Xamtanga		kʷ				
-xan	Xamtanga		χ				
-xan	Xamtanga		χʷ				
-xan	Xamtanga		qʷ				
-xan	Xamtanga		t̠ʃ				
-xan	Xamtanga		tʼ				
-xan	Xamtanga		ʃ				
-xan	Xamtanga		h				
-xan	Xamtanga		a				
-xan	Xamtanga		ɨ				
-xan	Xamtanga		u				
-xan	Xamtanga		ə				
-xan	Xamtanga		e				
-xan	Xamtanga		i				
-xan	Xamtanga		o				
-							
+xan	Xamtanga		s
+xan	Xamtanga		w
+xan	Xamtanga		z
+xan	Xamtanga		b
+xan	Xamtanga		d
+xan	Xamtanga		z
+xan	Xamtanga		ɡ
+xan	Xamtanga		ɡʷ
+xan	Xamtanga		t
+xan	Xamtanga		r
+xan	Xamtanga		sʼ
+xan	Xamtanga		t̠ʃʼ
+xan	Xamtanga		k
+xan	Xamtanga		q
+xan	Xamtanga		kʼ
+xan	Xamtanga		kʷ
+xan	Xamtanga		χ
+xan	Xamtanga		χʷ
+xan	Xamtanga		qʷ
+xan	Xamtanga		t̠ʃ
+xan	Xamtanga		tʼ
+xan	Xamtanga		ʃ
+xan	Xamtanga		h
+xan	Xamtanga		a
+xan	Xamtanga		ɨ
+xan	Xamtanga		u
+xan	Xamtanga		ə
+xan	Xamtanga		e
+xan	Xamtanga		i
+xan	Xamtanga		o
+
 lik	Lika		ɓ				lik.pdf
-lik	Lika		ɗ				
-lik	Lika		p				
-lik	Lika		t				
-lik	Lika		c				
-lik	Lika		k				
-lik	Lika		kp				
-lik	Lika		b				
-lik	Lika		d				
-lik	Lika		ɟ				
-lik	Lika		ɡ				
-lik	Lika		ɡb				
-lik	Lika		mb				
-lik	Lika		nd				
-lik	Lika		ɲɟ				
-lik	Lika		ŋɡ				
-lik	Lika		ŋmɡb				
-lik	Lika		f				
-lik	Lika		v				
-lik	Lika		s				
-lik	Lika		z				
-lik	Lika		ʃ				
-lik	Lika		ʒ				
-lik	Lika		h				
-lik	Lika		ɱv				
-lik	Lika		nz				
-lik	Lika		ɲʒ				
-lik	Lika		m				
-lik	Lika		n				
-lik	Lika		ɲ				
-lik	Lika		l				
-lik	Lika		w				
-lik	Lika		ʎ				
-lik	Lika		i				
-lik	Lika		u				
-lik	Lika		ɪ				
-lik	Lika		ʊ				
-lik	Lika		e				
-lik	Lika		o				
-lik	Lika		ɛ				
-lik	Lika		ɔ				
-lik	Lika		a				
-lik	Lika		˨˦				
-lik	Lika		˦				
-lik	Lika		˨				
-							
+lik	Lika		ɗ
+lik	Lika		p
+lik	Lika		t
+lik	Lika		c
+lik	Lika		k
+lik	Lika		kp
+lik	Lika		b
+lik	Lika		d
+lik	Lika		ɟ
+lik	Lika		ɡ
+lik	Lika		ɡb
+lik	Lika		mb
+lik	Lika		nd
+lik	Lika		ɲɟ
+lik	Lika		ŋɡ
+lik	Lika		ŋmɡb
+lik	Lika		f
+lik	Lika		v
+lik	Lika		s
+lik	Lika		z
+lik	Lika		ʃ
+lik	Lika		ʒ
+lik	Lika		h
+lik	Lika		ɱv
+lik	Lika		nz
+lik	Lika		ɲʒ
+lik	Lika		m
+lik	Lika		n
+lik	Lika		ɲ
+lik	Lika		l
+lik	Lika		w
+lik	Lika		ʎ
+lik	Lika		i
+lik	Lika		u
+lik	Lika		ɪ
+lik	Lika		ʊ
+lik	Lika		e
+lik	Lika		o
+lik	Lika		ɛ
+lik	Lika		ɔ
+lik	Lika		a
+lik	Lika		˨˦
+lik	Lika		˦
+lik	Lika		˨
+
 yns	Yanzi		i				yns.pdf
-yns	Yanzi		e				
-yns	Yanzi		ɛ				
-yns	Yanzi		y				
-yns	Yanzi		ø				
-yns	Yanzi		œ				
-yns	Yanzi		æ				
-yns	Yanzi		a				
-yns	Yanzi		o				
-yns	Yanzi		u				
-yns	Yanzi		ɔ				
-yns	Yanzi		j				
-yns	Yanzi		w				
-yns	Yanzi		m				
-yns	Yanzi		n				
-yns	Yanzi		ŋ				
-yns	Yanzi		l				
-yns	Yanzi		r				
-yns	Yanzi		b				
-yns	Yanzi		p				
-yns	Yanzi		t				
-yns	Yanzi		d				
-yns	Yanzi		k				
-yns	Yanzi		ɡ				
-yns	Yanzi		f				
-yns	Yanzi		v				
-yns	Yanzi		s				
-yns	Yanzi		z				
-yns	Yanzi		iː				
-yns	Yanzi		eː				
-yns	Yanzi		ɛː				
-yns	Yanzi		yː				
-yns	Yanzi		øː				
-yns	Yanzi		œː				
-yns	Yanzi		æː				
-yns	Yanzi		aː				
-yns	Yanzi		oː				
-yns	Yanzi		uː				
-yns	Yanzi		ɔː				
-yns	Yanzi		↓˦				
-yns	Yanzi		˦				
-yns	Yanzi		˨				
-							
+yns	Yanzi		e
+yns	Yanzi		ɛ
+yns	Yanzi		y
+yns	Yanzi		ø
+yns	Yanzi		œ
+yns	Yanzi		æ
+yns	Yanzi		a
+yns	Yanzi		o
+yns	Yanzi		u
+yns	Yanzi		ɔ
+yns	Yanzi		j
+yns	Yanzi		w
+yns	Yanzi		m
+yns	Yanzi		n
+yns	Yanzi		ŋ
+yns	Yanzi		l
+yns	Yanzi		r
+yns	Yanzi		b
+yns	Yanzi		p
+yns	Yanzi		t
+yns	Yanzi		d
+yns	Yanzi		k
+yns	Yanzi		ɡ
+yns	Yanzi		f
+yns	Yanzi		v
+yns	Yanzi		s
+yns	Yanzi		z
+yns	Yanzi		iː
+yns	Yanzi		eː
+yns	Yanzi		ɛː
+yns	Yanzi		yː
+yns	Yanzi		øː
+yns	Yanzi		œː
+yns	Yanzi		æː
+yns	Yanzi		aː
+yns	Yanzi		oː
+yns	Yanzi		uː
+yns	Yanzi		ɔː
+yns	Yanzi		↓˦
+yns	Yanzi		˦
+yns	Yanzi		˨
+
 buu	Kibudu		p				buu.pdf
-buu	Kibudu		b				
-buu	Kibudu		t				
-buu	Kibudu		d				
-buu	Kibudu		tɕ				
-buu	Kibudu		dʑ				
-buu	Kibudu		kʲ				
-buu	Kibudu		ɡʲ				
-buu	Kibudu		k				
-buu	Kibudu		ɡ				
-buu	Kibudu		kp				
-buu	Kibudu		ɡb				
-buu	Kibudu		mb				
-buu	Kibudu		nd				
-buu	Kibudu		ɲɟʑ	SM: changed from ndʑ to ɲɟʑ			
-buu	Kibudu		ŋɡ				
-buu	Kibudu		ŋɡʲ				
-buu	Kibudu		ŋmɡb				
-buu	Kibudu		ɓ				
-buu	Kibudu		ɗ		[ɗ]		
-buu	Kibudu		ɗ		[l]		
-buu	Kibudu		ɗ		[ɾ]		
-buu	Kibudu		f				
-buu	Kibudu		v				
-buu	Kibudu		s				
-buu	Kibudu		h				
-buu	Kibudu		ʄ				
-buu	Kibudu		ɱv				
-buu	Kibudu		m				
-buu	Kibudu		n				
-buu	Kibudu		ɲ				
-buu	Kibudu		j				
-buu	Kibudu		w				
-buu	Kibudu		i				
-buu	Kibudu		u				
-buu	Kibudu		ɪ				
-buu	Kibudu		ʊ				
-buu	Kibudu		e				
-buu	Kibudu		o				
-buu	Kibudu		ɛ				
-buu	Kibudu		ɔ				
-buu	Kibudu		a				
-buu	Kibudu		˨˦				
-buu	Kibudu		˦				
-buu	Kibudu		˨				
-							
+buu	Kibudu		b
+buu	Kibudu		t
+buu	Kibudu		d
+buu	Kibudu		tɕ
+buu	Kibudu		dʑ
+buu	Kibudu		kʲ
+buu	Kibudu		ɡʲ
+buu	Kibudu		k
+buu	Kibudu		ɡ
+buu	Kibudu		kp
+buu	Kibudu		ɡb
+buu	Kibudu		mb
+buu	Kibudu		nd
+buu	Kibudu		ɲɟʑ	SM: changed from ndʑ to ɲɟʑ
+buu	Kibudu		ŋɡ
+buu	Kibudu		ŋɡʲ
+buu	Kibudu		ŋmɡb
+buu	Kibudu		ɓ
+buu	Kibudu		ɗ		[ɗ]
+buu	Kibudu		ɗ		[l]
+buu	Kibudu		ɗ		[ɾ]
+buu	Kibudu		f
+buu	Kibudu		v
+buu	Kibudu		s
+buu	Kibudu		h
+buu	Kibudu		ʄ
+buu	Kibudu		ɱv
+buu	Kibudu		m
+buu	Kibudu		n
+buu	Kibudu		ɲ
+buu	Kibudu		j
+buu	Kibudu		w
+buu	Kibudu		i
+buu	Kibudu		u
+buu	Kibudu		ɪ
+buu	Kibudu		ʊ
+buu	Kibudu		e
+buu	Kibudu		o
+buu	Kibudu		ɛ
+buu	Kibudu		ɔ
+buu	Kibudu		a
+buu	Kibudu		˨˦
+buu	Kibudu		˦
+buu	Kibudu		˨
+
 khy	Iikile		i				khy.pdf
-khy	Iikile		e				
-khy	Iikile		ɛ				
-khy	Iikile		o				
-khy	Iikile		ɔ				
-khy	Iikile		u				
-khy	Iikile		a				
-khy	Iikile		p				
-khy	Iikile		b				
-khy	Iikile		t				
-khy	Iikile		d				
-khy	Iikile		k				
-khy	Iikile		kp				
-khy	Iikile		ɡb				
-khy	Iikile		f				
-khy	Iikile		s				
-khy	Iikile		χ				
-khy	Iikile		l				
-khy	Iikile		m				
-khy	Iikile		n				
-khy	Iikile		ŋ				
-khy	Iikile		mb				
-khy	Iikile		nd				
-khy	Iikile		ɲ				
-khy	Iikile		j				
-khy	Iikile		w				
-khy	Iikile		ŋɡ				
-khy	Iikile		ŋk				
-khy	Iikile		˦				
-khy	Iikile		˨				
+khy	Iikile		e
+khy	Iikile		ɛ
+khy	Iikile		o
+khy	Iikile		ɔ
+khy	Iikile		u
+khy	Iikile		a
+khy	Iikile		p
+khy	Iikile		b
+khy	Iikile		t
+khy	Iikile		d
+khy	Iikile		k
+khy	Iikile		kp
+khy	Iikile		ɡb
+khy	Iikile		f
+khy	Iikile		s
+khy	Iikile		χ
+khy	Iikile		l
+khy	Iikile		m
+khy	Iikile		n
+khy	Iikile		ŋ
+khy	Iikile		mb
+khy	Iikile		nd
+khy	Iikile		ɲ
+khy	Iikile		j
+khy	Iikile		w
+khy	Iikile		ŋɡ
+khy	Iikile		ŋk
+khy	Iikile		˦
+khy	Iikile		˨
 
 lej	Lengola	Balega	i				lej.pdf
-lej	Lengola	Balega	e				
-lej	Lengola	Balega	a				
-lej	Lengola	Balega	o				
-lej	Lengola	Balega	u				
-lej	Lengola	Balega	j				
-lej	Lengola	Balega	w				
-lej	Lengola	Balega	m				
-lej	Lengola	Balega	n				
-lej	Lengola	Balega	ɲ				
-lej	Lengola	Balega	b				
-lej	Lengola	Balega	d				
-lej	Lengola	Balega	d̠ʒ				
-lej	Lengola	Balega	ɡ				
-lej	Lengola	Balega	ɡb				
-lej	Lengola	Balega	ɓ				
-lej	Lengola	Balega	ɗ				
-lej	Lengola	Balega	ʄ				
-lej	Lengola	Balega	p				
-lej	Lengola	Balega	t				
-lej	Lengola	Balega	t̠ʃ				
-lej	Lengola	Balega	k				
-lej	Lengola	Balega	kp				
-lej	Lengola	Balega	ⱱ				
-lej	Lengola	Balega	ⱱ̟				
-lej	Lengola	Balega	v				
-lej	Lengola	Balega	f				
-lej	Lengola	Balega	s				
-lej	Lengola	Balega	l				
-lej	Lengola	Balega	˦				
-lej	Lengola	Balega	˧				
-lej	Lengola	Balega	˨				
-							
+lej	Lengola	Balega	e
+lej	Lengola	Balega	a
+lej	Lengola	Balega	o
+lej	Lengola	Balega	u
+lej	Lengola	Balega	j
+lej	Lengola	Balega	w
+lej	Lengola	Balega	m
+lej	Lengola	Balega	n
+lej	Lengola	Balega	ɲ
+lej	Lengola	Balega	b
+lej	Lengola	Balega	d
+lej	Lengola	Balega	d̠ʒ
+lej	Lengola	Balega	ɡ
+lej	Lengola	Balega	ɡb
+lej	Lengola	Balega	ɓ
+lej	Lengola	Balega	ɗ
+lej	Lengola	Balega	ʄ
+lej	Lengola	Balega	p
+lej	Lengola	Balega	t
+lej	Lengola	Balega	t̠ʃ
+lej	Lengola	Balega	k
+lej	Lengola	Balega	kp
+lej	Lengola	Balega	ⱱ
+lej	Lengola	Balega	ⱱ̟
+lej	Lengola	Balega	v
+lej	Lengola	Balega	f
+lej	Lengola	Balega	s
+lej	Lengola	Balega	l
+lej	Lengola	Balega	˦
+lej	Lengola	Balega	˧
+lej	Lengola	Balega	˨
+
 kbo	Kaliko		i				kbo.pdf
-kbo	Kaliko		e				
-kbo	Kaliko		ɛ				
-kbo	Kaliko		u				
-kbo	Kaliko		o				
-kbo	Kaliko		a				
-kbo	Kaliko		˦				
-kbo	Kaliko		˧				
-kbo	Kaliko		˨				
-kbo	Kaliko		m				
-kbo	Kaliko		n				
-kbo	Kaliko		ŋ				
-kbo	Kaliko		ɲ				
-kbo	Kaliko		p				
-kbo	Kaliko		t				
-kbo	Kaliko		k				
-kbo	Kaliko		b				
-kbo	Kaliko		d				
-kbo	Kaliko		ɡ				
-kbo	Kaliko		ɓ				
-kbo	Kaliko		ɗ				
-kbo	Kaliko		l				
-kbo	Kaliko		r				
-kbo	Kaliko		s				
-kbo	Kaliko		z				
-kbo	Kaliko		ʔ				
-kbo	Kaliko		f				
-kbo	Kaliko		v				
-kbo	Kaliko		t̠ʃ				
-kbo	Kaliko		d̠ʒ				
-kbo	Kaliko		h				
-kbo	Kaliko		ɡb				
-kbo	Kaliko		kp				
-kbo	Kaliko		jˀ	updated from ʔʲ			
-kbo	Kaliko		mb				
-kbo	Kaliko		ɱv				
-kbo	Kaliko		nd				
-kbo	Kaliko		nz				
-kbo	Kaliko		ɳɖr				
-kbo	Kaliko		ŋɡ				
-kbo	Kaliko		ŋmɡb				
-kbo	Kaliko		ʈr				
-kbo	Kaliko		ɖr				
-kbo	Kaliko		j				
-kbo	Kaliko		w				
-							
+kbo	Kaliko		e
+kbo	Kaliko		ɛ
+kbo	Kaliko		u
+kbo	Kaliko		o
+kbo	Kaliko		a
+kbo	Kaliko		˦
+kbo	Kaliko		˧
+kbo	Kaliko		˨
+kbo	Kaliko		m
+kbo	Kaliko		n
+kbo	Kaliko		ŋ
+kbo	Kaliko		ɲ
+kbo	Kaliko		p
+kbo	Kaliko		t
+kbo	Kaliko		k
+kbo	Kaliko		b
+kbo	Kaliko		d
+kbo	Kaliko		ɡ
+kbo	Kaliko		ɓ
+kbo	Kaliko		ɗ
+kbo	Kaliko		l
+kbo	Kaliko		r
+kbo	Kaliko		s
+kbo	Kaliko		z
+kbo	Kaliko		ʔ
+kbo	Kaliko		f
+kbo	Kaliko		v
+kbo	Kaliko		t̠ʃ
+kbo	Kaliko		d̠ʒ
+kbo	Kaliko		h
+kbo	Kaliko		ɡb
+kbo	Kaliko		kp
+kbo	Kaliko		jˀ	updated from ʔʲ
+kbo	Kaliko		mb
+kbo	Kaliko		ɱv
+kbo	Kaliko		nd
+kbo	Kaliko		nz
+kbo	Kaliko		ɳɖr
+kbo	Kaliko		ŋɡ
+kbo	Kaliko		ŋmɡb
+kbo	Kaliko		ʈr
+kbo	Kaliko		ɖr
+kbo	Kaliko		j
+kbo	Kaliko		w
+
 won	Wongo	Isiinkere	i		[i]		won.pdf
-won	Wongo	Isiinkere	i		[ĩ]		
-won	Wongo	Isiinkere	e		[e]		
-won	Wongo	Isiinkere	e		[ẽ]		
-won	Wongo	Isiinkere	ɛ		[ɛ]		
-won	Wongo	Isiinkere	ɛ		[ɛ̃]		
-won	Wongo	Isiinkere	a		[a]		
-won	Wongo	Isiinkere	a		[ã]		
-won	Wongo	Isiinkere	ɔ		[ɔ]		
-won	Wongo	Isiinkere	ɔ		[ɔ̃]		
-won	Wongo	Isiinkere	o		[o]		
-won	Wongo	Isiinkere	o		[õ]		
-won	Wongo	Isiinkere	u		[u]		
-won	Wongo	Isiinkere	u		[ũ]		
-won	Wongo	Isiinkere	b				
-won	Wongo	Isiinkere	p				
-won	Wongo	Isiinkere	d				
-won	Wongo	Isiinkere	t				
-won	Wongo	Isiinkere	dz				
-won	Wongo	Isiinkere	ts				
-won	Wongo	Isiinkere	s				
-won	Wongo	Isiinkere	m				
-won	Wongo	Isiinkere	n				
-won	Wongo	Isiinkere	ɲ				
-won	Wongo	Isiinkere	ŋ				
-won	Wongo	Isiinkere	k				
-won	Wongo	Isiinkere	j				
-won	Wongo	Isiinkere	w				
-won	Wongo	Isiinkere	ɰ				
-won	Wongo	Isiinkere	˦				
-won	Wongo	Isiinkere	˨				
-							
+won	Wongo	Isiinkere	i		[ĩ]
+won	Wongo	Isiinkere	e		[e]
+won	Wongo	Isiinkere	e		[ẽ]
+won	Wongo	Isiinkere	ɛ		[ɛ]
+won	Wongo	Isiinkere	ɛ		[ɛ̃]
+won	Wongo	Isiinkere	a		[a]
+won	Wongo	Isiinkere	a		[ã]
+won	Wongo	Isiinkere	ɔ		[ɔ]
+won	Wongo	Isiinkere	ɔ		[ɔ̃]
+won	Wongo	Isiinkere	o		[o]
+won	Wongo	Isiinkere	o		[õ]
+won	Wongo	Isiinkere	u		[u]
+won	Wongo	Isiinkere	u		[ũ]
+won	Wongo	Isiinkere	b
+won	Wongo	Isiinkere	p
+won	Wongo	Isiinkere	d
+won	Wongo	Isiinkere	t
+won	Wongo	Isiinkere	dz
+won	Wongo	Isiinkere	ts
+won	Wongo	Isiinkere	s
+won	Wongo	Isiinkere	m
+won	Wongo	Isiinkere	n
+won	Wongo	Isiinkere	ɲ
+won	Wongo	Isiinkere	ŋ
+won	Wongo	Isiinkere	k
+won	Wongo	Isiinkere	j
+won	Wongo	Isiinkere	w
+won	Wongo	Isiinkere	ɰ
+won	Wongo	Isiinkere	˦
+won	Wongo	Isiinkere	˨
+
 wlc	Mwali		i				wlc.pdf
-wlc	Mwali		e				
-wlc	Mwali		a				
-wlc	Mwali		o				
-wlc	Mwali		u				
-wlc	Mwali		j				
-wlc	Mwali		w				
-wlc	Mwali		m				
-wlc	Mwali		n				
-wlc	Mwali		ɲ				
-wlc	Mwali		v				
-wlc	Mwali		ɓ		[ɓ]		
-wlc	Mwali		ɓ		[w]		
-wlc	Mwali		b				
-wlc	Mwali		ɗ		[ɗ]		
-wlc	Mwali		ɗ		[l]		
-wlc	Mwali		d				
-wlc	Mwali		dz		[dz]		
-wlc	Mwali		dz		[z]		
-wlc	Mwali		d̠ʒ				
-wlc	Mwali		ɡ				
-wlc	Mwali		f				
-wlc	Mwali		p		[p]		
-wlc	Mwali		p		[β]		
-wlc	Mwali		tr		[tr]		
-wlc	Mwali		tr		[r]		
-wlc	Mwali		ts		[ts]		
-wlc	Mwali		ts		[s]		
-wlc	Mwali		ʃ				
-wlc	Mwali		k		[k]		
-wlc	Mwali		k		[h]		
-							
+wlc	Mwali		e
+wlc	Mwali		a
+wlc	Mwali		o
+wlc	Mwali		u
+wlc	Mwali		j
+wlc	Mwali		w
+wlc	Mwali		m
+wlc	Mwali		n
+wlc	Mwali		ɲ
+wlc	Mwali		v
+wlc	Mwali		ɓ		[ɓ]
+wlc	Mwali		ɓ		[w]
+wlc	Mwali		b
+wlc	Mwali		ɗ		[ɗ]
+wlc	Mwali		ɗ		[l]
+wlc	Mwali		d
+wlc	Mwali		dz		[dz]
+wlc	Mwali		dz		[z]
+wlc	Mwali		d̠ʒ
+wlc	Mwali		ɡ
+wlc	Mwali		f
+wlc	Mwali		p		[p]
+wlc	Mwali		p		[β]
+wlc	Mwali		tr		[tr]
+wlc	Mwali		tr		[r]
+wlc	Mwali		ts		[ts]
+wlc	Mwali		ts		[s]
+wlc	Mwali		ʃ
+wlc	Mwali		k		[k]
+wlc	Mwali		k		[h]
+
 aar	Afar		iː		[iː]		afar.pdf
-aar	Afar		iː		[iːˤ]		
-aar	Afar		i		[i]		
-aar	Afar		i		[iˤ]		
-aar	Afar		eː		[eː]		
-aar	Afar		eː		[eːˤ]		
-aar	Afar		e		[e]		
-aar	Afar		e		[eˤ]		
-aar	Afar		uː		[uː]		
-aar	Afar		uː		[uːˤ]		
-aar	Afar		u		[u]		
-aar	Afar		u		[uˤ]		
-aar	Afar		oː		[oː]		
-aar	Afar		oː		[oːˤ]		
-aar	Afar		o		[o]		
-aar	Afar		o		[oˤ]		
-aar	Afar		a		[a]		
-aar	Afar		a		[aˤ]		
-aar	Afar		ʌ		[ʌ]		
-aar	Afar		ʌ		[ʌˤ]		
-aar	Afar		ʌ		[ə]		
-aar	Afar		t				
-aar	Afar		k				
-aar	Afar		b				
-aar	Afar		d				
-aar	Afar		ɖ				
-aar	Afar		ɡ				
-aar	Afar		m				
-aar	Afar		n				
-aar	Afar		f				
-aar	Afar		s				
-aar	Afar		ħ				
-aar	Afar		ʕ				
-aar	Afar		h				
-aar	Afar		l				
-aar	Afar		r		[r]		
-aar	Afar		r		[rː]		
-aar	Afar		w		[w]		
-aar	Afar		w		[wː]		
-aar	Afar		j		[j]		
-aar	Afar		j		[jː]		
-							
+aar	Afar		iː		[iːˤ]
+aar	Afar		i		[i]
+aar	Afar		i		[iˤ]
+aar	Afar		eː		[eː]
+aar	Afar		eː		[eːˤ]
+aar	Afar		e		[e]
+aar	Afar		e		[eˤ]
+aar	Afar		uː		[uː]
+aar	Afar		uː		[uːˤ]
+aar	Afar		u		[u]
+aar	Afar		u		[uˤ]
+aar	Afar		oː		[oː]
+aar	Afar		oː		[oːˤ]
+aar	Afar		o		[o]
+aar	Afar		o		[oˤ]
+aar	Afar		a		[a]
+aar	Afar		a		[aˤ]
+aar	Afar		ʌ		[ʌ]
+aar	Afar		ʌ		[ʌˤ]
+aar	Afar		ʌ		[ə]
+aar	Afar		t
+aar	Afar		k
+aar	Afar		b
+aar	Afar		d
+aar	Afar		ɖ
+aar	Afar		ɡ
+aar	Afar		m
+aar	Afar		n
+aar	Afar		f
+aar	Afar		s
+aar	Afar		ħ
+aar	Afar		ʕ
+aar	Afar		h
+aar	Afar		l
+aar	Afar		r		[r]
+aar	Afar		r		[rː]
+aar	Afar		w		[w]
+aar	Afar		w		[wː]
+aar	Afar		j		[j]
+aar	Afar		j		[jː]
+
 mua	Mundang		p				kebi.pdf
-mua	Mundang		t				
-mua	Mundang		t̠ʃ				
-mua	Mundang		k				
-mua	Mundang		kp				
-mua	Mundang		ʔ				
-mua	Mundang		b				
-mua	Mundang		d				
-mua	Mundang		d̠ʒ				
-mua	Mundang		ɡ				
-mua	Mundang		ɡb				
-mua	Mundang		ɓ				
-mua	Mundang		ɗ				
-mua	Mundang		f				
-mua	Mundang		s				
-mua	Mundang		ʃ				
-mua	Mundang		h				
-mua	Mundang		v				
-mua	Mundang		z				
-mua	Mundang		ʒ				
-mua	Mundang		mb				
-mua	Mundang		nd				
-mua	Mundang		n̠d̠ʒ				
-mua	Mundang		ŋɡ				
-mua	Mundang		ŋmɡb				
-mua	Mundang		m				
-mua	Mundang		n				
-mua	Mundang		ŋ				
-mua	Mundang		mˀ				
-mua	Mundang		nˀ				
-mua	Mundang		l				
-mua	Mundang		r				
-mua	Mundang		j				
-mua	Mundang		w				
-mua	Mundang		jˀ				
-mua	Mundang		wˀ				
-mua	Mundang		ⱱ				
-mua	Mundang		i				
-mua	Mundang		ɪ				
-mua	Mundang		e				
-mua	Mundang		ə				
-mua	Mundang		a				
-mua	Mundang		ɔ				
-mua	Mundang		o				
-mua	Mundang		ʊ				
-mua	Mundang		u				
-mua	Mundang		iː				
-mua	Mundang		ɪː				
-mua	Mundang		eː				
-mua	Mundang		ɛː				
-mua	Mundang		aː				
-mua	Mundang		ɔː				
-mua	Mundang		oː				
-mua	Mundang		ʊː				
-mua	Mundang		uː				
-mua	Mundang		ĩ				
-mua	Mundang		ɪ̃				
-mua	Mundang		ã				
-mua	Mundang		ĩː				
-mua	Mundang		ɪ̃ː				
-mua	Mundang		ãː				
-mua	Mundang		ɔ̃ː				
-mua	Mundang		ʊ̃ː				
-mua	Mundang		ũː				
-mua	Mundang		˦				
-mua	Mundang		˧				
-mua	Mundang		˨				
-							
+mua	Mundang		t
+mua	Mundang		t̠ʃ
+mua	Mundang		k
+mua	Mundang		kp
+mua	Mundang		ʔ
+mua	Mundang		b
+mua	Mundang		d
+mua	Mundang		d̠ʒ
+mua	Mundang		ɡ
+mua	Mundang		ɡb
+mua	Mundang		ɓ
+mua	Mundang		ɗ
+mua	Mundang		f
+mua	Mundang		s
+mua	Mundang		ʃ
+mua	Mundang		h
+mua	Mundang		v
+mua	Mundang		z
+mua	Mundang		ʒ
+mua	Mundang		mb
+mua	Mundang		nd
+mua	Mundang		n̠d̠ʒ
+mua	Mundang		ŋɡ
+mua	Mundang		ŋmɡb
+mua	Mundang		m
+mua	Mundang		n
+mua	Mundang		ŋ
+mua	Mundang		mˀ
+mua	Mundang		nˀ
+mua	Mundang		l
+mua	Mundang		r
+mua	Mundang		j
+mua	Mundang		w
+mua	Mundang		jˀ
+mua	Mundang		wˀ
+mua	Mundang		ⱱ
+mua	Mundang		i
+mua	Mundang		ɪ
+mua	Mundang		e
+mua	Mundang		ə
+mua	Mundang		a
+mua	Mundang		ɔ
+mua	Mundang		o
+mua	Mundang		ʊ
+mua	Mundang		u
+mua	Mundang		iː
+mua	Mundang		ɪː
+mua	Mundang		eː
+mua	Mundang		ɛː
+mua	Mundang		aː
+mua	Mundang		ɔː
+mua	Mundang		oː
+mua	Mundang		ʊː
+mua	Mundang		uː
+mua	Mundang		ĩ
+mua	Mundang		ɪ̃
+mua	Mundang		ã
+mua	Mundang		ĩː
+mua	Mundang		ɪ̃ː
+mua	Mundang		ãː
+mua	Mundang		ɔ̃ː
+mua	Mundang		ʊ̃ː
+mua	Mundang		ũː
+mua	Mundang		˦
+mua	Mundang		˧
+mua	Mundang		˨
+
 mru	Mono		p				kebi.pdf
-mru	Mono		t				
-mru	Mono		t̠ʃ				
-mru	Mono		k				
-mru	Mono		kp				
-mru	Mono		ʔ				
-mru	Mono		b				
-mru	Mono		d				
-mru	Mono		d̠ʒ				
-mru	Mono		ɡ				
-mru	Mono		ɡb				
-mru	Mono		ɓ				
-mru	Mono		ɗ				
-mru	Mono		f				
-mru	Mono		s				
-mru	Mono		h				
-mru	Mono		v				
-mru	Mono		z				
-mru	Mono		mb				
-mru	Mono		nd				
-mru	Mono		n̠d̠ʒ				
-mru	Mono		ŋɡ				
-mru	Mono		ŋmɡb				
-mru	Mono		m				
-mru	Mono		n				
-mru	Mono		ŋ				
-mru	Mono		mˀ				
-mru	Mono		nˀ				
-mru	Mono		l				
-mru	Mono		r				
-mru	Mono		j				
-mru	Mono		w				
-mru	Mono		jˀ				
-mru	Mono		wˀ				
-mru	Mono		ⱱ				
-mru	Mono		i				
-mru	Mono		e				
-mru	Mono		a				
-mru	Mono		ɔ				
-mru	Mono		o				
-mru	Mono		u				
-mru	Mono		iː				
-mru	Mono		eː				
-mru	Mono		ɛː				
-mru	Mono		aː				
-mru	Mono		ɔː				
-mru	Mono		oː				
-mru	Mono		uː				
-mru	Mono		ĩ				
-mru	Mono		ẽ				
-mru	Mono		ã				
-mru	Mono		õ				
-mru	Mono		ũ				
-mru	Mono		ĩː				
-mru	Mono		ãː				
-mru	Mono		ẽː				
-mru	Mono		ɛ̃ː				
-mru	Mono		ũː				
-mru	Mono		ɔ̃ː				
-mru	Mono		˦				
-mru	Mono		˧				
-mru	Mono		˨				
-							
+mru	Mono		t
+mru	Mono		t̠ʃ
+mru	Mono		k
+mru	Mono		kp
+mru	Mono		ʔ
+mru	Mono		b
+mru	Mono		d
+mru	Mono		d̠ʒ
+mru	Mono		ɡ
+mru	Mono		ɡb
+mru	Mono		ɓ
+mru	Mono		ɗ
+mru	Mono		f
+mru	Mono		s
+mru	Mono		h
+mru	Mono		v
+mru	Mono		z
+mru	Mono		mb
+mru	Mono		nd
+mru	Mono		n̠d̠ʒ
+mru	Mono		ŋɡ
+mru	Mono		ŋmɡb
+mru	Mono		m
+mru	Mono		n
+mru	Mono		ŋ
+mru	Mono		mˀ
+mru	Mono		nˀ
+mru	Mono		l
+mru	Mono		r
+mru	Mono		j
+mru	Mono		w
+mru	Mono		jˀ
+mru	Mono		wˀ
+mru	Mono		ⱱ
+mru	Mono		i
+mru	Mono		e
+mru	Mono		a
+mru	Mono		ɔ
+mru	Mono		o
+mru	Mono		u
+mru	Mono		iː
+mru	Mono		eː
+mru	Mono		ɛː
+mru	Mono		aː
+mru	Mono		ɔː
+mru	Mono		oː
+mru	Mono		uː
+mru	Mono		ĩ
+mru	Mono		ẽ
+mru	Mono		ã
+mru	Mono		õ
+mru	Mono		ũ
+mru	Mono		ĩː
+mru	Mono		ãː
+mru	Mono		ẽː
+mru	Mono		ɛ̃ː
+mru	Mono		ũː
+mru	Mono		ɔ̃ː
+mru	Mono		˦
+mru	Mono		˧
+mru	Mono		˨
+
 tui	Tupuri		p				kebi.pdf
-tui	Tupuri		t				
-tui	Tupuri		t̠ʃ				
-tui	Tupuri		k				
-tui	Tupuri		ʔ				
-tui	Tupuri		b				
-tui	Tupuri		d				
-tui	Tupuri		d̠ʒ				
-tui	Tupuri		ɡ				
-tui	Tupuri		ɓ				
-tui	Tupuri		ɗ				
-tui	Tupuri		f				
-tui	Tupuri		s				
-tui	Tupuri		h				
-tui	Tupuri		v				
-tui	Tupuri		z				
-tui	Tupuri		mb				
-tui	Tupuri		nd				
-tui	Tupuri		n̠d̠ʒ				
-tui	Tupuri		ŋɡ				
-tui	Tupuri		m				
-tui	Tupuri		n				
-tui	Tupuri		ŋ				
-tui	Tupuri		l				
-tui	Tupuri		r				
-tui	Tupuri		j				
-tui	Tupuri		w				
-tui	Tupuri		ⱱ				
-tui	Tupuri		i				
-tui	Tupuri		e				
-tui	Tupuri		a				
-tui	Tupuri		ɔ				
-tui	Tupuri		o				
-tui	Tupuri		u				
-tui	Tupuri		iː				
-tui	Tupuri		eː				
-tui	Tupuri		ɛː				
-tui	Tupuri		aː				
-tui	Tupuri		ɔː				
-tui	Tupuri		oː				
-tui	Tupuri		uː				
-tui	Tupuri		ĩ				
-tui	Tupuri		ẽ				
-tui	Tupuri		ã				
-tui	Tupuri		õ				
-tui	Tupuri		ũ				
-tui	Tupuri		ĩː				
-tui	Tupuri		ãː				
-tui	Tupuri		ẽː				
-tui	Tupuri		ɛ̃ː				
-tui	Tupuri		ũː				
-tui	Tupuri		ɔ̃ː				
-tui	Tupuri		˦				
-tui	Tupuri		˧				
-tui	Tupuri		˨				
-tui	Tupuri		˨˧				
-							
+tui	Tupuri		t
+tui	Tupuri		t̠ʃ
+tui	Tupuri		k
+tui	Tupuri		ʔ
+tui	Tupuri		b
+tui	Tupuri		d
+tui	Tupuri		d̠ʒ
+tui	Tupuri		ɡ
+tui	Tupuri		ɓ
+tui	Tupuri		ɗ
+tui	Tupuri		f
+tui	Tupuri		s
+tui	Tupuri		h
+tui	Tupuri		v
+tui	Tupuri		z
+tui	Tupuri		mb
+tui	Tupuri		nd
+tui	Tupuri		n̠d̠ʒ
+tui	Tupuri		ŋɡ
+tui	Tupuri		m
+tui	Tupuri		n
+tui	Tupuri		ŋ
+tui	Tupuri		l
+tui	Tupuri		r
+tui	Tupuri		j
+tui	Tupuri		w
+tui	Tupuri		ⱱ
+tui	Tupuri		i
+tui	Tupuri		e
+tui	Tupuri		a
+tui	Tupuri		ɔ
+tui	Tupuri		o
+tui	Tupuri		u
+tui	Tupuri		iː
+tui	Tupuri		eː
+tui	Tupuri		ɛː
+tui	Tupuri		aː
+tui	Tupuri		ɔː
+tui	Tupuri		oː
+tui	Tupuri		uː
+tui	Tupuri		ĩ
+tui	Tupuri		ẽ
+tui	Tupuri		ã
+tui	Tupuri		õ
+tui	Tupuri		ũ
+tui	Tupuri		ĩː
+tui	Tupuri		ãː
+tui	Tupuri		ẽː
+tui	Tupuri		ɛ̃ː
+tui	Tupuri		ũː
+tui	Tupuri		ɔ̃ː
+tui	Tupuri		˦
+tui	Tupuri		˧
+tui	Tupuri		˨
+tui	Tupuri		˨˧
+
 xuo	Kuo		p				kebi.pdf
-xuo	Kuo		t				
-xuo	Kuo		k				
-xuo	Kuo		kp				
-xuo	Kuo		b				
-xuo	Kuo		d				
-xuo	Kuo		ɡ				
-xuo	Kuo		ɡb				
-xuo	Kuo		ɓ				
-xuo	Kuo		ɗ				
-xuo	Kuo		f				
-xuo	Kuo		s				
-xuo	Kuo		h				
-xuo	Kuo		v				
-xuo	Kuo		z				
-xuo	Kuo		mb				
-xuo	Kuo		nd				
-xuo	Kuo		n̠d̠ʒ				
-xuo	Kuo		ŋɡ				
-xuo	Kuo		ŋmɡb				
-xuo	Kuo		m				
-xuo	Kuo		n				
-xuo	Kuo		ŋ				
-xuo	Kuo		l				
-xuo	Kuo		r				
-xuo	Kuo		j				
-xuo	Kuo		w				
-xuo	Kuo		jʔ	“Karang and Kuo are the only Central languages reported so far having a glottalized glide, y? (Ubels and Ubels 1980:24); E. Ubels (1981:5) analyzes [ y? ] in Kuo as a palatalized allophone of the glottal stop before ?.” (Elders, 2006:48)			
-xuo	Kuo		ⱱ				
-xuo	Kuo		i				
-xuo	Kuo		e				
-xuo	Kuo		a				
-xuo	Kuo		ɔ				
-xuo	Kuo		o				
-xuo	Kuo		u				
-xuo	Kuo		iː				
-xuo	Kuo		eː				
-xuo	Kuo		ɛː				
-xuo	Kuo		aː				
-xuo	Kuo		ɔː				
-xuo	Kuo		oː				
-xuo	Kuo		uː				
-xuo	Kuo		ĩ				
-xuo	Kuo		ẽ				
-xuo	Kuo		ã				
-xuo	Kuo		õ				
-xuo	Kuo		ũ				
-xuo	Kuo		ĩː				
-xuo	Kuo		ãː				
-xuo	Kuo		ẽː				
-xuo	Kuo		ɛ̃ː				
-xuo	Kuo		ũː				
-xuo	Kuo		ɔ̃ː				
-xuo	Kuo		˦				
-xuo	Kuo		˧				
-xuo	Kuo		˨				
-							
+xuo	Kuo		t
+xuo	Kuo		k
+xuo	Kuo		kp
+xuo	Kuo		b
+xuo	Kuo		d
+xuo	Kuo		ɡ
+xuo	Kuo		ɡb
+xuo	Kuo		ɓ
+xuo	Kuo		ɗ
+xuo	Kuo		f
+xuo	Kuo		s
+xuo	Kuo		h
+xuo	Kuo		v
+xuo	Kuo		z
+xuo	Kuo		mb
+xuo	Kuo		nd
+xuo	Kuo		n̠d̠ʒ
+xuo	Kuo		ŋɡ
+xuo	Kuo		ŋmɡb
+xuo	Kuo		m
+xuo	Kuo		n
+xuo	Kuo		ŋ
+xuo	Kuo		l
+xuo	Kuo		r
+xuo	Kuo		j
+xuo	Kuo		w
+xuo	Kuo		jʔ	“Karang and Kuo are the only Central languages reported so far having a glottalized glide, y? (Ubels and Ubels 1980:24); E. Ubels (1981:5) analyzes [ y? ] in Kuo as a palatalized allophone of the glottal stop before ?.” (Elders, 2006:48)
+xuo	Kuo		ⱱ
+xuo	Kuo		i
+xuo	Kuo		e
+xuo	Kuo		a
+xuo	Kuo		ɔ
+xuo	Kuo		o
+xuo	Kuo		u
+xuo	Kuo		iː
+xuo	Kuo		eː
+xuo	Kuo		ɛː
+xuo	Kuo		aː
+xuo	Kuo		ɔː
+xuo	Kuo		oː
+xuo	Kuo		uː
+xuo	Kuo		ĩ
+xuo	Kuo		ẽ
+xuo	Kuo		ã
+xuo	Kuo		õ
+xuo	Kuo		ũ
+xuo	Kuo		ĩː
+xuo	Kuo		ãː
+xuo	Kuo		ẽː
+xuo	Kuo		ɛ̃ː
+xuo	Kuo		ũː
+xuo	Kuo		ɔ̃ː
+xuo	Kuo		˦
+xuo	Kuo		˧
+xuo	Kuo		˨
+
 kbn	Kare		p				kebi.pdf
-kbn	Kare		t				
-kbn	Kare		k				
-kbn	Kare		kp				
-kbn	Kare		ʔ	word-initial only before vowels, may be phonetic			
-kbn	Kare		b				
-kbn	Kare		d				
-kbn	Kare		d̠ʒ				
-kbn	Kare		ɡ				
-kbn	Kare		ɡb				
-kbn	Kare		ɓ				
-kbn	Kare		ɗ				
-kbn	Kare		f				
-kbn	Kare		s				
-kbn	Kare		h				
-kbn	Kare		v				
-kbn	Kare		z				
-kbn	Kare		mb				
-kbn	Kare		nd				
-kbn	Kare		n̠d̠ʒ				
-kbn	Kare		ŋɡ				
-kbn	Kare		ŋmɡb				
-kbn	Kare		m				
-kbn	Kare		n				
-kbn	Kare		ŋ				
-kbn	Kare		l				
-kbn	Kare		r				
-kbn	Kare		j				
-kbn	Kare		w				
-kbn	Kare		ⱱ				
-kbn	Kare		i				
-kbn	Kare		e				
-kbn	Kare		a				
-kbn	Kare		ɔ				
-kbn	Kare		o				
-kbn	Kare		u				
-kbn	Kare		iː				
-kbn	Kare		eː				
-kbn	Kare		ɛː				
-kbn	Kare		aː				
-kbn	Kare		ɔː				
-kbn	Kare		oː				
-kbn	Kare		uː				
-kbn	Kare		ĩ				
-kbn	Kare		ẽ				
-kbn	Kare		ã				
-kbn	Kare		õ				
-kbn	Kare		ũ				
-kbn	Kare		ĩː				
-kbn	Kare		ãː				
-kbn	Kare		ẽː				
-kbn	Kare		ɛ̃ː				
-kbn	Kare		ũː				
-kbn	Kare		ɔ̃ː				
-kbn	Kare		˦				
-kbn	Kare		˧				
-kbn	Kare		˨				
-							
+kbn	Kare		t
+kbn	Kare		k
+kbn	Kare		kp
+kbn	Kare		ʔ	word-initial only before vowels, may be phonetic
+kbn	Kare		b
+kbn	Kare		d
+kbn	Kare		d̠ʒ
+kbn	Kare		ɡ
+kbn	Kare		ɡb
+kbn	Kare		ɓ
+kbn	Kare		ɗ
+kbn	Kare		f
+kbn	Kare		s
+kbn	Kare		h
+kbn	Kare		v
+kbn	Kare		z
+kbn	Kare		mb
+kbn	Kare		nd
+kbn	Kare		n̠d̠ʒ
+kbn	Kare		ŋɡ
+kbn	Kare		ŋmɡb
+kbn	Kare		m
+kbn	Kare		n
+kbn	Kare		ŋ
+kbn	Kare		l
+kbn	Kare		r
+kbn	Kare		j
+kbn	Kare		w
+kbn	Kare		ⱱ
+kbn	Kare		i
+kbn	Kare		e
+kbn	Kare		a
+kbn	Kare		ɔ
+kbn	Kare		o
+kbn	Kare		u
+kbn	Kare		iː
+kbn	Kare		eː
+kbn	Kare		ɛː
+kbn	Kare		aː
+kbn	Kare		ɔː
+kbn	Kare		oː
+kbn	Kare		uː
+kbn	Kare		ĩ
+kbn	Kare		ẽ
+kbn	Kare		ã
+kbn	Kare		õ
+kbn	Kare		ũ
+kbn	Kare		ĩː
+kbn	Kare		ãː
+kbn	Kare		ẽː
+kbn	Kare		ɛ̃ː
+kbn	Kare		ũː
+kbn	Kare		ɔ̃ː
+kbn	Kare		˦
+kbn	Kare		˧
+kbn	Kare		˨
+
 gke	Galke		p				kebi.pdf
-gke	Galke		t				
-gke	Galke		t̠ʃ				
-gke	Galke		k				
-gke	Galke		kp				
-gke	Galke		ʔ				
-gke	Galke		b				
-gke	Galke		d				
-gke	Galke		d̠ʒ				
-gke	Galke		ɡ				
-gke	Galke		ɡb				
-gke	Galke		ɓ				
-gke	Galke		ɗ				
-gke	Galke		f				
-gke	Galke		s				
-gke	Galke		ʃ				
-gke	Galke		h				
-gke	Galke		v				
-gke	Galke		z				
-gke	Galke		mb				
-gke	Galke		nd				
-gke	Galke		n̠d̠ʒ				
-gke	Galke		ŋɡ				
-gke	Galke		ŋmɡb				
-gke	Galke		m				
-gke	Galke		n				
-gke	Galke		ŋ				
-gke	Galke		l				
-gke	Galke		r				
-gke	Galke		j				
-gke	Galke		w				
-gke	Galke		ⱱ				
-gke	Galke		i				
-gke	Galke		e				
-gke	Galke		a				
-gke	Galke		ɔ				
-gke	Galke		o				
-gke	Galke		u				
-gke	Galke		iː				
-gke	Galke		eː				
-gke	Galke		ɛː				
-gke	Galke		aː				
-gke	Galke		ɔː				
-gke	Galke		oː				
-gke	Galke		uː				
-gke	Galke		ĩ				
-gke	Galke		ẽ				
-gke	Galke		õ				
-gke	Galke		ũ				
-gke	Galke		ã				
-gke	Galke		ĩː				
-gke	Galke		ãː				
-gke	Galke		ɔ̃ː				
-gke	Galke		ũː				
-gke	Galke		˦				
-gke	Galke		˧				
-gke	Galke		˨				
-							
+gke	Galke		t
+gke	Galke		t̠ʃ
+gke	Galke		k
+gke	Galke		kp
+gke	Galke		ʔ
+gke	Galke		b
+gke	Galke		d
+gke	Galke		d̠ʒ
+gke	Galke		ɡ
+gke	Galke		ɡb
+gke	Galke		ɓ
+gke	Galke		ɗ
+gke	Galke		f
+gke	Galke		s
+gke	Galke		ʃ
+gke	Galke		h
+gke	Galke		v
+gke	Galke		z
+gke	Galke		mb
+gke	Galke		nd
+gke	Galke		n̠d̠ʒ
+gke	Galke		ŋɡ
+gke	Galke		ŋmɡb
+gke	Galke		m
+gke	Galke		n
+gke	Galke		ŋ
+gke	Galke		l
+gke	Galke		r
+gke	Galke		j
+gke	Galke		w
+gke	Galke		ⱱ
+gke	Galke		i
+gke	Galke		e
+gke	Galke		a
+gke	Galke		ɔ
+gke	Galke		o
+gke	Galke		u
+gke	Galke		iː
+gke	Galke		eː
+gke	Galke		ɛː
+gke	Galke		aː
+gke	Galke		ɔː
+gke	Galke		oː
+gke	Galke		uː
+gke	Galke		ĩ
+gke	Galke		ẽ
+gke	Galke		õ
+gke	Galke		ũ
+gke	Galke		ã
+gke	Galke		ĩː
+gke	Galke		ãː
+gke	Galke		ɔ̃ː
+gke	Galke		ũː
+gke	Galke		˦
+gke	Galke		˧
+gke	Galke		˨
+
 myf	Northern Mao		p		[p]		myf.pdf
-myf	Northern Mao		p		[f]		
-myf	Northern Mao		p		[ɸ]		
-myf	Northern Mao		p		[pʲ]		
-myf	Northern Mao		p		[fʲ]		
-myf	Northern Mao		b				
-myf	Northern Mao		t		[t]		
-myf	Northern Mao		t		[tʷ]		
-myf	Northern Mao		d				
-myf	Northern Mao		k		[k]		
-myf	Northern Mao		k		[kʷ]		
-myf	Northern Mao		k		[kʲ]		
-myf	Northern Mao		ɡ		[ɡ]		
-myf	Northern Mao		ɡ		[ɡʷ]		
-myf	Northern Mao		ɡ		[ɡʲ]		
-myf	Northern Mao		pʼ		pʼ		
-myf	Northern Mao		pʼ		[pʲʼ]		
-myf	Northern Mao		tʼ		[tʼ]	intervocalic	
-myf	Northern Mao		tʼ		[ɗ]	intervocalic	
-myf	Northern Mao		tʼ		[tʷʼ]	intervocalic	
-myf	Northern Mao		kʼ		[kʼ]		
-myf	Northern Mao		kʼ		[kʷʼ]		
-myf	Northern Mao		kʼ		[kʲʼ]		
-myf	Northern Mao		s				
-myf	Northern Mao		z				
-myf	Northern Mao		ʃ		[ʃ]		
-myf	Northern Mao		ʃ		[ʃʷ]		
-myf	Northern Mao		h				
-myf	Northern Mao		<t̠ʃ>	marɡinal			
-myf	Northern Mao		tsʼ				
-myf	Northern Mao		l				
-myf	Northern Mao		r				
-myf	Northern Mao		m				
-myf	Northern Mao		n				
-myf	Northern Mao		ŋ				
-myf	Northern Mao		w				
-myf	Northern Mao		j				
-myf	Northern Mao		˦				
-myf	Northern Mao		˧				
-myf	Northern Mao		˨				
-myf	Northern Mao		ʔ	word initial, epenthetic			
-myf	Northern Mao		i				
-myf	Northern Mao		iː				
-myf	Northern Mao		u				
-myf	Northern Mao		uː				
-myf	Northern Mao		e				
-myf	Northern Mao		eː				
-myf	Northern Mao		o				
-myf	Northern Mao		oː				
-myf	Northern Mao		a				
-myf	Northern Mao		aː				
-							
+myf	Northern Mao		p		[f]
+myf	Northern Mao		p		[ɸ]
+myf	Northern Mao		p		[pʲ]
+myf	Northern Mao		p		[fʲ]
+myf	Northern Mao		b
+myf	Northern Mao		t		[t]
+myf	Northern Mao		t		[tʷ]
+myf	Northern Mao		d
+myf	Northern Mao		k		[k]
+myf	Northern Mao		k		[kʷ]
+myf	Northern Mao		k		[kʲ]
+myf	Northern Mao		ɡ		[ɡ]
+myf	Northern Mao		ɡ		[ɡʷ]
+myf	Northern Mao		ɡ		[ɡʲ]
+myf	Northern Mao		pʼ		pʼ
+myf	Northern Mao		pʼ		[pʲʼ]
+myf	Northern Mao		tʼ		[tʼ]	intervocalic
+myf	Northern Mao		tʼ		[ɗ]	intervocalic
+myf	Northern Mao		tʼ		[tʷʼ]	intervocalic
+myf	Northern Mao		kʼ		[kʼ]
+myf	Northern Mao		kʼ		[kʷʼ]
+myf	Northern Mao		kʼ		[kʲʼ]
+myf	Northern Mao		s
+myf	Northern Mao		z
+myf	Northern Mao		ʃ		[ʃ]
+myf	Northern Mao		ʃ		[ʃʷ]
+myf	Northern Mao		h
+myf	Northern Mao		<t̠ʃ>	marɡinal
+myf	Northern Mao		tsʼ
+myf	Northern Mao		l
+myf	Northern Mao		r
+myf	Northern Mao		m
+myf	Northern Mao		n
+myf	Northern Mao		ŋ
+myf	Northern Mao		w
+myf	Northern Mao		j
+myf	Northern Mao		˦
+myf	Northern Mao		˧
+myf	Northern Mao		˨
+myf	Northern Mao		ʔ	word initial, epenthetic
+myf	Northern Mao		i
+myf	Northern Mao		iː
+myf	Northern Mao		u
+myf	Northern Mao		uː
+myf	Northern Mao		e
+myf	Northern Mao		eː
+myf	Northern Mao		o
+myf	Northern Mao		oː
+myf	Northern Mao		a
+myf	Northern Mao		aː
+
 tir	Tigrinya		ʌ				tir.pdf
-tir	Tigrinya		u				
-tir	Tigrinya		i				
-tir	Tigrinya		a				
-tir	Tigrinya		e				
-tir	Tigrinya		ɨ				
-tir	Tigrinya		o				
-tir	Tigrinya		h				
-tir	Tigrinya		l		[l]		
-tir	Tigrinya		l		[lː]		
-tir	Tigrinya		ħ		[ħ]		
-tir	Tigrinya		ħ		[ħʷ]		
-tir	Tigrinya		m		[m]		
-tir	Tigrinya		m		[mː]		
-tir	Tigrinya		s		[s]		
-tir	Tigrinya		s		[sː]		
-tir	Tigrinya		ɾ		[ɾ]		
-tir	Tigrinya		ɾ		[ɾː]		
-tir	Tigrinya		ʃ		[ʃ]		
-tir	Tigrinya		ʃ		[ʃː]		
-tir	Tigrinya		q		[q]		
-tir	Tigrinya		q		[qʷ]		
-tir	Tigrinya		q		[qː]		
-tir	Tigrinya		qʼ		[qʼ̪]		
-tir	Tigrinya		qʼ		[qʷʼ]		
-tir	Tigrinya		qʼ		[qʼː]		
-tir	Tigrinya		b		[b]		
-tir	Tigrinya		b		[bː]		
-tir	Tigrinya		t		[t]		
-tir	Tigrinya		t		[tː]		
-tir	Tigrinya		t̠ʃ		[t̠ʃ]		
-tir	Tigrinya		t̠ʃ		[t̠ʃː]		
-tir	Tigrinya		n		[n]		
-tir	Tigrinya		n		[nː]		
-tir	Tigrinya		ɲ		[ɲ]		
-tir	Tigrinya		ɲ		[ɲː]		
-tir	Tigrinya		ʔ				
-tir	Tigrinya		k		[k]		
-tir	Tigrinya		k		[kʷ]		
-tir	Tigrinya		k		[kː]		
-tir	Tigrinya		x		[x]		
-tir	Tigrinya		x		[xʷ]		
-tir	Tigrinya		x		[xː]		
-tir	Tigrinya		w		[w]		
-tir	Tigrinya		w		[wː]		
-tir	Tigrinya		ʕ				
-tir	Tigrinya		z		[z]		
-tir	Tigrinya		z		[zː]		
-tir	Tigrinya		ʒ		[ʒ]		
-tir	Tigrinya		ʒ		[ʒː]		
-tir	Tigrinya		j		[j]		
-tir	Tigrinya		j		[jː]		
-tir	Tigrinya		d		[d]		
-tir	Tigrinya		d		[dː]		
-tir	Tigrinya		d̠ʒ		[d̠ʒ]		
-tir	Tigrinya		d̠ʒ		[d̠ʒː]		
-tir	Tigrinya		ɡ		[ɡ]		
-tir	Tigrinya		ɡ		[ɡʷ]		
-tir	Tigrinya		ɡ		[ɡː]		
-tir	Tigrinya		tʼ		[tʼ]		
-tir	Tigrinya		tʼ		[tʼː]		
-tir	Tigrinya		cʼ		[cʼ]		
-tir	Tigrinya		cʼ		[cʼː]		
-tir	Tigrinya		pʼ		[pʼ]		
-tir	Tigrinya		pʼ		[pʼː]		
-tir	Tigrinya		sʼ		[sʼ]		
-tir	Tigrinya		sʼ		[sʼː]		
-tir	Tigrinya		f		[fː]		
-tir	Tigrinya		f		[f]		
-tir	Tigrinya		p		[p]		
-tir	Tigrinya		p		[pː]		
-tir	Tigrinya		<v>	loanwords from English			
-							
+tir	Tigrinya		u
+tir	Tigrinya		i
+tir	Tigrinya		a
+tir	Tigrinya		e
+tir	Tigrinya		ɨ
+tir	Tigrinya		o
+tir	Tigrinya		h
+tir	Tigrinya		l		[l]
+tir	Tigrinya		l		[lː]
+tir	Tigrinya		ħ		[ħ]
+tir	Tigrinya		ħ		[ħʷ]
+tir	Tigrinya		m		[m]
+tir	Tigrinya		m		[mː]
+tir	Tigrinya		s		[s]
+tir	Tigrinya		s		[sː]
+tir	Tigrinya		ɾ		[ɾ]
+tir	Tigrinya		ɾ		[ɾː]
+tir	Tigrinya		ʃ		[ʃ]
+tir	Tigrinya		ʃ		[ʃː]
+tir	Tigrinya		q		[q]
+tir	Tigrinya		q		[qʷ]
+tir	Tigrinya		q		[qː]
+tir	Tigrinya		qʼ		[qʼ̪]
+tir	Tigrinya		qʼ		[qʷʼ]
+tir	Tigrinya		qʼ		[qʼː]
+tir	Tigrinya		b		[b]
+tir	Tigrinya		b		[bː]
+tir	Tigrinya		t		[t]
+tir	Tigrinya		t		[tː]
+tir	Tigrinya		t̠ʃ		[t̠ʃ]
+tir	Tigrinya		t̠ʃ		[t̠ʃː]
+tir	Tigrinya		n		[n]
+tir	Tigrinya		n		[nː]
+tir	Tigrinya		ɲ		[ɲ]
+tir	Tigrinya		ɲ		[ɲː]
+tir	Tigrinya		ʔ
+tir	Tigrinya		k		[k]
+tir	Tigrinya		k		[kʷ]
+tir	Tigrinya		k		[kː]
+tir	Tigrinya		x		[x]
+tir	Tigrinya		x		[xʷ]
+tir	Tigrinya		x		[xː]
+tir	Tigrinya		w		[w]
+tir	Tigrinya		w		[wː]
+tir	Tigrinya		ʕ
+tir	Tigrinya		z		[z]
+tir	Tigrinya		z		[zː]
+tir	Tigrinya		ʒ		[ʒ]
+tir	Tigrinya		ʒ		[ʒː]
+tir	Tigrinya		j		[j]
+tir	Tigrinya		j		[jː]
+tir	Tigrinya		d		[d]
+tir	Tigrinya		d		[dː]
+tir	Tigrinya		d̠ʒ		[d̠ʒ]
+tir	Tigrinya		d̠ʒ		[d̠ʒː]
+tir	Tigrinya		ɡ		[ɡ]
+tir	Tigrinya		ɡ		[ɡʷ]
+tir	Tigrinya		ɡ		[ɡː]
+tir	Tigrinya		tʼ		[tʼ]
+tir	Tigrinya		tʼ		[tʼː]
+tir	Tigrinya		cʼ		[cʼ]
+tir	Tigrinya		cʼ		[cʼː]
+tir	Tigrinya		pʼ		[pʼ]
+tir	Tigrinya		pʼ		[pʼː]
+tir	Tigrinya		sʼ		[sʼ]
+tir	Tigrinya		sʼ		[sʼː]
+tir	Tigrinya		f		[fː]
+tir	Tigrinya		f		[f]
+tir	Tigrinya		p		[p]
+tir	Tigrinya		p		[pː]
+tir	Tigrinya		<v>	loanwords from English
+
 kdj	Karimojong		i				kdj.pdf
-kdj	Karimojong		y				
-kdj	Karimojong		e				
-kdj	Karimojong		ɪ				
-kdj	Karimojong		ɛ				
-kdj	Karimojong		œ				
-kdj	Karimojong		a				
-kdj	Karimojong		u				
-kdj	Karimojong		ʊ				
-kdj	Karimojong		o				
-kdj	Karimojong		ɔ				
-kdj	Karimojong		ɑ				
-kdj	Karimojong		ɵ				
-kdj	Karimojong		iː				
-kdj	Karimojong		yː				
-kdj	Karimojong		eː				
-kdj	Karimojong		ɪː				
-kdj	Karimojong		ɛː				
-kdj	Karimojong		œː				
-kdj	Karimojong		aː				
-kdj	Karimojong		uː				
-kdj	Karimojong		ʊː				
-kdj	Karimojong		oː				
-kdj	Karimojong		ɔː				
-kdj	Karimojong		ɑː				
-kdj	Karimojong		ɵː				
-kdj	Karimojong		i̤				
-kdj	Karimojong		y̤				
-kdj	Karimojong		e̤				
-kdj	Karimojong		ɪ̤				
-kdj	Karimojong		ɛ̤				
-kdj	Karimojong		œ̤				
-kdj	Karimojong		a̤				
-kdj	Karimojong		ṳ				
-kdj	Karimojong		ʊ̤				
-kdj	Karimojong		o̤				
-kdj	Karimojong		ɔ̤				
-kdj	Karimojong		ɑ̤				
-kdj	Karimojong		ɵ̤				
-kdj	Karimojong		w				
-kdj	Karimojong		j				
-kdj	Karimojong		p				
-kdj	Karimojong		b				
-kdj	Karimojong		t				
-kdj	Karimojong		d				
-kdj	Karimojong		k				
-kdj	Karimojong		ɡ				
-kdj	Karimojong		ts				
-kdj	Karimojong		dz				
-kdj	Karimojong		m				
-kdj	Karimojong		n		[n]		
-kdj	Karimojong		n		[ɲ]		
-kdj	Karimojong		ɲ				
-kdj	Karimojong		ŋ				
-kdj	Karimojong		l				
-kdj	Karimojong		r				
-kdj	Karimojong		ð				
-kdj	Karimojong		s				
-kdj	Karimojong		z		[z]		
-kdj	Karimojong		z		[s]		
-kdj	Karimojong		ɣ				
-kdj	Karimojong		ʔ	epenthetic			
-kdj	Karimojong		˦				
-kdj	Karimojong		˧				
-kdj	Karimojong		˨				
-kdj	Karimojong		˦˨				
-kdj	Karimojong		˨˧				
-kdj	Karimojong		˧˨				
-							
+kdj	Karimojong		y
+kdj	Karimojong		e
+kdj	Karimojong		ɪ
+kdj	Karimojong		ɛ
+kdj	Karimojong		œ
+kdj	Karimojong		a
+kdj	Karimojong		u
+kdj	Karimojong		ʊ
+kdj	Karimojong		o
+kdj	Karimojong		ɔ
+kdj	Karimojong		ɑ
+kdj	Karimojong		ɵ
+kdj	Karimojong		iː
+kdj	Karimojong		yː
+kdj	Karimojong		eː
+kdj	Karimojong		ɪː
+kdj	Karimojong		ɛː
+kdj	Karimojong		œː
+kdj	Karimojong		aː
+kdj	Karimojong		uː
+kdj	Karimojong		ʊː
+kdj	Karimojong		oː
+kdj	Karimojong		ɔː
+kdj	Karimojong		ɑː
+kdj	Karimojong		ɵː
+kdj	Karimojong		i̤
+kdj	Karimojong		y̤
+kdj	Karimojong		e̤
+kdj	Karimojong		ɪ̤
+kdj	Karimojong		ɛ̤
+kdj	Karimojong		œ̤
+kdj	Karimojong		a̤
+kdj	Karimojong		ṳ
+kdj	Karimojong		ʊ̤
+kdj	Karimojong		o̤
+kdj	Karimojong		ɔ̤
+kdj	Karimojong		ɑ̤
+kdj	Karimojong		ɵ̤
+kdj	Karimojong		w
+kdj	Karimojong		j
+kdj	Karimojong		p
+kdj	Karimojong		b
+kdj	Karimojong		t
+kdj	Karimojong		d
+kdj	Karimojong		k
+kdj	Karimojong		ɡ
+kdj	Karimojong		ts
+kdj	Karimojong		dz
+kdj	Karimojong		m
+kdj	Karimojong		n		[n]
+kdj	Karimojong		n		[ɲ]
+kdj	Karimojong		ɲ
+kdj	Karimojong		ŋ
+kdj	Karimojong		l
+kdj	Karimojong		r
+kdj	Karimojong		ð
+kdj	Karimojong		s
+kdj	Karimojong		z		[z]
+kdj	Karimojong		z		[s]
+kdj	Karimojong		ɣ
+kdj	Karimojong		ʔ	epenthetic
+kdj	Karimojong		˦
+kdj	Karimojong		˧
+kdj	Karimojong		˨
+kdj	Karimojong		˦˨
+kdj	Karimojong		˨˧
+kdj	Karimojong		˧˨
+
 gwn	Gwandara (Karshi)	Karshi	i		[i]		gwn.pdf
-gwn	Gwandara (Karshi)	Karshi	i		[ɨ]	after velar consonants	
-gwn	Gwandara (Karshi)	Karshi	e		[e]		
-gwn	Gwandara (Karshi)	Karshi	e		[ə]	after velar consonants	
-gwn	Gwandara (Karshi)	Karshi	a				
-gwn	Gwandara (Karshi)	Karshi	o				
-gwn	Gwandara (Karshi)	Karshi	u				
-gwn	Gwandara (Karshi)	Karshi	ĩ				
-gwn	Gwandara (Karshi)	Karshi	ẽ				
-gwn	Gwandara (Karshi)	Karshi	ã				
-gwn	Gwandara (Karshi)	Karshi	õ				
-gwn	Gwandara (Karshi)	Karshi	ũ				
-gwn	Gwandara (Karshi)	Karshi	p				
-gwn	Gwandara (Karshi)	Karshi	b				
-gwn	Gwandara (Karshi)	Karshi	t				
-gwn	Gwandara (Karshi)	Karshi	d				
-gwn	Gwandara (Karshi)	Karshi	k				
-gwn	Gwandara (Karshi)	Karshi	ɡ				
-gwn	Gwandara (Karshi)	Karshi	kp				
-gwn	Gwandara (Karshi)	Karshi	ɡb				
-gwn	Gwandara (Karshi)	Karshi	s				
-gwn	Gwandara (Karshi)	Karshi	z				
-gwn	Gwandara (Karshi)	Karshi	ʃ				
-gwn	Gwandara (Karshi)	Karshi	t̠ʃ				
-gwn	Gwandara (Karshi)	Karshi	d̠ʒ				
-gwn	Gwandara (Karshi)	Karshi	m				
-gwn	Gwandara (Karshi)	Karshi	n				
-gwn	Gwandara (Karshi)	Karshi	ɾ		[ɾ]		
-gwn	Gwandara (Karshi)	Karshi	ɾ		[ɾ̃]		
-gwn	Gwandara (Karshi)	Karshi	l				
-gwn	Gwandara (Karshi)	Karshi	j		[j]		
-gwn	Gwandara (Karshi)	Karshi	j		[j̃]		
-gwn	Gwandara (Karshi)	Karshi	w		[w]		
-gwn	Gwandara (Karshi)	Karshi	w		[w̃]		
-gwn	Gwandara (Karshi)	Karshi	bʷ				
-gwn	Gwandara (Karshi)	Karshi	t̠ʃʷ				
-gwn	Gwandara (Karshi)	Karshi	kʷ				
-gwn	Gwandara (Karshi)	Karshi	ɡʷ				
-gwn	Gwandara (Karshi)	Karshi	hʷ				
-gwn	Gwandara (Karshi)	Karshi	h				
-gwn	Gwandara (Karshi)	Karshi	pʲ				
-gwn	Gwandara (Karshi)	Karshi	kʲ				
-gwn	Gwandara (Karshi)	Karshi	ɡʲ				
-gwn	Gwandara (Karshi)	Karshi	˦				
-gwn	Gwandara (Karshi)	Karshi	˧				
-gwn	Gwandara (Karshi)	Karshi	˨				
-gwn	Gwandara (Karshi)	Karshi	˨˧				
-gwn	Gwandara (Karshi)	Karshi	˨˧				
-gwn	Gwandara (Karshi)	Karshi	˨˦				
-gwn	Gwandara (Karshi)	Karshi	˧˨				
-gwn	Gwandara (Karshi)	Karshi	˦˨				
-gwn	Gwandara (Karshi)	Karshi	˦˧				
-							
+gwn	Gwandara (Karshi)	Karshi	i		[ɨ]	after velar consonants
+gwn	Gwandara (Karshi)	Karshi	e		[e]
+gwn	Gwandara (Karshi)	Karshi	e		[ə]	after velar consonants
+gwn	Gwandara (Karshi)	Karshi	a
+gwn	Gwandara (Karshi)	Karshi	o
+gwn	Gwandara (Karshi)	Karshi	u
+gwn	Gwandara (Karshi)	Karshi	ĩ
+gwn	Gwandara (Karshi)	Karshi	ẽ
+gwn	Gwandara (Karshi)	Karshi	ã
+gwn	Gwandara (Karshi)	Karshi	õ
+gwn	Gwandara (Karshi)	Karshi	ũ
+gwn	Gwandara (Karshi)	Karshi	p
+gwn	Gwandara (Karshi)	Karshi	b
+gwn	Gwandara (Karshi)	Karshi	t
+gwn	Gwandara (Karshi)	Karshi	d
+gwn	Gwandara (Karshi)	Karshi	k
+gwn	Gwandara (Karshi)	Karshi	ɡ
+gwn	Gwandara (Karshi)	Karshi	kp
+gwn	Gwandara (Karshi)	Karshi	ɡb
+gwn	Gwandara (Karshi)	Karshi	s
+gwn	Gwandara (Karshi)	Karshi	z
+gwn	Gwandara (Karshi)	Karshi	ʃ
+gwn	Gwandara (Karshi)	Karshi	t̠ʃ
+gwn	Gwandara (Karshi)	Karshi	d̠ʒ
+gwn	Gwandara (Karshi)	Karshi	m
+gwn	Gwandara (Karshi)	Karshi	n
+gwn	Gwandara (Karshi)	Karshi	ɾ		[ɾ]
+gwn	Gwandara (Karshi)	Karshi	ɾ		[ɾ̃]
+gwn	Gwandara (Karshi)	Karshi	l
+gwn	Gwandara (Karshi)	Karshi	j		[j]
+gwn	Gwandara (Karshi)	Karshi	j		[j̃]
+gwn	Gwandara (Karshi)	Karshi	w		[w]
+gwn	Gwandara (Karshi)	Karshi	w		[w̃]
+gwn	Gwandara (Karshi)	Karshi	bʷ
+gwn	Gwandara (Karshi)	Karshi	t̠ʃʷ
+gwn	Gwandara (Karshi)	Karshi	kʷ
+gwn	Gwandara (Karshi)	Karshi	ɡʷ
+gwn	Gwandara (Karshi)	Karshi	hʷ
+gwn	Gwandara (Karshi)	Karshi	h
+gwn	Gwandara (Karshi)	Karshi	pʲ
+gwn	Gwandara (Karshi)	Karshi	kʲ
+gwn	Gwandara (Karshi)	Karshi	ɡʲ
+gwn	Gwandara (Karshi)	Karshi	˦
+gwn	Gwandara (Karshi)	Karshi	˧
+gwn	Gwandara (Karshi)	Karshi	˨
+gwn	Gwandara (Karshi)	Karshi	˨˧
+gwn	Gwandara (Karshi)	Karshi	˨˧
+gwn	Gwandara (Karshi)	Karshi	˨˦
+gwn	Gwandara (Karshi)	Karshi	˧˨
+gwn	Gwandara (Karshi)	Karshi	˦˨
+gwn	Gwandara (Karshi)	Karshi	˦˧
+
 gwn	Gwandara (Cancara)	Cancara	i				gwn.pdf
-gwn	Gwandara (Cancara)	Cancara	e				
-gwn	Gwandara (Cancara)	Cancara	a				
-gwn	Gwandara (Cancara)	Cancara	o				
-gwn	Gwandara (Cancara)	Cancara	u				
-gwn	Gwandara (Cancara)	Cancara	ɨ				
-gwn	Gwandara (Cancara)	Cancara	ə				
-gwn	Gwandara (Cancara)	Cancara	ĩ				
-gwn	Gwandara (Cancara)	Cancara	ẽ				
-gwn	Gwandara (Cancara)	Cancara	ã				
-gwn	Gwandara (Cancara)	Cancara	õ				
-gwn	Gwandara (Cancara)	Cancara	ũ				
-gwn	Gwandara (Cancara)	Cancara	p				
-gwn	Gwandara (Cancara)	Cancara	b				
-gwn	Gwandara (Cancara)	Cancara	t				
-gwn	Gwandara (Cancara)	Cancara	d				
-gwn	Gwandara (Cancara)	Cancara	k				
-gwn	Gwandara (Cancara)	Cancara	ɡ				
-gwn	Gwandara (Cancara)	Cancara	kp				
-gwn	Gwandara (Cancara)	Cancara	ɡb				
-gwn	Gwandara (Cancara)	Cancara	ʔ				
-gwn	Gwandara (Cancara)	Cancara	f				
-gwn	Gwandara (Cancara)	Cancara	s				
-gwn	Gwandara (Cancara)	Cancara	z				
-gwn	Gwandara (Cancara)	Cancara	ʃ				
-gwn	Gwandara (Cancara)	Cancara	t̠ʃ				
-gwn	Gwandara (Cancara)	Cancara	d̠ʒ				
-gwn	Gwandara (Cancara)	Cancara	m				
-gwn	Gwandara (Cancara)	Cancara	n				
-gwn	Gwandara (Cancara)	Cancara	ŋ				
-gwn	Gwandara (Cancara)	Cancara	ɾ		[ɾ]		
-gwn	Gwandara (Cancara)	Cancara	ɾ		[ɾ̃]		
-gwn	Gwandara (Cancara)	Cancara	l				
-gwn	Gwandara (Cancara)	Cancara	j		[j]		
-gwn	Gwandara (Cancara)	Cancara	j		[j̃]		
-gwn	Gwandara (Cancara)	Cancara	w		[w]		
-gwn	Gwandara (Cancara)	Cancara	w		[w̃]		
-gwn	Gwandara (Cancara)	Cancara	bʷ				
-gwn	Gwandara (Cancara)	Cancara	tʷ				
-gwn	Gwandara (Cancara)	Cancara	t̠ʃʷ				
-gwn	Gwandara (Cancara)	Cancara	kʷ				
-gwn	Gwandara (Cancara)	Cancara	ɡʷ				
-gwn	Gwandara (Cancara)	Cancara	hʷ				
-gwn	Gwandara (Cancara)	Cancara	h				
-gwn	Gwandara (Cancara)	Cancara	ç				
-gwn	Gwandara (Cancara)	Cancara	kʲ				
-gwn	Gwandara (Cancara)	Cancara	ɡʲ				
-gwn	Gwandara (Cancara)	Cancara	˦				
-gwn	Gwandara (Cancara)	Cancara	˧				
-gwn	Gwandara (Cancara)	Cancara	˨				
-gwn	Gwandara (Cancara)	Cancara	˨˧				
-gwn	Gwandara (Cancara)	Cancara	˨˧				
-gwn	Gwandara (Cancara)	Cancara	˨˦				
-gwn	Gwandara (Cancara)	Cancara	˧˨				
-gwn	Gwandara (Cancara)	Cancara	˦˨				
-gwn	Gwandara (Cancara)	Cancara	˦˧				
-							
+gwn	Gwandara (Cancara)	Cancara	e
+gwn	Gwandara (Cancara)	Cancara	a
+gwn	Gwandara (Cancara)	Cancara	o
+gwn	Gwandara (Cancara)	Cancara	u
+gwn	Gwandara (Cancara)	Cancara	ɨ
+gwn	Gwandara (Cancara)	Cancara	ə
+gwn	Gwandara (Cancara)	Cancara	ĩ
+gwn	Gwandara (Cancara)	Cancara	ẽ
+gwn	Gwandara (Cancara)	Cancara	ã
+gwn	Gwandara (Cancara)	Cancara	õ
+gwn	Gwandara (Cancara)	Cancara	ũ
+gwn	Gwandara (Cancara)	Cancara	p
+gwn	Gwandara (Cancara)	Cancara	b
+gwn	Gwandara (Cancara)	Cancara	t
+gwn	Gwandara (Cancara)	Cancara	d
+gwn	Gwandara (Cancara)	Cancara	k
+gwn	Gwandara (Cancara)	Cancara	ɡ
+gwn	Gwandara (Cancara)	Cancara	kp
+gwn	Gwandara (Cancara)	Cancara	ɡb
+gwn	Gwandara (Cancara)	Cancara	ʔ
+gwn	Gwandara (Cancara)	Cancara	f
+gwn	Gwandara (Cancara)	Cancara	s
+gwn	Gwandara (Cancara)	Cancara	z
+gwn	Gwandara (Cancara)	Cancara	ʃ
+gwn	Gwandara (Cancara)	Cancara	t̠ʃ
+gwn	Gwandara (Cancara)	Cancara	d̠ʒ
+gwn	Gwandara (Cancara)	Cancara	m
+gwn	Gwandara (Cancara)	Cancara	n
+gwn	Gwandara (Cancara)	Cancara	ŋ
+gwn	Gwandara (Cancara)	Cancara	ɾ		[ɾ]
+gwn	Gwandara (Cancara)	Cancara	ɾ		[ɾ̃]
+gwn	Gwandara (Cancara)	Cancara	l
+gwn	Gwandara (Cancara)	Cancara	j		[j]
+gwn	Gwandara (Cancara)	Cancara	j		[j̃]
+gwn	Gwandara (Cancara)	Cancara	w		[w]
+gwn	Gwandara (Cancara)	Cancara	w		[w̃]
+gwn	Gwandara (Cancara)	Cancara	bʷ
+gwn	Gwandara (Cancara)	Cancara	tʷ
+gwn	Gwandara (Cancara)	Cancara	t̠ʃʷ
+gwn	Gwandara (Cancara)	Cancara	kʷ
+gwn	Gwandara (Cancara)	Cancara	ɡʷ
+gwn	Gwandara (Cancara)	Cancara	hʷ
+gwn	Gwandara (Cancara)	Cancara	h
+gwn	Gwandara (Cancara)	Cancara	ç
+gwn	Gwandara (Cancara)	Cancara	kʲ
+gwn	Gwandara (Cancara)	Cancara	ɡʲ
+gwn	Gwandara (Cancara)	Cancara	˦
+gwn	Gwandara (Cancara)	Cancara	˧
+gwn	Gwandara (Cancara)	Cancara	˨
+gwn	Gwandara (Cancara)	Cancara	˨˧
+gwn	Gwandara (Cancara)	Cancara	˨˧
+gwn	Gwandara (Cancara)	Cancara	˨˦
+gwn	Gwandara (Cancara)	Cancara	˧˨
+gwn	Gwandara (Cancara)	Cancara	˦˨
+gwn	Gwandara (Cancara)	Cancara	˦˧
+
 gwn	Gwandara (Toni)	Toni	i		[i]		gwn.pdf
-gwn	Gwandara (Toni)	Toni	i		[ɨ]	after velar consonants	
-gwn	Gwandara (Toni)	Toni	e				
-gwn	Gwandara (Toni)	Toni	a				
-gwn	Gwandara (Toni)	Toni	o				
-gwn	Gwandara (Toni)	Toni	u				
-gwn	Gwandara (Toni)	Toni	ə				
-gwn	Gwandara (Toni)	Toni	ĩ				
-gwn	Gwandara (Toni)	Toni	ẽ				
-gwn	Gwandara (Toni)	Toni	ã				
-gwn	Gwandara (Toni)	Toni	õ				
-gwn	Gwandara (Toni)	Toni	ũ				
-gwn	Gwandara (Toni)	Toni	ə̃				
-gwn	Gwandara (Toni)	Toni	˦				
-gwn	Gwandara (Toni)	Toni	˧				
-gwn	Gwandara (Toni)	Toni	˨				
-gwn	Gwandara (Toni)	Toni	˨˧				
-gwn	Gwandara (Toni)	Toni	˨˧				
-gwn	Gwandara (Toni)	Toni	˨˦				
-gwn	Gwandara (Toni)	Toni	˧˨				
-gwn	Gwandara (Toni)	Toni	˦˨				
-gwn	Gwandara (Toni)	Toni	˦˧				
-gwn	Gwandara (Toni)	Toni	p				
-gwn	Gwandara (Toni)	Toni	b				
-gwn	Gwandara (Toni)	Toni	t				
-gwn	Gwandara (Toni)	Toni	d				
-gwn	Gwandara (Toni)	Toni	k				
-gwn	Gwandara (Toni)	Toni	ɡ				
-gwn	Gwandara (Toni)	Toni	kp				
-gwn	Gwandara (Toni)	Toni	ɡb				
-gwn	Gwandara (Toni)	Toni	f				
-gwn	Gwandara (Toni)	Toni	s				
-gwn	Gwandara (Toni)	Toni	z				
-gwn	Gwandara (Toni)	Toni	ʃ				
-gwn	Gwandara (Toni)	Toni	ʒ				
-gwn	Gwandara (Toni)	Toni	h				
-gwn	Gwandara (Toni)	Toni	m				
-gwn	Gwandara (Toni)	Toni	n				
-gwn	Gwandara (Toni)	Toni	ɾ		[ɾ]		
-gwn	Gwandara (Toni)	Toni	ɾ		[ɾ̃]		
-gwn	Gwandara (Toni)	Toni	l				
-gwn	Gwandara (Toni)	Toni	j		[j]		
-gwn	Gwandara (Toni)	Toni	j		[j̃]		
-gwn	Gwandara (Toni)	Toni	w		[w]		
-gwn	Gwandara (Toni)	Toni	w		[w̃]		
-gwn	Gwandara (Toni)	Toni	bʷ				
-gwn	Gwandara (Toni)	Toni	fʷ				
-gwn	Gwandara (Toni)	Toni	sʷ				
-gwn	Gwandara (Toni)	Toni	kʷ				
-gwn	Gwandara (Toni)	Toni	ɡʷ				
-gwn	Gwandara (Toni)	Toni	mʷ				
-gwn	Gwandara (Toni)	Toni	kʲ				
-gwn	Gwandara (Toni)	Toni	ɡʲ				
-							
+gwn	Gwandara (Toni)	Toni	i		[ɨ]	after velar consonants
+gwn	Gwandara (Toni)	Toni	e
+gwn	Gwandara (Toni)	Toni	a
+gwn	Gwandara (Toni)	Toni	o
+gwn	Gwandara (Toni)	Toni	u
+gwn	Gwandara (Toni)	Toni	ə
+gwn	Gwandara (Toni)	Toni	ĩ
+gwn	Gwandara (Toni)	Toni	ẽ
+gwn	Gwandara (Toni)	Toni	ã
+gwn	Gwandara (Toni)	Toni	õ
+gwn	Gwandara (Toni)	Toni	ũ
+gwn	Gwandara (Toni)	Toni	ə̃
+gwn	Gwandara (Toni)	Toni	˦
+gwn	Gwandara (Toni)	Toni	˧
+gwn	Gwandara (Toni)	Toni	˨
+gwn	Gwandara (Toni)	Toni	˨˧
+gwn	Gwandara (Toni)	Toni	˨˧
+gwn	Gwandara (Toni)	Toni	˨˦
+gwn	Gwandara (Toni)	Toni	˧˨
+gwn	Gwandara (Toni)	Toni	˦˨
+gwn	Gwandara (Toni)	Toni	˦˧
+gwn	Gwandara (Toni)	Toni	p
+gwn	Gwandara (Toni)	Toni	b
+gwn	Gwandara (Toni)	Toni	t
+gwn	Gwandara (Toni)	Toni	d
+gwn	Gwandara (Toni)	Toni	k
+gwn	Gwandara (Toni)	Toni	ɡ
+gwn	Gwandara (Toni)	Toni	kp
+gwn	Gwandara (Toni)	Toni	ɡb
+gwn	Gwandara (Toni)	Toni	f
+gwn	Gwandara (Toni)	Toni	s
+gwn	Gwandara (Toni)	Toni	z
+gwn	Gwandara (Toni)	Toni	ʃ
+gwn	Gwandara (Toni)	Toni	ʒ
+gwn	Gwandara (Toni)	Toni	h
+gwn	Gwandara (Toni)	Toni	m
+gwn	Gwandara (Toni)	Toni	n
+gwn	Gwandara (Toni)	Toni	ɾ		[ɾ]
+gwn	Gwandara (Toni)	Toni	ɾ		[ɾ̃]
+gwn	Gwandara (Toni)	Toni	l
+gwn	Gwandara (Toni)	Toni	j		[j]
+gwn	Gwandara (Toni)	Toni	j		[j̃]
+gwn	Gwandara (Toni)	Toni	w		[w]
+gwn	Gwandara (Toni)	Toni	w		[w̃]
+gwn	Gwandara (Toni)	Toni	bʷ
+gwn	Gwandara (Toni)	Toni	fʷ
+gwn	Gwandara (Toni)	Toni	sʷ
+gwn	Gwandara (Toni)	Toni	kʷ
+gwn	Gwandara (Toni)	Toni	ɡʷ
+gwn	Gwandara (Toni)	Toni	mʷ
+gwn	Gwandara (Toni)	Toni	kʲ
+gwn	Gwandara (Toni)	Toni	ɡʲ
+
 gwn	Gwandara (Gitata)	Gitata	i				gwn.pdf
-gwn	Gwandara (Gitata)	Gitata	e				
-gwn	Gwandara (Gitata)	Gitata	ɨ				
-gwn	Gwandara (Gitata)	Gitata	ə				
-gwn	Gwandara (Gitata)	Gitata	a				
-gwn	Gwandara (Gitata)	Gitata	o				
-gwn	Gwandara (Gitata)	Gitata	u				
-gwn	Gwandara (Gitata)	Gitata	iː				
-gwn	Gwandara (Gitata)	Gitata	eː				
-gwn	Gwandara (Gitata)	Gitata	əː				
-gwn	Gwandara (Gitata)	Gitata	aː				
-gwn	Gwandara (Gitata)	Gitata	oː				
-gwn	Gwandara (Gitata)	Gitata	uː				
-gwn	Gwandara (Gitata)	Gitata	ĩ				
-gwn	Gwandara (Gitata)	Gitata	əː				
-gwn	Gwandara (Gitata)	Gitata	ã				
-gwn	Gwandara (Gitata)	Gitata	õ				
-gwn	Gwandara (Gitata)	Gitata	ũ				
-gwn	Gwandara (Gitata)	Gitata	ĩː				
-gwn	Gwandara (Gitata)	Gitata	ẽː				
-gwn	Gwandara (Gitata)	Gitata	ə̃ː				
-gwn	Gwandara (Gitata)	Gitata	ãː				
-gwn	Gwandara (Gitata)	Gitata	p				
-gwn	Gwandara (Gitata)	Gitata	b				
-gwn	Gwandara (Gitata)	Gitata	t				
-gwn	Gwandara (Gitata)	Gitata	d				
-gwn	Gwandara (Gitata)	Gitata	k				
-gwn	Gwandara (Gitata)	Gitata	ɡ				
-gwn	Gwandara (Gitata)	Gitata	kp				
-gwn	Gwandara (Gitata)	Gitata	ɡb				
-gwn	Gwandara (Gitata)	Gitata	f				
-gwn	Gwandara (Gitata)	Gitata	s				
-gwn	Gwandara (Gitata)	Gitata	z				
-gwn	Gwandara (Gitata)	Gitata	ʃ				
-gwn	Gwandara (Gitata)	Gitata	x				
-gwn	Gwandara (Gitata)	Gitata	h				
-gwn	Gwandara (Gitata)	Gitata	ts				
-gwn	Gwandara (Gitata)	Gitata	t̠ʃ				
-gwn	Gwandara (Gitata)	Gitata	d̠ʒ				
-gwn	Gwandara (Gitata)	Gitata	m				
-gwn	Gwandara (Gitata)	Gitata	n				
-gwn	Gwandara (Gitata)	Gitata	ŋ				
-gwn	Gwandara (Gitata)	Gitata	ɾ				
-gwn	Gwandara (Gitata)	Gitata	l				
-gwn	Gwandara (Gitata)	Gitata	j		[j]		
-gwn	Gwandara (Gitata)	Gitata	j		[j̃]		
-gwn	Gwandara (Gitata)	Gitata	w		[w]		
-gwn	Gwandara (Gitata)	Gitata	w		[w̃]		
-gwn	Gwandara (Gitata)	Gitata	pʷ				
-gwn	Gwandara (Gitata)	Gitata	bʷ				
-gwn	Gwandara (Gitata)	Gitata	tsʷ				
-gwn	Gwandara (Gitata)	Gitata	fʷ				
-gwn	Gwandara (Gitata)	Gitata	kʷ				
-gwn	Gwandara (Gitata)	Gitata	ɡʷ				
-gwn	Gwandara (Gitata)	Gitata	xʷ				
-gwn	Gwandara (Gitata)	Gitata	mʷ				
-gwn	Gwandara (Gitata)	Gitata	bʲ				
-gwn	Gwandara (Gitata)	Gitata	kʲ				
-gwn	Gwandara (Gitata)	Gitata	ɡʲ				
-gwn	Gwandara (Gitata)	Gitata	˦				
-gwn	Gwandara (Gitata)	Gitata	˧				
-gwn	Gwandara (Gitata)	Gitata	˨				
-gwn	Gwandara (Gitata)	Gitata	˨˧				
-gwn	Gwandara (Gitata)	Gitata	˨˧				
-gwn	Gwandara (Gitata)	Gitata	˨˦				
-gwn	Gwandara (Gitata)	Gitata	˧˨				
-gwn	Gwandara (Gitata)	Gitata	˦˨				
-gwn	Gwandara (Gitata)	Gitata	˦˧				
-							
+gwn	Gwandara (Gitata)	Gitata	e
+gwn	Gwandara (Gitata)	Gitata	ɨ
+gwn	Gwandara (Gitata)	Gitata	ə
+gwn	Gwandara (Gitata)	Gitata	a
+gwn	Gwandara (Gitata)	Gitata	o
+gwn	Gwandara (Gitata)	Gitata	u
+gwn	Gwandara (Gitata)	Gitata	iː
+gwn	Gwandara (Gitata)	Gitata	eː
+gwn	Gwandara (Gitata)	Gitata	əː
+gwn	Gwandara (Gitata)	Gitata	aː
+gwn	Gwandara (Gitata)	Gitata	oː
+gwn	Gwandara (Gitata)	Gitata	uː
+gwn	Gwandara (Gitata)	Gitata	ĩ
+gwn	Gwandara (Gitata)	Gitata	əː
+gwn	Gwandara (Gitata)	Gitata	ã
+gwn	Gwandara (Gitata)	Gitata	õ
+gwn	Gwandara (Gitata)	Gitata	ũ
+gwn	Gwandara (Gitata)	Gitata	ĩː
+gwn	Gwandara (Gitata)	Gitata	ẽː
+gwn	Gwandara (Gitata)	Gitata	ə̃ː
+gwn	Gwandara (Gitata)	Gitata	ãː
+gwn	Gwandara (Gitata)	Gitata	p
+gwn	Gwandara (Gitata)	Gitata	b
+gwn	Gwandara (Gitata)	Gitata	t
+gwn	Gwandara (Gitata)	Gitata	d
+gwn	Gwandara (Gitata)	Gitata	k
+gwn	Gwandara (Gitata)	Gitata	ɡ
+gwn	Gwandara (Gitata)	Gitata	kp
+gwn	Gwandara (Gitata)	Gitata	ɡb
+gwn	Gwandara (Gitata)	Gitata	f
+gwn	Gwandara (Gitata)	Gitata	s
+gwn	Gwandara (Gitata)	Gitata	z
+gwn	Gwandara (Gitata)	Gitata	ʃ
+gwn	Gwandara (Gitata)	Gitata	x
+gwn	Gwandara (Gitata)	Gitata	h
+gwn	Gwandara (Gitata)	Gitata	ts
+gwn	Gwandara (Gitata)	Gitata	t̠ʃ
+gwn	Gwandara (Gitata)	Gitata	d̠ʒ
+gwn	Gwandara (Gitata)	Gitata	m
+gwn	Gwandara (Gitata)	Gitata	n
+gwn	Gwandara (Gitata)	Gitata	ŋ
+gwn	Gwandara (Gitata)	Gitata	ɾ
+gwn	Gwandara (Gitata)	Gitata	l
+gwn	Gwandara (Gitata)	Gitata	j		[j]
+gwn	Gwandara (Gitata)	Gitata	j		[j̃]
+gwn	Gwandara (Gitata)	Gitata	w		[w]
+gwn	Gwandara (Gitata)	Gitata	w		[w̃]
+gwn	Gwandara (Gitata)	Gitata	pʷ
+gwn	Gwandara (Gitata)	Gitata	bʷ
+gwn	Gwandara (Gitata)	Gitata	tsʷ
+gwn	Gwandara (Gitata)	Gitata	fʷ
+gwn	Gwandara (Gitata)	Gitata	kʷ
+gwn	Gwandara (Gitata)	Gitata	ɡʷ
+gwn	Gwandara (Gitata)	Gitata	xʷ
+gwn	Gwandara (Gitata)	Gitata	mʷ
+gwn	Gwandara (Gitata)	Gitata	bʲ
+gwn	Gwandara (Gitata)	Gitata	kʲ
+gwn	Gwandara (Gitata)	Gitata	ɡʲ
+gwn	Gwandara (Gitata)	Gitata	˦
+gwn	Gwandara (Gitata)	Gitata	˧
+gwn	Gwandara (Gitata)	Gitata	˨
+gwn	Gwandara (Gitata)	Gitata	˨˧
+gwn	Gwandara (Gitata)	Gitata	˨˧
+gwn	Gwandara (Gitata)	Gitata	˨˦
+gwn	Gwandara (Gitata)	Gitata	˧˨
+gwn	Gwandara (Gitata)	Gitata	˦˨
+gwn	Gwandara (Gitata)	Gitata	˦˧
+
 gwn	Gwandara (Koro)	Koro	i		[i]		gwn.pdf
-gwn	Gwandara (Koro)	Koro	i		[ɨ]		
-gwn	Gwandara (Koro)	Koro	e				
-gwn	Gwandara (Koro)	Koro	a				
-gwn	Gwandara (Koro)	Koro	o				
-gwn	Gwandara (Koro)	Koro	u				
-gwn	Gwandara (Koro)	Koro	ə				
-gwn	Gwandara (Koro)	Koro	ĩ				
-gwn	Gwandara (Koro)	Koro	ẽ				
-gwn	Gwandara (Koro)	Koro	ã				
-gwn	Gwandara (Koro)	Koro	õ				
-gwn	Gwandara (Koro)	Koro	ũ				
-gwn	Gwandara (Koro)	Koro	ə̃				
-gwn	Gwandara (Koro)	Koro	˦				
-gwn	Gwandara (Koro)	Koro	˧				
-gwn	Gwandara (Koro)	Koro	˨				
-gwn	Gwandara (Koro)	Koro	˨˧				
-gwn	Gwandara (Koro)	Koro	˨˧				
-gwn	Gwandara (Koro)	Koro	˨˦				
-gwn	Gwandara (Koro)	Koro	˧˨				
-gwn	Gwandara (Koro)	Koro	˦˨				
-gwn	Gwandara (Koro)	Koro	˦˧				
-gwn	Gwandara (Koro)	Koro	p				
-gwn	Gwandara (Koro)	Koro	b				
-gwn	Gwandara (Koro)	Koro	t				
-gwn	Gwandara (Koro)	Koro	d				
-gwn	Gwandara (Koro)	Koro	k				
-gwn	Gwandara (Koro)	Koro	ɡ				
-gwn	Gwandara (Koro)	Koro	kp				
-gwn	Gwandara (Koro)	Koro	ɡb				
-gwn	Gwandara (Koro)	Koro	f				
-gwn	Gwandara (Koro)	Koro	s				
-gwn	Gwandara (Koro)	Koro	z				
-gwn	Gwandara (Koro)	Koro	ʃ				
-gwn	Gwandara (Koro)	Koro	h				
-gwn	Gwandara (Koro)	Koro	ts				
-gwn	Gwandara (Koro)	Koro	t̠ʃ				
-gwn	Gwandara (Koro)	Koro	d̠ʒ				
-gwn	Gwandara (Koro)	Koro	m				
-gwn	Gwandara (Koro)	Koro	n				
-gwn	Gwandara (Koro)	Koro	ɾ		[ɾ]		
-gwn	Gwandara (Koro)	Koro	ɾ		[ɾ̃]		
-gwn	Gwandara (Koro)	Koro	l				
-gwn	Gwandara (Koro)	Koro	j		[j]		
-gwn	Gwandara (Koro)	Koro	j		[j̃]		
-gwn	Gwandara (Koro)	Koro	w		[w]		
-gwn	Gwandara (Koro)	Koro	w		[w̃]		
-gwn	Gwandara (Koro)	Koro	tsʷ				
-gwn	Gwandara (Koro)	Koro	kʷ				
-gwn	Gwandara (Koro)	Koro	ɡʷ				
-gwn	Gwandara (Koro)	Koro	mʷ				
-gwn	Gwandara (Koro)	Koro	kʲ				
-gwn	Gwandara (Koro)	Koro	ɡʲ				
-							
+gwn	Gwandara (Koro)	Koro	i		[ɨ]
+gwn	Gwandara (Koro)	Koro	e
+gwn	Gwandara (Koro)	Koro	a
+gwn	Gwandara (Koro)	Koro	o
+gwn	Gwandara (Koro)	Koro	u
+gwn	Gwandara (Koro)	Koro	ə
+gwn	Gwandara (Koro)	Koro	ĩ
+gwn	Gwandara (Koro)	Koro	ẽ
+gwn	Gwandara (Koro)	Koro	ã
+gwn	Gwandara (Koro)	Koro	õ
+gwn	Gwandara (Koro)	Koro	ũ
+gwn	Gwandara (Koro)	Koro	ə̃
+gwn	Gwandara (Koro)	Koro	˦
+gwn	Gwandara (Koro)	Koro	˧
+gwn	Gwandara (Koro)	Koro	˨
+gwn	Gwandara (Koro)	Koro	˨˧
+gwn	Gwandara (Koro)	Koro	˨˧
+gwn	Gwandara (Koro)	Koro	˨˦
+gwn	Gwandara (Koro)	Koro	˧˨
+gwn	Gwandara (Koro)	Koro	˦˨
+gwn	Gwandara (Koro)	Koro	˦˧
+gwn	Gwandara (Koro)	Koro	p
+gwn	Gwandara (Koro)	Koro	b
+gwn	Gwandara (Koro)	Koro	t
+gwn	Gwandara (Koro)	Koro	d
+gwn	Gwandara (Koro)	Koro	k
+gwn	Gwandara (Koro)	Koro	ɡ
+gwn	Gwandara (Koro)	Koro	kp
+gwn	Gwandara (Koro)	Koro	ɡb
+gwn	Gwandara (Koro)	Koro	f
+gwn	Gwandara (Koro)	Koro	s
+gwn	Gwandara (Koro)	Koro	z
+gwn	Gwandara (Koro)	Koro	ʃ
+gwn	Gwandara (Koro)	Koro	h
+gwn	Gwandara (Koro)	Koro	ts
+gwn	Gwandara (Koro)	Koro	t̠ʃ
+gwn	Gwandara (Koro)	Koro	d̠ʒ
+gwn	Gwandara (Koro)	Koro	m
+gwn	Gwandara (Koro)	Koro	n
+gwn	Gwandara (Koro)	Koro	ɾ		[ɾ]
+gwn	Gwandara (Koro)	Koro	ɾ		[ɾ̃]
+gwn	Gwandara (Koro)	Koro	l
+gwn	Gwandara (Koro)	Koro	j		[j]
+gwn	Gwandara (Koro)	Koro	j		[j̃]
+gwn	Gwandara (Koro)	Koro	w		[w]
+gwn	Gwandara (Koro)	Koro	w		[w̃]
+gwn	Gwandara (Koro)	Koro	tsʷ
+gwn	Gwandara (Koro)	Koro	kʷ
+gwn	Gwandara (Koro)	Koro	ɡʷ
+gwn	Gwandara (Koro)	Koro	mʷ
+gwn	Gwandara (Koro)	Koro	kʲ
+gwn	Gwandara (Koro)	Koro	ɡʲ
+
 gwn	Gwandara (Nimbia)	Nimbia	i				gwn.pdf
-gwn	Gwandara (Nimbia)	Nimbia	e				
-gwn	Gwandara (Nimbia)	Nimbia	ɨ				
-gwn	Gwandara (Nimbia)	Nimbia	ə				
-gwn	Gwandara (Nimbia)	Nimbia	a				
-gwn	Gwandara (Nimbia)	Nimbia	o				
-gwn	Gwandara (Nimbia)	Nimbia	u				
-gwn	Gwandara (Nimbia)	Nimbia	ĩ				
-gwn	Gwandara (Nimbia)	Nimbia	ẽ				
-gwn	Gwandara (Nimbia)	Nimbia	ɨ̃				
-gwn	Gwandara (Nimbia)	Nimbia	ə̃				
-gwn	Gwandara (Nimbia)	Nimbia	ã				
-gwn	Gwandara (Nimbia)	Nimbia	õ				
-gwn	Gwandara (Nimbia)	Nimbia	ũ				
-gwn	Gwandara (Nimbia)	Nimbia	p				
-gwn	Gwandara (Nimbia)	Nimbia	b				
-gwn	Gwandara (Nimbia)	Nimbia	t				
-gwn	Gwandara (Nimbia)	Nimbia	d				
-gwn	Gwandara (Nimbia)	Nimbia	k				
-gwn	Gwandara (Nimbia)	Nimbia	ɡ				
-gwn	Gwandara (Nimbia)	Nimbia	kp				
-gwn	Gwandara (Nimbia)	Nimbia	ɡb				
-gwn	Gwandara (Nimbia)	Nimbia	ʔ				
-gwn	Gwandara (Nimbia)	Nimbia	f				
-gwn	Gwandara (Nimbia)	Nimbia	s				
-gwn	Gwandara (Nimbia)	Nimbia	ʃ				
-gwn	Gwandara (Nimbia)	Nimbia	x				
-gwn	Gwandara (Nimbia)	Nimbia	ɣ				
-gwn	Gwandara (Nimbia)	Nimbia	ts				
-gwn	Gwandara (Nimbia)	Nimbia	t̠ʃ				
-gwn	Gwandara (Nimbia)	Nimbia	d̠ʒ				
-gwn	Gwandara (Nimbia)	Nimbia	m				
-gwn	Gwandara (Nimbia)	Nimbia	n				
-gwn	Gwandara (Nimbia)	Nimbia	ŋ				
-gwn	Gwandara (Nimbia)	Nimbia	ɾ		[ɾ]		
-gwn	Gwandara (Nimbia)	Nimbia	ɾ		[ɾ̃]		
-gwn	Gwandara (Nimbia)	Nimbia	l				
-gwn	Gwandara (Nimbia)	Nimbia	ɥ				
-gwn	Gwandara (Nimbia)	Nimbia	j		[j]		
-gwn	Gwandara (Nimbia)	Nimbia	j		[j̃]		
-gwn	Gwandara (Nimbia)	Nimbia	w		[w]		
-gwn	Gwandara (Nimbia)	Nimbia	w		[w̃]		
-gwn	Gwandara (Nimbia)	Nimbia	pʷ				
-gwn	Gwandara (Nimbia)	Nimbia	bʷ				
-gwn	Gwandara (Nimbia)	Nimbia	tʷ				
-gwn	Gwandara (Nimbia)	Nimbia	tsʷ				
-gwn	Gwandara (Nimbia)	Nimbia	t̠ʃʷ				
-gwn	Gwandara (Nimbia)	Nimbia	fʷ				
-gwn	Gwandara (Nimbia)	Nimbia	kʷ				
-gwn	Gwandara (Nimbia)	Nimbia	ɡʷ				
-gwn	Gwandara (Nimbia)	Nimbia	xʷ				
-gwn	Gwandara (Nimbia)	Nimbia	mʷ				
-gwn	Gwandara (Nimbia)	Nimbia	kᶣ				
-gwn	Gwandara (Nimbia)	Nimbia	ɡᶣ				
-gwn	Gwandara (Nimbia)	Nimbia	rᶣ				
-gwn	Gwandara (Nimbia)	Nimbia	bʲ				
-gwn	Gwandara (Nimbia)	Nimbia	fʲ				
-gwn	Gwandara (Nimbia)	Nimbia	kʲ				
-gwn	Gwandara (Nimbia)	Nimbia	ɡʲ				
-gwn	Gwandara (Nimbia)	Nimbia	ç				
-gwn	Gwandara (Nimbia)	Nimbia	˦				
-gwn	Gwandara (Nimbia)	Nimbia	˧				
-gwn	Gwandara (Nimbia)	Nimbia	˨				
-gwn	Gwandara (Nimbia)	Nimbia	˨˧				
-gwn	Gwandara (Nimbia)	Nimbia	˨˧				
-gwn	Gwandara (Nimbia)	Nimbia	˨˦				
-gwn	Gwandara (Nimbia)	Nimbia	˧˨				
-gwn	Gwandara (Nimbia)	Nimbia	˦˨				
-gwn	Gwandara (Nimbia)	Nimbia	˦˧				
-							
+gwn	Gwandara (Nimbia)	Nimbia	e
+gwn	Gwandara (Nimbia)	Nimbia	ɨ
+gwn	Gwandara (Nimbia)	Nimbia	ə
+gwn	Gwandara (Nimbia)	Nimbia	a
+gwn	Gwandara (Nimbia)	Nimbia	o
+gwn	Gwandara (Nimbia)	Nimbia	u
+gwn	Gwandara (Nimbia)	Nimbia	ĩ
+gwn	Gwandara (Nimbia)	Nimbia	ẽ
+gwn	Gwandara (Nimbia)	Nimbia	ɨ̃
+gwn	Gwandara (Nimbia)	Nimbia	ə̃
+gwn	Gwandara (Nimbia)	Nimbia	ã
+gwn	Gwandara (Nimbia)	Nimbia	õ
+gwn	Gwandara (Nimbia)	Nimbia	ũ
+gwn	Gwandara (Nimbia)	Nimbia	p
+gwn	Gwandara (Nimbia)	Nimbia	b
+gwn	Gwandara (Nimbia)	Nimbia	t
+gwn	Gwandara (Nimbia)	Nimbia	d
+gwn	Gwandara (Nimbia)	Nimbia	k
+gwn	Gwandara (Nimbia)	Nimbia	ɡ
+gwn	Gwandara (Nimbia)	Nimbia	kp
+gwn	Gwandara (Nimbia)	Nimbia	ɡb
+gwn	Gwandara (Nimbia)	Nimbia	ʔ
+gwn	Gwandara (Nimbia)	Nimbia	f
+gwn	Gwandara (Nimbia)	Nimbia	s
+gwn	Gwandara (Nimbia)	Nimbia	ʃ
+gwn	Gwandara (Nimbia)	Nimbia	x
+gwn	Gwandara (Nimbia)	Nimbia	ɣ
+gwn	Gwandara (Nimbia)	Nimbia	ts
+gwn	Gwandara (Nimbia)	Nimbia	t̠ʃ
+gwn	Gwandara (Nimbia)	Nimbia	d̠ʒ
+gwn	Gwandara (Nimbia)	Nimbia	m
+gwn	Gwandara (Nimbia)	Nimbia	n
+gwn	Gwandara (Nimbia)	Nimbia	ŋ
+gwn	Gwandara (Nimbia)	Nimbia	ɾ		[ɾ]
+gwn	Gwandara (Nimbia)	Nimbia	ɾ		[ɾ̃]
+gwn	Gwandara (Nimbia)	Nimbia	l
+gwn	Gwandara (Nimbia)	Nimbia	ɥ
+gwn	Gwandara (Nimbia)	Nimbia	j		[j]
+gwn	Gwandara (Nimbia)	Nimbia	j		[j̃]
+gwn	Gwandara (Nimbia)	Nimbia	w		[w]
+gwn	Gwandara (Nimbia)	Nimbia	w		[w̃]
+gwn	Gwandara (Nimbia)	Nimbia	pʷ
+gwn	Gwandara (Nimbia)	Nimbia	bʷ
+gwn	Gwandara (Nimbia)	Nimbia	tʷ
+gwn	Gwandara (Nimbia)	Nimbia	tsʷ
+gwn	Gwandara (Nimbia)	Nimbia	t̠ʃʷ
+gwn	Gwandara (Nimbia)	Nimbia	fʷ
+gwn	Gwandara (Nimbia)	Nimbia	kʷ
+gwn	Gwandara (Nimbia)	Nimbia	ɡʷ
+gwn	Gwandara (Nimbia)	Nimbia	xʷ
+gwn	Gwandara (Nimbia)	Nimbia	mʷ
+gwn	Gwandara (Nimbia)	Nimbia	kᶣ
+gwn	Gwandara (Nimbia)	Nimbia	ɡᶣ
+gwn	Gwandara (Nimbia)	Nimbia	rᶣ
+gwn	Gwandara (Nimbia)	Nimbia	bʲ
+gwn	Gwandara (Nimbia)	Nimbia	fʲ
+gwn	Gwandara (Nimbia)	Nimbia	kʲ
+gwn	Gwandara (Nimbia)	Nimbia	ɡʲ
+gwn	Gwandara (Nimbia)	Nimbia	ç
+gwn	Gwandara (Nimbia)	Nimbia	˦
+gwn	Gwandara (Nimbia)	Nimbia	˧
+gwn	Gwandara (Nimbia)	Nimbia	˨
+gwn	Gwandara (Nimbia)	Nimbia	˨˧
+gwn	Gwandara (Nimbia)	Nimbia	˨˧
+gwn	Gwandara (Nimbia)	Nimbia	˨˦
+gwn	Gwandara (Nimbia)	Nimbia	˧˨
+gwn	Gwandara (Nimbia)	Nimbia	˦˨
+gwn	Gwandara (Nimbia)	Nimbia	˦˧
+
 avi	Avikam		ɓ				avi.pdf
-avi	Avikam		t̠ʃ				
-avi	Avikam		e		[e]		
-avi	Avikam		e		[ẽ]		
-avi	Avikam		ɡ				
-avi	Avikam		ɡb				
-avi	Avikam		ɣ				
-avi	Avikam		d̠ʒ				
-avi	Avikam		kp				
-avi	Avikam		n		[n]		
-avi	Avikam		n		[m]		
-avi	Avikam		n		[ŋ]		
-avi	Avikam		ŋ				
-avi	Avikam		ɲ				
-avi	Avikam		ŋm				
-avi	Avikam		ɔ		[ɔ]		
-avi	Avikam		ɔ		[ɔ̃]		
-avi	Avikam		r				
-avi	Avikam		s				
-avi	Avikam		ʃ				
-avi	Avikam		w				
-avi	Avikam		ʒ				
-avi	Avikam		i		[i]		
-avi	Avikam		i		[ɪ]		
-avi	Avikam		i		[ĩ]		
-avi	Avikam		i		[ɪ̃]		
-avi	Avikam		u		[u]		
-avi	Avikam		u		[ʊ]		
-avi	Avikam		u		[ʊ̃]		
-avi	Avikam		u		[ũ]		
-avi	Avikam		o		[o]		
-avi	Avikam		o		[õ]		
-avi	Avikam		a		[a]		
-avi	Avikam		a		[ã]		
-avi	Avikam		b				
-avi	Avikam		d				
-avi	Avikam		f				
-avi	Avikam		l				
-avi	Avikam		m				
-avi	Avikam		p				
-avi	Avikam		t				
-avi	Avikam		v				
-avi	Avikam		z				
-avi	Avikam		˦				
-avi	Avikam		˨				
-avi	Avikam		˦˨				
-							
+avi	Avikam		t̠ʃ
+avi	Avikam		e		[e]
+avi	Avikam		e		[ẽ]
+avi	Avikam		ɡ
+avi	Avikam		ɡb
+avi	Avikam		ɣ
+avi	Avikam		d̠ʒ
+avi	Avikam		kp
+avi	Avikam		n		[n]
+avi	Avikam		n		[m]
+avi	Avikam		n		[ŋ]
+avi	Avikam		ŋ
+avi	Avikam		ɲ
+avi	Avikam		ŋm
+avi	Avikam		ɔ		[ɔ]
+avi	Avikam		ɔ		[ɔ̃]
+avi	Avikam		r
+avi	Avikam		s
+avi	Avikam		ʃ
+avi	Avikam		w
+avi	Avikam		ʒ
+avi	Avikam		i		[i]
+avi	Avikam		i		[ɪ]
+avi	Avikam		i		[ĩ]
+avi	Avikam		i		[ɪ̃]
+avi	Avikam		u		[u]
+avi	Avikam		u		[ʊ]
+avi	Avikam		u		[ʊ̃]
+avi	Avikam		u		[ũ]
+avi	Avikam		o		[o]
+avi	Avikam		o		[õ]
+avi	Avikam		a		[a]
+avi	Avikam		a		[ã]
+avi	Avikam		b
+avi	Avikam		d
+avi	Avikam		f
+avi	Avikam		l
+avi	Avikam		m
+avi	Avikam		p
+avi	Avikam		t
+avi	Avikam		v
+avi	Avikam		z
+avi	Avikam		˦
+avi	Avikam		˨
+avi	Avikam		˦˨
+
 shk	Shilluk		b				shk.pdf
-shk	Shilluk		tç	described as 'like the ch in church, but a little further back'			
-shk	Shilluk		d				
-shk	Shilluk		b̪				
-shk	Shilluk		f				
-shk	Shilluk		ɡ				
-shk	Shilluk		h				
-shk	Shilluk		ɣ				
-shk	Shilluk		ɟʝ	updated from dʝ			
-shk	Shilluk		k				
-shk	Shilluk		l				
-shk	Shilluk		m				
-shk	Shilluk		n				
-shk	Shilluk		ɲ				
-shk	Shilluk		m̪				
-shk	Shilluk		ŋ				
-shk	Shilluk		p				
-shk	Shilluk		ɹ				
-shk	Shilluk		x				
-shk	Shilluk		θ				
-shk	Shilluk		t				
-shk	Shilluk		p̪				
-shk	Shilluk		w				
-shk	Shilluk		j				
-shk	Shilluk		ð				
-shk	Shilluk		a				
-shk	Shilluk		ɑ				
-shk	Shilluk		ɔ				
-shk	Shilluk		o				
-shk	Shilluk		ʊ				
-shk	Shilluk		u				
-shk	Shilluk		ɛ				
-shk	Shilluk		e				
-shk	Shilluk		e̥				
-shk	Shilluk		ɪ				
-shk	Shilluk		i				
-shk	Shilluk		aː				
-shk	Shilluk		ɑː				
-shk	Shilluk		ɔː				
-shk	Shilluk		oː				
-shk	Shilluk		ʊː				
-shk	Shilluk		uː				
-shk	Shilluk		ɛː				
-shk	Shilluk		eː				
-shk	Shilluk		e̥ː				
-shk	Shilluk		ɪː				
-shk	Shilluk		iː				
-shk	Shilluk		˦				
-shk	Shilluk		˨				
-shk	Shilluk		˧				
-shk	Shilluk		aɪ				
-shk	Shilluk		au				
-shk	Shilluk		ɔɪ				
-shk	Shilluk		eɪ				
-							
+shk	Shilluk		tç	described as 'like the ch in church, but a little further back'
+shk	Shilluk		d
+shk	Shilluk		b̪
+shk	Shilluk		f
+shk	Shilluk		ɡ
+shk	Shilluk		h
+shk	Shilluk		ɣ
+shk	Shilluk		ɟʝ	updated from dʝ
+shk	Shilluk		k
+shk	Shilluk		l
+shk	Shilluk		m
+shk	Shilluk		n
+shk	Shilluk		ɲ
+shk	Shilluk		m̪
+shk	Shilluk		ŋ
+shk	Shilluk		p
+shk	Shilluk		ɹ
+shk	Shilluk		x
+shk	Shilluk		θ
+shk	Shilluk		t
+shk	Shilluk		p̪
+shk	Shilluk		w
+shk	Shilluk		j
+shk	Shilluk		ð
+shk	Shilluk		a
+shk	Shilluk		ɑ
+shk	Shilluk		ɔ
+shk	Shilluk		o
+shk	Shilluk		ʊ
+shk	Shilluk		u
+shk	Shilluk		ɛ
+shk	Shilluk		e
+shk	Shilluk		e̥
+shk	Shilluk		ɪ
+shk	Shilluk		i
+shk	Shilluk		aː
+shk	Shilluk		ɑː
+shk	Shilluk		ɔː
+shk	Shilluk		oː
+shk	Shilluk		ʊː
+shk	Shilluk		uː
+shk	Shilluk		ɛː
+shk	Shilluk		eː
+shk	Shilluk		e̥ː
+shk	Shilluk		ɪː
+shk	Shilluk		iː
+shk	Shilluk		˦
+shk	Shilluk		˨
+shk	Shilluk		˧
+shk	Shilluk		aɪ
+shk	Shilluk		au
+shk	Shilluk		ɔɪ
+shk	Shilluk		eɪ
+
 hgm	San		a				hgm.pdf
-hgm	San		b				
-hgm	San		d				
-hgm	San		e				
-hgm	San		ɡ				
-hgm	San		h				
-hgm	San		i				
-hgm	San		d̠ʒ				
-hgm	San		k				
-hgm	San		m				
-hgm	San		n				
-hgm	San		o				
-hgm	San		r				
-hgm	San		s				
-hgm	San		t				
-hgm	San		t̠ʃ				
-hgm	San		u				
-hgm	San		w				
-hgm	San		j				
-hgm	San		z				
-hgm	San		kǀ	ǀ			
-hgm	San		kǂ	ǂ			
-hgm	San		kǃ	ǃ			
-hgm	San		kǁ	ǁ			
-hgm	San		ʔ				
-hgm	San		x				
-hgm	San		<l>	loanwords only			
-hgm	San		<p>	loanwords only			
-hgm	San		ħ	approximation, pronounced more strongly than 'x', with the mouth opened wide			
-							
+hgm	San		b
+hgm	San		d
+hgm	San		e
+hgm	San		ɡ
+hgm	San		h
+hgm	San		i
+hgm	San		d̠ʒ
+hgm	San		k
+hgm	San		m
+hgm	San		n
+hgm	San		o
+hgm	San		r
+hgm	San		s
+hgm	San		t
+hgm	San		t̠ʃ
+hgm	San		u
+hgm	San		w
+hgm	San		j
+hgm	San		z
+hgm	San		kǀ	ǀ
+hgm	San		kǂ	ǂ
+hgm	San		kǃ	ǃ
+hgm	San		kǁ	ǁ
+hgm	San		ʔ
+hgm	San		x
+hgm	San		<l>	loanwords only
+hgm	San		<p>	loanwords only
+hgm	San		ħ	approximation, pronounced more strongly than 'x', with the mouth opened wide
+
 pip	Pero		p		[p]		pip.pdf
-pip	Pero		p		[f]		
-pip	Pero		p		[b]		
-pip	Pero		b		[b]		
-pip	Pero		b		[v]		
-pip	Pero		ɓ				
-pip	Pero		m				
-pip	Pero		w		[w]		
-pip	Pero		w		[p]		
-pip	Pero		t		[t]		
-pip	Pero		t		[ʁ]		
-pip	Pero		t		[ⱱ]		
-pip	Pero		d				
-pip	Pero		ɗ				
-pip	Pero		n				
-pip	Pero		r				
-pip	Pero		l				
-pip	Pero		c		[c]		
-pip	Pero		c		[ʃ]		
-pip	Pero		ɟ				
-pip	Pero		j				
-pip	Pero		k		[k]		
-pip	Pero		k		[kp]		
-pip	Pero		k		[ɡ]		
-pip	Pero		ɡ		[ɡ]		
-pip	Pero		ɡ		[ɣ]		
-pip	Pero		ɡ		[k]		
-pip	Pero		ɡ		[ɡb]		
-pip	Pero		ŋ				
-pip	Pero		ʔ				
-pip	Pero		i				
-pip	Pero		e				
-pip	Pero		a				
-pip	Pero		o				
-pip	Pero		u				
-pip	Pero		iː				
-pip	Pero		eː				
-pip	Pero		aː				
-pip	Pero		oː				
-pip	Pero		uː				
-pip	Pero		˦				
-pip	Pero		˨				
-							
+pip	Pero		p		[f]
+pip	Pero		p		[b]
+pip	Pero		b		[b]
+pip	Pero		b		[v]
+pip	Pero		ɓ
+pip	Pero		m
+pip	Pero		w		[w]
+pip	Pero		w		[p]
+pip	Pero		t		[t]
+pip	Pero		t		[ʁ]
+pip	Pero		t		[ⱱ]
+pip	Pero		d
+pip	Pero		ɗ
+pip	Pero		n
+pip	Pero		r
+pip	Pero		l
+pip	Pero		c		[c]
+pip	Pero		c		[ʃ]
+pip	Pero		ɟ
+pip	Pero		j
+pip	Pero		k		[k]
+pip	Pero		k		[kp]
+pip	Pero		k		[ɡ]
+pip	Pero		ɡ		[ɡ]
+pip	Pero		ɡ		[ɣ]
+pip	Pero		ɡ		[k]
+pip	Pero		ɡ		[ɡb]
+pip	Pero		ŋ
+pip	Pero		ʔ
+pip	Pero		i
+pip	Pero		e
+pip	Pero		a
+pip	Pero		o
+pip	Pero		u
+pip	Pero		iː
+pip	Pero		eː
+pip	Pero		aː
+pip	Pero		oː
+pip	Pero		uː
+pip	Pero		˦
+pip	Pero		˨
+
 gax	Galla		i				gax-hdy.pdf
-gax	Galla		e				
-gax	Galla		a				
-gax	Galla		o				
-gax	Galla		u				
-gax	Galla		iː				
-gax	Galla		eː				
-gax	Galla		aː				
-gax	Galla		oː				
-gax	Galla		uː				
-gax	Galla		p				
-gax	Galla		pʼ				
-gax	Galla		b				
-gax	Galla		m				
-gax	Galla		f				
-gax	Galla		t				
-gax	Galla		tʼ				
-gax	Galla		r				
-gax	Galla		l				
-gax	Galla		d				
-gax	Galla		ᶑʼ				
-gax	Galla		s				
-gax	Galla		n				
-gax	Galla		c				
-gax	Galla		cʼ				
-gax	Galla		ɟ				
-gax	Galla		ɲ				
-gax	Galla		ʃ				
-gax	Galla		k				
-gax	Galla		kʼ				
-gax	Galla		ɡ				
-gax	Galla		h				
-gax	Galla		ʔ				
-gax	Galla		w				
-gax	Galla		j				
-gax	Galla		<z>	loanwords only			
-							
+gax	Galla		e
+gax	Galla		a
+gax	Galla		o
+gax	Galla		u
+gax	Galla		iː
+gax	Galla		eː
+gax	Galla		aː
+gax	Galla		oː
+gax	Galla		uː
+gax	Galla		p
+gax	Galla		pʼ
+gax	Galla		b
+gax	Galla		m
+gax	Galla		f
+gax	Galla		t
+gax	Galla		tʼ
+gax	Galla		r
+gax	Galla		l
+gax	Galla		d
+gax	Galla		ᶑʼ
+gax	Galla		s
+gax	Galla		n
+gax	Galla		c
+gax	Galla		cʼ
+gax	Galla		ɟ
+gax	Galla		ɲ
+gax	Galla		ʃ
+gax	Galla		k
+gax	Galla		kʼ
+gax	Galla		ɡ
+gax	Galla		h
+gax	Galla		ʔ
+gax	Galla		w
+gax	Galla		j
+gax	Galla		<z>	loanwords only
+
 hdy	Hadiyya		i				gax-hdy.pdf
-hdy	Hadiyya		e				
-hdy	Hadiyya		a				
-hdy	Hadiyya		o				
-hdy	Hadiyya		u				
-hdy	Hadiyya		iː				
-hdy	Hadiyya		eː				
-hdy	Hadiyya		aː				
-hdy	Hadiyya		oː				
-hdy	Hadiyya		uː				
-hdy	Hadiyya		pʼ				
-hdy	Hadiyya		b				
-hdy	Hadiyya		m				
-hdy	Hadiyya		f				
-hdy	Hadiyya		t				
-hdy	Hadiyya		tʼ				
-hdy	Hadiyya		r				
-hdy	Hadiyya		l				
-hdy	Hadiyya		d				
-hdy	Hadiyya		ᶑʼ				
-hdy	Hadiyya		s				
-hdy	Hadiyya		n				
-hdy	Hadiyya		c				
-hdy	Hadiyya		cʼ				
-hdy	Hadiyya		ɟ				
-hdy	Hadiyya		ʃ				
-hdy	Hadiyya		k				
-hdy	Hadiyya		kʼ				
-hdy	Hadiyya		ɡ				
-hdy	Hadiyya		h				
-hdy	Hadiyya		ʔ				
-hdy	Hadiyya		w				
-hdy	Hadiyya		j				
-hdy	Hadiyya		pʼː				
-hdy	Hadiyya		bː				
-hdy	Hadiyya		mː				
-hdy	Hadiyya		fː				
-hdy	Hadiyya		tː				
-hdy	Hadiyya		tʼː				
-hdy	Hadiyya		rː				
-hdy	Hadiyya		lː				
-hdy	Hadiyya		dː				
-hdy	Hadiyya		ᶑʼː				
-hdy	Hadiyya		sː				
-hdy	Hadiyya		nː				
-hdy	Hadiyya		cː				
-hdy	Hadiyya		cʼː				
-hdy	Hadiyya		ɟː				
-hdy	Hadiyya		ʃː				
-hdy	Hadiyya		kː				
-hdy	Hadiyya		kʼː				
-hdy	Hadiyya		ɡː				
-hdy	Hadiyya		hː				
-hdy	Hadiyya		ʔː				
-hdy	Hadiyya		wː				
-hdy	Hadiyya		jː				
-							
+hdy	Hadiyya		e
+hdy	Hadiyya		a
+hdy	Hadiyya		o
+hdy	Hadiyya		u
+hdy	Hadiyya		iː
+hdy	Hadiyya		eː
+hdy	Hadiyya		aː
+hdy	Hadiyya		oː
+hdy	Hadiyya		uː
+hdy	Hadiyya		pʼ
+hdy	Hadiyya		b
+hdy	Hadiyya		m
+hdy	Hadiyya		f
+hdy	Hadiyya		t
+hdy	Hadiyya		tʼ
+hdy	Hadiyya		r
+hdy	Hadiyya		l
+hdy	Hadiyya		d
+hdy	Hadiyya		ᶑʼ
+hdy	Hadiyya		s
+hdy	Hadiyya		n
+hdy	Hadiyya		c
+hdy	Hadiyya		cʼ
+hdy	Hadiyya		ɟ
+hdy	Hadiyya		ʃ
+hdy	Hadiyya		k
+hdy	Hadiyya		kʼ
+hdy	Hadiyya		ɡ
+hdy	Hadiyya		h
+hdy	Hadiyya		ʔ
+hdy	Hadiyya		w
+hdy	Hadiyya		j
+hdy	Hadiyya		pʼː
+hdy	Hadiyya		bː
+hdy	Hadiyya		mː
+hdy	Hadiyya		fː
+hdy	Hadiyya		tː
+hdy	Hadiyya		tʼː
+hdy	Hadiyya		rː
+hdy	Hadiyya		lː
+hdy	Hadiyya		dː
+hdy	Hadiyya		ᶑʼː
+hdy	Hadiyya		sː
+hdy	Hadiyya		nː
+hdy	Hadiyya		cː
+hdy	Hadiyya		cʼː
+hdy	Hadiyya		ɟː
+hdy	Hadiyya		ʃː
+hdy	Hadiyya		kː
+hdy	Hadiyya		kʼː
+hdy	Hadiyya		ɡː
+hdy	Hadiyya		hː
+hdy	Hadiyya		ʔː
+hdy	Hadiyya		wː
+hdy	Hadiyya		jː
+
 wal	Welamo		pʼ				wal.pdf
-wal	Welamo		tʼ				
-wal	Welamo		cʼ				
-wal	Welamo		kʼ				
-wal	Welamo		ʃ				
-wal	Welamo		ɟ				
-wal	Welamo		s				
-wal	Welamo		z				
-wal	Welamo		d				
-wal	Welamo		p				
-wal	Welamo		t				
-wal	Welamo		c				
-wal	Welamo		k				
-wal	Welamo		ɡʷ				
-wal	Welamo		kʷ				
-wal	Welamo		kʼʷ				
-wal	Welamo		hʷ				
-wal	Welamo		fʷ				
-wal	Welamo		mʷ				
-wal	Welamo		bʷ				
-wal	Welamo		h				
-wal	Welamo		ʔ				
-wal	Welamo		ᶑʼ				
-wal	Welamo		pʼː				
-wal	Welamo		tʼː				
-wal	Welamo		cʼː				
-wal	Welamo		kʼː				
-wal	Welamo		ʃː				
-wal	Welamo		cː				
-wal	Welamo		ɟː				
-wal	Welamo		sː				
-wal	Welamo		zː				
-wal	Welamo		tː				
-wal	Welamo		dː				
-wal	Welamo		pː				
-wal	Welamo		kː				
-wal	Welamo		i				
-wal	Welamo		e				
-wal	Welamo		a				
-wal	Welamo		o				
-wal	Welamo		u				
-wal	Welamo		iː				
-wal	Welamo		eː				
-wal	Welamo		aː				
-wal	Welamo		oː				
-wal	Welamo		uː				
-wal	Welamo		hː				
-wal	Welamo		ʔː				
-							
+wal	Welamo		tʼ
+wal	Welamo		cʼ
+wal	Welamo		kʼ
+wal	Welamo		ʃ
+wal	Welamo		ɟ
+wal	Welamo		s
+wal	Welamo		z
+wal	Welamo		d
+wal	Welamo		p
+wal	Welamo		t
+wal	Welamo		c
+wal	Welamo		k
+wal	Welamo		ɡʷ
+wal	Welamo		kʷ
+wal	Welamo		kʷʼ
+wal	Welamo		hʷ
+wal	Welamo		fʷ
+wal	Welamo		mʷ
+wal	Welamo		bʷ
+wal	Welamo		h
+wal	Welamo		ʔ
+wal	Welamo		ᶑʼ
+wal	Welamo		pʼː
+wal	Welamo		tʼː
+wal	Welamo		cʼː
+wal	Welamo		kʼː
+wal	Welamo		ʃː
+wal	Welamo		cː
+wal	Welamo		ɟː
+wal	Welamo		sː
+wal	Welamo		zː
+wal	Welamo		tː
+wal	Welamo		dː
+wal	Welamo		pː
+wal	Welamo		kː
+wal	Welamo		i
+wal	Welamo		e
+wal	Welamo		a
+wal	Welamo		o
+wal	Welamo		u
+wal	Welamo		iː
+wal	Welamo		eː
+wal	Welamo		aː
+wal	Welamo		oː
+wal	Welamo		uː
+wal	Welamo		hː
+wal	Welamo		ʔː
+
 njx	Nyanga		ɪ				njx.pdf
-njx	Nyanga		i				
-njx	Nyanga		e				
-njx	Nyanga		a				
-njx	Nyanga		ʊ				
-njx	Nyanga		u				
-njx	Nyanga		o				
-njx	Nyanga		j				
-njx	Nyanga		w				
-njx	Nyanga		m		[m]		
-njx	Nyanga		m		[ŋm]		
-njx	Nyanga		m		[ŋ]		
-njx	Nyanga		n		[n]		
-njx	Nyanga		n		[ŋ]		
-njx	Nyanga		ɲ				
-njx	Nyanga		r				
-njx	Nyanga		d				
-njx	Nyanga		ɡ				
-njx	Nyanga		p				
-njx	Nyanga		t				
-njx	Nyanga		k		[k]		
-njx	Nyanga		k		[k]		
-njx	Nyanga		β		[β]		
-njx	Nyanga		β		[b]		
-njx	Nyanga		f				
-njx	Nyanga		s		[s]		
-njx	Nyanga		s		[ts]		
-njx	Nyanga		ʃ				
-njx	Nyanga		h				
-njx	Nyanga		d̠ʒ				
-njx	Nyanga		t̠ʃ				
-njx	Nyanga		mb				
-njx	Nyanga		nd				
-njx	Nyanga		ŋɡ				
-njx	Nyanga		mp				
-njx	Nyanga		nt				
-njx	Nyanga		ŋk				
-njx	Nyanga		ns				
-njx	Nyanga		n̠d̠ʒ				
-njx	Nyanga		n̠t̠ʃ				
-njx	Nyanga		mʲ				
-njx	Nyanga		mʷ				
-njx	Nyanga		rʲ				
-njx	Nyanga		rʷ				
-njx	Nyanga		bʲ				
-njx	Nyanga		bʷ				
-njx	Nyanga		dʷ				
-njx	Nyanga		ɡʷ				
-njx	Nyanga		tʷ				
-njx	Nyanga		kʷ				
-njx	Nyanga		sʷ				
-njx	Nyanga		ʃʷ				
-njx	Nyanga		mbʷ				
-njx	Nyanga		ndʷ				
-njx	Nyanga		ŋɡʷ				
-njx	Nyanga		ntʷ				
-njx	Nyanga		n̠t̠ʃʷ				
-njx	Nyanga		˦				
-njx	Nyanga		˨				
-njx	Nyanga		˦˨				
-njx	Nyanga		˨˦				
-							
+njx	Nyanga		i
+njx	Nyanga		e
+njx	Nyanga		a
+njx	Nyanga		ʊ
+njx	Nyanga		u
+njx	Nyanga		o
+njx	Nyanga		j
+njx	Nyanga		w
+njx	Nyanga		m		[m]
+njx	Nyanga		m		[ŋm]
+njx	Nyanga		m		[ŋ]
+njx	Nyanga		n		[n]
+njx	Nyanga		n		[ŋ]
+njx	Nyanga		ɲ
+njx	Nyanga		r
+njx	Nyanga		d
+njx	Nyanga		ɡ
+njx	Nyanga		p
+njx	Nyanga		t
+njx	Nyanga		k		[k]
+njx	Nyanga		k		[k]
+njx	Nyanga		β		[β]
+njx	Nyanga		β		[b]
+njx	Nyanga		f
+njx	Nyanga		s		[s]
+njx	Nyanga		s		[ts]
+njx	Nyanga		ʃ
+njx	Nyanga		h
+njx	Nyanga		d̠ʒ
+njx	Nyanga		t̠ʃ
+njx	Nyanga		mb
+njx	Nyanga		nd
+njx	Nyanga		ŋɡ
+njx	Nyanga		mp
+njx	Nyanga		nt
+njx	Nyanga		ŋk
+njx	Nyanga		ns
+njx	Nyanga		n̠d̠ʒ
+njx	Nyanga		n̠t̠ʃ
+njx	Nyanga		mʲ
+njx	Nyanga		mʷ
+njx	Nyanga		rʲ
+njx	Nyanga		rʷ
+njx	Nyanga		bʲ
+njx	Nyanga		bʷ
+njx	Nyanga		dʷ
+njx	Nyanga		ɡʷ
+njx	Nyanga		tʷ
+njx	Nyanga		kʷ
+njx	Nyanga		sʷ
+njx	Nyanga		ʃʷ
+njx	Nyanga		mbʷ
+njx	Nyanga		ndʷ
+njx	Nyanga		ŋɡʷ
+njx	Nyanga		ntʷ
+njx	Nyanga		n̠t̠ʃʷ
+njx	Nyanga		˦
+njx	Nyanga		˨
+njx	Nyanga		˦˨
+njx	Nyanga		˨˦
+
 lot	Otuho		<p>	rare			otuho.pdf
-lot	Otuho		b				
-lot	Otuho		t̪				
-lot	Otuho		d				
-lot	Otuho		ɟ				
-lot	Otuho		k				
-lot	Otuho		ɡ				
-lot	Otuho		ʔ				
-lot	Otuho		ɸ				
-lot	Otuho		β				
-lot	Otuho		f				
-lot	Otuho		v				
-lot	Otuho		θ				
-lot	Otuho		x				
-lot	Otuho		ɣ				
-lot	Otuho		h				
-lot	Otuho		ɦ				
-lot	Otuho		s				
-lot	Otuho		t̠ʃ				
-lot	Otuho		ɾ				
-lot	Otuho		ɺ				
-lot	Otuho		r				
-lot	Otuho		l				
-lot	Otuho		lː				
-lot	Otuho		m				
-lot	Otuho		n				
-lot	Otuho		nː				
-lot	Otuho		ɲ				
-lot	Otuho		ŋ				
-lot	Otuho		w				
-lot	Otuho		wː				
-lot	Otuho		j				
-lot	Otuho		jː				
-lot	Otuho		i				
-lot	Otuho		e				
-lot	Otuho		ʌ				
-lot	Otuho		u				
-lot	Otuho		o				
-lot	Otuho		ɪ				
-lot	Otuho		ɛ				
-lot	Otuho		a				
-lot	Otuho		ʊ				
-lot	Otuho		ɔ				
-lot	Otuho		iː				
-lot	Otuho		eː				
-lot	Otuho		ʌː				
-lot	Otuho		uː				
-lot	Otuho		oː				
-lot	Otuho		ɪː				
-lot	Otuho		ɛː				
-lot	Otuho		aː				
-lot	Otuho		ʊː				
-lot	Otuho		ɔː				
-lot	Otuho		˧				
-lot	Otuho		˦				
-lot	Otuho		˨				
-							
+lot	Otuho		b
+lot	Otuho		t̪
+lot	Otuho		d
+lot	Otuho		ɟ
+lot	Otuho		k
+lot	Otuho		ɡ
+lot	Otuho		ʔ
+lot	Otuho		ɸ
+lot	Otuho		β
+lot	Otuho		f
+lot	Otuho		v
+lot	Otuho		θ
+lot	Otuho		x
+lot	Otuho		ɣ
+lot	Otuho		h
+lot	Otuho		ɦ
+lot	Otuho		s
+lot	Otuho		t̠ʃ
+lot	Otuho		ɾ
+lot	Otuho		ɺ
+lot	Otuho		r
+lot	Otuho		l
+lot	Otuho		lː
+lot	Otuho		m
+lot	Otuho		n
+lot	Otuho		nː
+lot	Otuho		ɲ
+lot	Otuho		ŋ
+lot	Otuho		w
+lot	Otuho		wː
+lot	Otuho		j
+lot	Otuho		jː
+lot	Otuho		i
+lot	Otuho		e
+lot	Otuho		ʌ
+lot	Otuho		u
+lot	Otuho		o
+lot	Otuho		ɪ
+lot	Otuho		ɛ
+lot	Otuho		a
+lot	Otuho		ʊ
+lot	Otuho		ɔ
+lot	Otuho		iː
+lot	Otuho		eː
+lot	Otuho		ʌː
+lot	Otuho		uː
+lot	Otuho		oː
+lot	Otuho		ɪː
+lot	Otuho		ɛː
+lot	Otuho		aː
+lot	Otuho		ʊː
+lot	Otuho		ɔː
+lot	Otuho		˧
+lot	Otuho		˦
+lot	Otuho		˨
+
 myx	Orusyan		i				myx.pdf
-myx	Orusyan		e				
-myx	Orusyan		a				
-myx	Orusyan		o				
-myx	Orusyan		u				
-myx	Orusyan		iː				
-myx	Orusyan		eː				
-myx	Orusyan		aː				
-myx	Orusyan		oː				
-myx	Orusyan		uː				
-myx	Orusyan		ɛ̃				
-myx	Orusyan		ã				
-myx	Orusyan		b				
-myx	Orusyan		t̠ʃ				
-myx	Orusyan		d				
-myx	Orusyan		f				
-myx	Orusyan		ɡ				
-myx	Orusyan		h				
-myx	Orusyan		d̠ʒ				
-myx	Orusyan		k				
-myx	Orusyan		l				
-myx	Orusyan		m				
-myx	Orusyan		n				
-myx	Orusyan		ŋ				
-myx	Orusyan		ɲ				
-myx	Orusyan		p				
-myx	Orusyan		r				
-myx	Orusyan		s				
-myx	Orusyan		t				
-myx	Orusyan		v				
-myx	Orusyan		w				
-myx	Orusyan		j				
-myx	Orusyan		z				
-myx	Orusyan		mb				
-myx	Orusyan		nd				
-myx	Orusyan		ɱf				
-myx	Orusyan		ŋɡ				
-myx	Orusyan		ŋk				
-myx	Orusyan		mp				
-myx	Orusyan		ns				
-myx	Orusyan		nt				
-myx	Orusyan		ɱv				
-myx	Orusyan		nz				
-myx	Orusyan		fʷ				
-myx	Orusyan		ɡʷ				
-myx	Orusyan		kʷ				
-myx	Orusyan		mʷ				
-myx	Orusyan		pʷ				
-myx	Orusyan		rʷ				
-myx	Orusyan		sʷ				
-myx	Orusyan		tʷ				
-myx	Orusyan		vʷ				
-myx	Orusyan		ŋkʷ				
-myx	Orusyan		nsʷ				
-myx	Orusyan		ɲʷ				
-myx	Orusyan		t̠ʃʲ				
-myx	Orusyan		kʲ				
-myx	Orusyan		mʲ				
-myx	Orusyan		nʲ				
-myx	Orusyan		rʲ				
-myx	Orusyan		sʲ				
-myx	Orusyan		tʲ				
-myx	Orusyan		vʲ				
-							
+myx	Orusyan		e
+myx	Orusyan		a
+myx	Orusyan		o
+myx	Orusyan		u
+myx	Orusyan		iː
+myx	Orusyan		eː
+myx	Orusyan		aː
+myx	Orusyan		oː
+myx	Orusyan		uː
+myx	Orusyan		ɛ̃
+myx	Orusyan		ã
+myx	Orusyan		b
+myx	Orusyan		t̠ʃ
+myx	Orusyan		d
+myx	Orusyan		f
+myx	Orusyan		ɡ
+myx	Orusyan		h
+myx	Orusyan		d̠ʒ
+myx	Orusyan		k
+myx	Orusyan		l
+myx	Orusyan		m
+myx	Orusyan		n
+myx	Orusyan		ŋ
+myx	Orusyan		ɲ
+myx	Orusyan		p
+myx	Orusyan		r
+myx	Orusyan		s
+myx	Orusyan		t
+myx	Orusyan		v
+myx	Orusyan		w
+myx	Orusyan		j
+myx	Orusyan		z
+myx	Orusyan		mb
+myx	Orusyan		nd
+myx	Orusyan		ɱf
+myx	Orusyan		ŋɡ
+myx	Orusyan		ŋk
+myx	Orusyan		mp
+myx	Orusyan		ns
+myx	Orusyan		nt
+myx	Orusyan		ɱv
+myx	Orusyan		nz
+myx	Orusyan		fʷ
+myx	Orusyan		ɡʷ
+myx	Orusyan		kʷ
+myx	Orusyan		mʷ
+myx	Orusyan		pʷ
+myx	Orusyan		rʷ
+myx	Orusyan		sʷ
+myx	Orusyan		tʷ
+myx	Orusyan		vʷ
+myx	Orusyan		ŋkʷ
+myx	Orusyan		nsʷ
+myx	Orusyan		ɲʷ
+myx	Orusyan		t̠ʃʲ
+myx	Orusyan		kʲ
+myx	Orusyan		mʲ
+myx	Orusyan		nʲ
+myx	Orusyan		rʲ
+myx	Orusyan		sʲ
+myx	Orusyan		tʲ
+myx	Orusyan		vʲ
+
 hig	Higi		i				hig.pdf
-hig	Higi		e				
-hig	Higi		ɛ				
-hig	Higi		a				
-hig	Higi		u				
-hig	Higi		ɘ				
-hig	Higi		o				
-hig	Higi		p		[p]		
-hig	Higi		p		[pʷ]		
-hig	Higi		p		[pʲ]		
-hig	Higi		b		[b]		
-hig	Higi		b		[bʷ]		
-hig	Higi		b		[bʲ]		
-hig	Higi		ɓ		[ɓ]		
-hig	Higi		ɓ		[ɓʷ]		
-hig	Higi		ɓ		[ɓʲ]		
-hig	Higi		f		[f]		
-hig	Higi		f		[fʷ]		
-hig	Higi		f		[fʲ]		
-hig	Higi		v		[v]		
-hig	Higi		v		[vʷ]		
-hig	Higi		v		[vʲ]		
-hig	Higi		m		[m]		
-hig	Higi		m		[mʷ]		
-hig	Higi		m		[mʲ]		
-hig	Higi		w		[w]		
-hig	Higi		w		[wʲ]		
-hig	Higi		t		[t]		
-hig	Higi		t		[ʷt]		
-hig	Higi		t		[tʲ]		
-hig	Higi		t		[tʲʷ]		
-hig	Higi		d		[d]		
-hig	Higi		d		[ʷd]		
-hig	Higi		d		[dʲ]		
-hig	Higi		d		[dʲʷ]		
-hig	Higi		ɗ		[ɗ]		
-hig	Higi		ɗ		[ʷɗ]		
-hig	Higi		ɗ		[ɗʲ]		
-hig	Higi		ɗ		[ɗʲʷ]		
-hig	Higi		ts		[ts]		
-hig	Higi		ts		[ʷts]		
-hig	Higi		ts		[tsʲ]		
-hig	Higi		ts		[tsʲʷ]		
-hig	Higi		dz		[dz]		
-hig	Higi		dz		[ʷdz]		
-hig	Higi		dz		[dzʲ]		
-hig	Higi		dz		[dzʲʷ]		
-hig	Higi		s		[s]		
-hig	Higi		s		[ʷs]		
-hig	Higi		s		[sʲ]		
-hig	Higi		s		[sʲʷ]		
-hig	Higi		z		[z]		
-hig	Higi		z		[ʷz]		
-hig	Higi		z		[zʲ]		
-hig	Higi		z		[zʲʷ]		
-hig	Higi		ɬ		[ɬ]		
-hig	Higi		ɬ		[ʷɬ]		
-hig	Higi		ɬ		[ɬʲ]		
-hig	Higi		ɬ		[ɬʲʷ]		
-hig	Higi		ɮ		[ɮ]		
-hig	Higi		ɮ		[ʷɮ]		
-hig	Higi		ɮ		[ɮʲ]		
-hig	Higi		ɮ		[ɮʲʷ]		
-hig	Higi		l		[l]		
-hig	Higi		l		[lʲ]		
-hig	Higi		r		[r]		
-hig	Higi		r		[rʷ]		
-hig	Higi		n		[n]		
-hig	Higi		n		[nʷ]		
-hig	Higi		n		[nʲ]		
-hig	Higi		n		[nʲʷ]		
-hig	Higi		j		[j]		
-hig	Higi		j		[jʷ]		
-hig	Higi		k		[k]		
-hig	Higi		k		[ʷk]		
-hig	Higi		k		[kʲ]		
-hig	Higi		k		[kʲʷ]		
-hig	Higi		ɡ		[ɡ]		
-hig	Higi		ɡ		[ʷɡ]		
-hig	Higi		ɡ		[ɡʲ]		
-hig	Higi		ɡ		[ɡʲʷ]		
-hig	Higi		ʔ		[ʔ]		
-hig	Higi		ʔ		[ʷʔ]		
-hig	Higi		ʔ		[ʔʲ]		
-hig	Higi		ʔ		[ʔʲʷ]		
-hig	Higi		x		[x]		
-hig	Higi		x		[ʷx]		
-hig	Higi		x		[xʲ]		
-hig	Higi		x		[xʲʷ]		
-hig	Higi		ɣ		[ɣ]		
-hig	Higi		ɣ		[ʷɣ]		
-hig	Higi		ɣ		[ɣʲ]		
-hig	Higi		ɣ		[ɣʲʷ]		
-hig	Higi		ŋ		[ŋ]		
-hig	Higi		ŋ		[ʷŋ]		
-hig	Higi		ŋ		[ŋʲ]		
-hig	Higi		ŋ		[ŋʲʷ]		
-hig	Higi		˦				
-hig	Higi		˨				
-							
+hig	Higi		e
+hig	Higi		ɛ
+hig	Higi		a
+hig	Higi		u
+hig	Higi		ɘ
+hig	Higi		o
+hig	Higi		p		[p]
+hig	Higi		p		[pʷ]
+hig	Higi		p		[pʲ]
+hig	Higi		b		[b]
+hig	Higi		b		[bʷ]
+hig	Higi		b		[bʲ]
+hig	Higi		ɓ		[ɓ]
+hig	Higi		ɓ		[ɓʷ]
+hig	Higi		ɓ		[ɓʲ]
+hig	Higi		f		[f]
+hig	Higi		f		[fʷ]
+hig	Higi		f		[fʲ]
+hig	Higi		v		[v]
+hig	Higi		v		[vʷ]
+hig	Higi		v		[vʲ]
+hig	Higi		m		[m]
+hig	Higi		m		[mʷ]
+hig	Higi		m		[mʲ]
+hig	Higi		w		[w]
+hig	Higi		w		[wʲ]
+hig	Higi		t		[t]
+hig	Higi		t		[ʷt]
+hig	Higi		t		[tʲ]
+hig	Higi		t		[tʲʷ]
+hig	Higi		d		[d]
+hig	Higi		d		[ʷd]
+hig	Higi		d		[dʲ]
+hig	Higi		d		[dʲʷ]
+hig	Higi		ɗ		[ɗ]
+hig	Higi		ɗ		[ʷɗ]
+hig	Higi		ɗ		[ɗʲ]
+hig	Higi		ɗ		[ɗʲʷ]
+hig	Higi		ts		[ts]
+hig	Higi		ts		[ʷts]
+hig	Higi		ts		[tsʲ]
+hig	Higi		ts		[tsʲʷ]
+hig	Higi		dz		[dz]
+hig	Higi		dz		[ʷdz]
+hig	Higi		dz		[dzʲ]
+hig	Higi		dz		[dzʲʷ]
+hig	Higi		s		[s]
+hig	Higi		s		[ʷs]
+hig	Higi		s		[sʲ]
+hig	Higi		s		[sʲʷ]
+hig	Higi		z		[z]
+hig	Higi		z		[ʷz]
+hig	Higi		z		[zʲ]
+hig	Higi		z		[zʲʷ]
+hig	Higi		ɬ		[ɬ]
+hig	Higi		ɬ		[ʷɬ]
+hig	Higi		ɬ		[ɬʲ]
+hig	Higi		ɬ		[ɬʲʷ]
+hig	Higi		ɮ		[ɮ]
+hig	Higi		ɮ		[ʷɮ]
+hig	Higi		ɮ		[ɮʲ]
+hig	Higi		ɮ		[ɮʲʷ]
+hig	Higi		l		[l]
+hig	Higi		l		[lʲ]
+hig	Higi		r		[r]
+hig	Higi		r		[rʷ]
+hig	Higi		n		[n]
+hig	Higi		n		[nʷ]
+hig	Higi		n		[nʲ]
+hig	Higi		n		[nʲʷ]
+hig	Higi		j		[j]
+hig	Higi		j		[jʷ]
+hig	Higi		k		[k]
+hig	Higi		k		[ʷk]
+hig	Higi		k		[kʲ]
+hig	Higi		k		[kʲʷ]
+hig	Higi		ɡ		[ɡ]
+hig	Higi		ɡ		[ʷɡ]
+hig	Higi		ɡ		[ɡʲ]
+hig	Higi		ɡ		[ɡʲʷ]
+hig	Higi		ʔ		[ʔ]
+hig	Higi		ʔ		[ʷʔ]
+hig	Higi		ʔ		[ʔʲ]
+hig	Higi		ʔ		[ʔʲʷ]
+hig	Higi		x		[x]
+hig	Higi		x		[ʷx]
+hig	Higi		x		[xʲ]
+hig	Higi		x		[xʲʷ]
+hig	Higi		ɣ		[ɣ]
+hig	Higi		ɣ		[ʷɣ]
+hig	Higi		ɣ		[ɣʲ]
+hig	Higi		ɣ		[ɣʲʷ]
+hig	Higi		ŋ		[ŋ]
+hig	Higi		ŋ		[ʷŋ]
+hig	Higi		ŋ		[ŋʲ]
+hig	Higi		ŋ		[ŋʲʷ]
+hig	Higi		˦
+hig	Higi		˨
+
 mzj	Manya		p				mzj.pdf
-mzj	Manya		b				
-mzj	Manya		m				
-mzj	Manya		f				
-mzj	Manya		v				
-mzj	Manya		t				
-mzj	Manya		s				
-mzj	Manya		z				
-mzj	Manya		n				
-mzj	Manya		l				
-mzj	Manya		ɖ				
-mzj	Manya		d̠ʒ				
-mzj	Manya		ɲ				
-mzj	Manya		j				
-mzj	Manya		k				
-mzj	Manya		ɡ				
-mzj	Manya		ɡb				
-mzj	Manya		w				
-mzj	Manya		o				
-mzj	Manya		ɔ				
-mzj	Manya		a				
-mzj	Manya		e				
-mzj	Manya		u				
-mzj	Manya		i				
-mzj	Manya		ɛ				
-mzj	Manya		˦				
-mzj	Manya		˨				
-							
+mzj	Manya		b
+mzj	Manya		m
+mzj	Manya		f
+mzj	Manya		v
+mzj	Manya		t
+mzj	Manya		s
+mzj	Manya		z
+mzj	Manya		n
+mzj	Manya		l
+mzj	Manya		ɖ
+mzj	Manya		d̠ʒ
+mzj	Manya		ɲ
+mzj	Manya		j
+mzj	Manya		k
+mzj	Manya		ɡ
+mzj	Manya		ɡb
+mzj	Manya		w
+mzj	Manya		o
+mzj	Manya		ɔ
+mzj	Manya		a
+mzj	Manya		e
+mzj	Manya		u
+mzj	Manya		i
+mzj	Manya		ɛ
+mzj	Manya		˦
+mzj	Manya		˨
+
 say	Syan		p				say.pdf
-say	Syan		t				
-say	Syan		kʲ				
-say	Syan		k				
-say	Syan		b				
-say	Syan		d				
-say	Syan		ɡʲ				
-say	Syan		ɡ				
-say	Syan		mb				
-say	Syan		nd				
-say	Syan		ŋɡʲ				
-say	Syan		ŋɡ				
-say	Syan		ɓ				
-say	Syan		ɗ				
-say	Syan		ts				
-say	Syan		t̠ʃ				
-say	Syan		dz				
-say	Syan		d̠ʒ				
-say	Syan		ndz				
-say	Syan		n̠d̠ʒ				
-say	Syan		f				
-say	Syan		s				
-say	Syan		ʃ				
-say	Syan		v				
-say	Syan		z				
-say	Syan		ʒ				
-say	Syan		ɬ				
-say	Syan		ɮ				
-say	Syan		m				
-say	Syan		n				
-say	Syan		ɳ				
-say	Syan		ŋ				
-say	Syan		m̩				
-say	Syan		n̩				
-say	Syan		ŋ̩				
-say	Syan		l				
-say	Syan		r				
-say	Syan		w				
-say	Syan		j				
-say	Syan		i				
-say	Syan		e				
-say	Syan		ə				
-say	Syan		a				
-say	Syan		u				
-say	Syan		o				
-say	Syan		iː				
-say	Syan		eː				
-say	Syan		ɘː				
-say	Syan		aː				
-say	Syan		uː				
-say	Syan		oː				
-say	Syan		˦				
-say	Syan		˧				
-say	Syan		˨				
-							
+say	Syan		t
+say	Syan		kʲ
+say	Syan		k
+say	Syan		b
+say	Syan		d
+say	Syan		ɡʲ
+say	Syan		ɡ
+say	Syan		mb
+say	Syan		nd
+say	Syan		ŋɡʲ
+say	Syan		ŋɡ
+say	Syan		ɓ
+say	Syan		ɗ
+say	Syan		ts
+say	Syan		t̠ʃ
+say	Syan		dz
+say	Syan		d̠ʒ
+say	Syan		ndz
+say	Syan		n̠d̠ʒ
+say	Syan		f
+say	Syan		s
+say	Syan		ʃ
+say	Syan		v
+say	Syan		z
+say	Syan		ʒ
+say	Syan		ɬ
+say	Syan		ɮ
+say	Syan		m
+say	Syan		n
+say	Syan		ɳ
+say	Syan		ŋ
+say	Syan		m̩
+say	Syan		n̩
+say	Syan		ŋ̩
+say	Syan		l
+say	Syan		r
+say	Syan		w
+say	Syan		j
+say	Syan		i
+say	Syan		e
+say	Syan		ə
+say	Syan		a
+say	Syan		u
+say	Syan		o
+say	Syan		iː
+say	Syan		eː
+say	Syan		ɘː
+say	Syan		aː
+say	Syan		uː
+say	Syan		oː
+say	Syan		˦
+say	Syan		˧
+say	Syan		˨
+
 nzb	Nzɛbi		b		[b]		nzb.pdf
-nzb	Nzɛbi		b		[ɓ]		
-nzb	Nzɛbi		β				
-nzb	Nzɛbi		d		[d]		
-nzb	Nzɛbi		d		[ɗ]		
-nzb	Nzɛbi		f				
-nzb	Nzɛbi		k				
-nzb	Nzɛbi		l				
-nzb	Nzɛbi		m				
-nzb	Nzɛbi		n		[n]		
-nzb	Nzɛbi		n		[ɲ]		
-nzb	Nzɛbi		ɲ				
-nzb	Nzɛbi		<ŋ>		rare		
-nzb	Nzɛbi		p				
-nzb	Nzɛbi		pf				
-nzb	Nzɛbi		ɾ				
-nzb	Nzɛbi		s		[s]		
-nzb	Nzɛbi		s		[ʃ]		
-nzb	Nzɛbi		ʃ				
-nzb	Nzɛbi		t				
-nzb	Nzɛbi		ts		[ts]		
-nzb	Nzɛbi		ts		[t̠ʃ]		
-nzb	Nzɛbi		x				
-nzb	Nzɛbi		j				
-nzb	Nzɛbi		mb				
-nzb	Nzɛbi		ɱv				
-nzb	Nzɛbi		nd		[nd]		
-nzb	Nzɛbi		nd		[ndɾ]		
-nzb	Nzɛbi		ŋɡ				
-nzb	Nzɛbi		nz		[nz]		
-nzb	Nzɛbi		nz		[n̠d̠ʒ]		
-nzb	Nzɛbi		a				
-nzb	Nzɛbi		e				
-nzb	Nzɛbi		ɛ				
-nzb	Nzɛbi		ə				
-nzb	Nzɛbi		i				
-nzb	Nzɛbi		o				
-nzb	Nzɛbi		u				
-nzb	Nzɛbi		ɔ				
-nzb	Nzɛbi		˦				
-nzb	Nzɛbi		˨				
-							
+nzb	Nzɛbi		b		[ɓ]
+nzb	Nzɛbi		β
+nzb	Nzɛbi		d		[d]
+nzb	Nzɛbi		d		[ɗ]
+nzb	Nzɛbi		f
+nzb	Nzɛbi		k
+nzb	Nzɛbi		l
+nzb	Nzɛbi		m
+nzb	Nzɛbi		n		[n]
+nzb	Nzɛbi		n		[ɲ]
+nzb	Nzɛbi		ɲ
+nzb	Nzɛbi		<ŋ>		rare
+nzb	Nzɛbi		p
+nzb	Nzɛbi		pf
+nzb	Nzɛbi		ɾ
+nzb	Nzɛbi		s		[s]
+nzb	Nzɛbi		s		[ʃ]
+nzb	Nzɛbi		ʃ
+nzb	Nzɛbi		t
+nzb	Nzɛbi		ts		[ts]
+nzb	Nzɛbi		ts		[t̠ʃ]
+nzb	Nzɛbi		x
+nzb	Nzɛbi		j
+nzb	Nzɛbi		mb
+nzb	Nzɛbi		ɱv
+nzb	Nzɛbi		nd		[nd]
+nzb	Nzɛbi		nd		[ndɾ]
+nzb	Nzɛbi		ŋɡ
+nzb	Nzɛbi		nz		[nz]
+nzb	Nzɛbi		nz		[n̠d̠ʒ]
+nzb	Nzɛbi		a
+nzb	Nzɛbi		e
+nzb	Nzɛbi		ɛ
+nzb	Nzɛbi		ə
+nzb	Nzɛbi		i
+nzb	Nzɛbi		o
+nzb	Nzɛbi		u
+nzb	Nzɛbi		ɔ
+nzb	Nzɛbi		˦
+nzb	Nzɛbi		˨
+
 dsq	Tadaksahak		b				dsq.pdf
-dsq	Tadaksahak		t				
-dsq	Tadaksahak		d				
-dsq	Tadaksahak		f				
-dsq	Tadaksahak		s				
-dsq	Tadaksahak		z				
-dsq	Tadaksahak		w				
-dsq	Tadaksahak		l				
-dsq	Tadaksahak		ɾ				
-dsq	Tadaksahak		n				
-dsq	Tadaksahak		m				
-dsq	Tadaksahak		tˤ				
-dsq	Tadaksahak		dˤ				
-dsq	Tadaksahak		sˤ				
-dsq	Tadaksahak		zˤ				
-dsq	Tadaksahak		lˤ				
-dsq	Tadaksahak		ɾˤ				
-dsq	Tadaksahak		nˤ				
-dsq	Tadaksahak		t̠ʃ				
-dsq	Tadaksahak		d̠ʒ				
-dsq	Tadaksahak		ʃ				
-dsq	Tadaksahak		ʒ				
-dsq	Tadaksahak		j				
-dsq	Tadaksahak		k				
-dsq	Tadaksahak		ɡ				
-dsq	Tadaksahak		x				
-dsq	Tadaksahak		ɣ				
-dsq	Tadaksahak		ŋ				
-dsq	Tadaksahak		q				
-dsq	Tadaksahak		ħ				
-dsq	Tadaksahak		ʕ				
-dsq	Tadaksahak		h				
-dsq	Tadaksahak		bː				
-dsq	Tadaksahak		tː				
-dsq	Tadaksahak		dː				
-dsq	Tadaksahak		zː				
-dsq	Tadaksahak		wː				
-dsq	Tadaksahak		lː				
-dsq	Tadaksahak		r				
-dsq	Tadaksahak		nː				
-dsq	Tadaksahak		mː				
-dsq	Tadaksahak		tˤː				
-dsq	Tadaksahak		dˤː				
-dsq	Tadaksahak		sˤː				
-dsq	Tadaksahak		zˤː				
-dsq	Tadaksahak		lˤː				
-dsq	Tadaksahak		rˤ				
-dsq	Tadaksahak		nˤː				
-dsq	Tadaksahak		t̠ʃː				
-dsq	Tadaksahak		d̠ʒː				
-dsq	Tadaksahak		ʃː				
-dsq	Tadaksahak		ʒː				
-dsq	Tadaksahak		jː				
-dsq	Tadaksahak		kː				
-dsq	Tadaksahak		ɡː				
-dsq	Tadaksahak		xː				
-dsq	Tadaksahak		ŋː				
-dsq	Tadaksahak		qː				
-dsq	Tadaksahak		hː				
-dsq	Tadaksahak		i		[i]		
-dsq	Tadaksahak		i		[ɪ]		
-dsq	Tadaksahak		i		[e]		
-dsq	Tadaksahak		e		[e]		
-dsq	Tadaksahak		e		[ɛ]		
-dsq	Tadaksahak		a		[a]		
-dsq	Tadaksahak		a		[ɑ]		
-dsq	Tadaksahak		a		[ɐ]		
-dsq	Tadaksahak		a		[æ]		
-dsq	Tadaksahak		o		[o]		
-dsq	Tadaksahak		o		[ɔ]		
-dsq	Tadaksahak		u		[u]		
-dsq	Tadaksahak		u		[o]		
-dsq	Tadaksahak		ə		[ə]		
-dsq	Tadaksahak		ə		[ʌ]		
-dsq	Tadaksahak		iː				
-dsq	Tadaksahak		eː				
-dsq	Tadaksahak		aː				
-dsq	Tadaksahak		oː				
-dsq	Tadaksahak		uː				
-							
+dsq	Tadaksahak		t
+dsq	Tadaksahak		d
+dsq	Tadaksahak		f
+dsq	Tadaksahak		s
+dsq	Tadaksahak		z
+dsq	Tadaksahak		w
+dsq	Tadaksahak		l
+dsq	Tadaksahak		ɾ
+dsq	Tadaksahak		n
+dsq	Tadaksahak		m
+dsq	Tadaksahak		tˤ
+dsq	Tadaksahak		dˤ
+dsq	Tadaksahak		sˤ
+dsq	Tadaksahak		zˤ
+dsq	Tadaksahak		lˤ
+dsq	Tadaksahak		ɾˤ
+dsq	Tadaksahak		nˤ
+dsq	Tadaksahak		t̠ʃ
+dsq	Tadaksahak		d̠ʒ
+dsq	Tadaksahak		ʃ
+dsq	Tadaksahak		ʒ
+dsq	Tadaksahak		j
+dsq	Tadaksahak		k
+dsq	Tadaksahak		ɡ
+dsq	Tadaksahak		x
+dsq	Tadaksahak		ɣ
+dsq	Tadaksahak		ŋ
+dsq	Tadaksahak		q
+dsq	Tadaksahak		ħ
+dsq	Tadaksahak		ʕ
+dsq	Tadaksahak		h
+dsq	Tadaksahak		bː
+dsq	Tadaksahak		tː
+dsq	Tadaksahak		dː
+dsq	Tadaksahak		zː
+dsq	Tadaksahak		wː
+dsq	Tadaksahak		lː
+dsq	Tadaksahak		r
+dsq	Tadaksahak		nː
+dsq	Tadaksahak		mː
+dsq	Tadaksahak		tˤː
+dsq	Tadaksahak		dˤː
+dsq	Tadaksahak		sˤː
+dsq	Tadaksahak		zˤː
+dsq	Tadaksahak		lˤː
+dsq	Tadaksahak		rˤ
+dsq	Tadaksahak		nˤː
+dsq	Tadaksahak		t̠ʃː
+dsq	Tadaksahak		d̠ʒː
+dsq	Tadaksahak		ʃː
+dsq	Tadaksahak		ʒː
+dsq	Tadaksahak		jː
+dsq	Tadaksahak		kː
+dsq	Tadaksahak		ɡː
+dsq	Tadaksahak		xː
+dsq	Tadaksahak		ŋː
+dsq	Tadaksahak		qː
+dsq	Tadaksahak		hː
+dsq	Tadaksahak		i		[i]
+dsq	Tadaksahak		i		[ɪ]
+dsq	Tadaksahak		i		[e]
+dsq	Tadaksahak		e		[e]
+dsq	Tadaksahak		e		[ɛ]
+dsq	Tadaksahak		a		[a]
+dsq	Tadaksahak		a		[ɑ]
+dsq	Tadaksahak		a		[ɐ]
+dsq	Tadaksahak		a		[æ]
+dsq	Tadaksahak		o		[o]
+dsq	Tadaksahak		o		[ɔ]
+dsq	Tadaksahak		u		[u]
+dsq	Tadaksahak		u		[o]
+dsq	Tadaksahak		ə		[ə]
+dsq	Tadaksahak		ə		[ʌ]
+dsq	Tadaksahak		iː
+dsq	Tadaksahak		eː
+dsq	Tadaksahak		aː
+dsq	Tadaksahak		oː
+dsq	Tadaksahak		uː
+
 ktb	Kambaata		i		[i]		ktb.pdf
-ktb	Kambaata		i		[i̥]		
-ktb	Kambaata		i		[ĩ]		
-ktb	Kambaata		e		[e]		
-ktb	Kambaata		e		[e̥]		
-ktb	Kambaata		e		[ẽ]		
-ktb	Kambaata		a		[a]		
-ktb	Kambaata		a		[ḁ]		
-ktb	Kambaata		a		[ã]		
-ktb	Kambaata		o		[o]		
-ktb	Kambaata		o		[o̥]		
-ktb	Kambaata		o		[õ]		
-ktb	Kambaata		u		[u]		
-ktb	Kambaata		u		[u̥]		
-ktb	Kambaata		u		[ũ]		
-ktb	Kambaata		iː		[iː]		
-ktb	Kambaata		iː		[ĩː]		
-ktb	Kambaata		eː		[eː]		
-ktb	Kambaata		eː		[ẽː]		
-ktb	Kambaata		aː		[aː]		
-ktb	Kambaata		aː		[ãː]		
-ktb	Kambaata		oː		[oː]		
-ktb	Kambaata		oː		[õː]		
-ktb	Kambaata		uː		[uː]		
-ktb	Kambaata		uː		[ũː]		
-ktb	Kambaata		b				
-ktb	Kambaata		pʼ				
-ktb	Kambaata		f				
-ktb	Kambaata		m				
-ktb	Kambaata		w				
-ktb	Kambaata		t				
-ktb	Kambaata		d				
-ktb	Kambaata		tʼ				
-ktb	Kambaata		s				
-ktb	Kambaata		z				
-ktb	Kambaata		n				
-ktb	Kambaata		r				
-ktb	Kambaata		rʼ				
-ktb	Kambaata		l				
-ktb	Kambaata		lʼ				
-ktb	Kambaata		j				
-ktb	Kambaata		<ɲ>	marɡinal			
-ktb	Kambaata		<ʒ>	marɡinal			
-ktb	Kambaata		ʃ				
-ktb	Kambaata		t̠ʃʼ				
-ktb	Kambaata		d̠ʒ				
-ktb	Kambaata		t̠ʃ				
-ktb	Kambaata		k				
-ktb	Kambaata		ɡ				
-ktb	Kambaata		kʼ				
-ktb	Kambaata		ʔ				
-ktb	Kambaata		h				
-ktb	Kambaata		bː				
-ktb	Kambaata		pʼː				
-ktb	Kambaata		fː				
-ktb	Kambaata		mː				
-ktb	Kambaata		wː				
-ktb	Kambaata		tː				
-ktb	Kambaata		dː				
-ktb	Kambaata		tʼː				
-ktb	Kambaata		sː				
-ktb	Kambaata		zː				
-ktb	Kambaata		nː				
-ktb	Kambaata		rː				
-ktb	Kambaata		rʼː				
-ktb	Kambaata		lː				
-ktb	Kambaata		lʼː				
-ktb	Kambaata		jː				
-ktb	Kambaata		sː				
-ktb	Kambaata		t̠ʃʼː				
-ktb	Kambaata		d̠ʒː				
-ktb	Kambaata		t̠ʃː				
-ktb	Kambaata		kː				
-ktb	Kambaata		ɡː				
-ktb	Kambaata		kʼː				
-							
+ktb	Kambaata		i		[i̥]
+ktb	Kambaata		i		[ĩ]
+ktb	Kambaata		e		[e]
+ktb	Kambaata		e		[e̥]
+ktb	Kambaata		e		[ẽ]
+ktb	Kambaata		a		[a]
+ktb	Kambaata		a		[ḁ]
+ktb	Kambaata		a		[ã]
+ktb	Kambaata		o		[o]
+ktb	Kambaata		o		[o̥]
+ktb	Kambaata		o		[õ]
+ktb	Kambaata		u		[u]
+ktb	Kambaata		u		[u̥]
+ktb	Kambaata		u		[ũ]
+ktb	Kambaata		iː		[iː]
+ktb	Kambaata		iː		[ĩː]
+ktb	Kambaata		eː		[eː]
+ktb	Kambaata		eː		[ẽː]
+ktb	Kambaata		aː		[aː]
+ktb	Kambaata		aː		[ãː]
+ktb	Kambaata		oː		[oː]
+ktb	Kambaata		oː		[õː]
+ktb	Kambaata		uː		[uː]
+ktb	Kambaata		uː		[ũː]
+ktb	Kambaata		b
+ktb	Kambaata		pʼ
+ktb	Kambaata		f
+ktb	Kambaata		m
+ktb	Kambaata		w
+ktb	Kambaata		t
+ktb	Kambaata		d
+ktb	Kambaata		tʼ
+ktb	Kambaata		s
+ktb	Kambaata		z
+ktb	Kambaata		n
+ktb	Kambaata		r
+ktb	Kambaata		rʼ
+ktb	Kambaata		l
+ktb	Kambaata		lʼ
+ktb	Kambaata		j
+ktb	Kambaata		<ɲ>	marɡinal
+ktb	Kambaata		<ʒ>	marɡinal
+ktb	Kambaata		ʃ
+ktb	Kambaata		t̠ʃʼ
+ktb	Kambaata		d̠ʒ
+ktb	Kambaata		t̠ʃ
+ktb	Kambaata		k
+ktb	Kambaata		ɡ
+ktb	Kambaata		kʼ
+ktb	Kambaata		ʔ
+ktb	Kambaata		h
+ktb	Kambaata		bː
+ktb	Kambaata		pʼː
+ktb	Kambaata		fː
+ktb	Kambaata		mː
+ktb	Kambaata		wː
+ktb	Kambaata		tː
+ktb	Kambaata		dː
+ktb	Kambaata		tʼː
+ktb	Kambaata		sː
+ktb	Kambaata		zː
+ktb	Kambaata		nː
+ktb	Kambaata		rː
+ktb	Kambaata		rʼː
+ktb	Kambaata		lː
+ktb	Kambaata		lʼː
+ktb	Kambaata		jː
+ktb	Kambaata		sː
+ktb	Kambaata		t̠ʃʼː
+ktb	Kambaata		d̠ʒː
+ktb	Kambaata		t̠ʃː
+ktb	Kambaata		kː
+ktb	Kambaata		ɡː
+ktb	Kambaata		kʼː
+
 otr	Otoro		i		[i]		otr.pdf
-otr	Otoro		i		[ɪ]		
-otr	Otoro		a		[a]		
-otr	Otoro		a		[ɑ]		
-otr	Otoro		a		[æ]		
-otr	Otoro		o		[o]		
-otr	Otoro		o		[o̤]		
-otr	Otoro		u		[u]		
-otr	Otoro		u		[ʊ]		
-otr	Otoro		e̝				
-otr	Otoro		ɛ				
-otr	Otoro		ɔ				
-otr	Otoro		ɜ				
-otr	Otoro		ə				
-otr	Otoro		ei				
-otr	Otoro		ai				
-otr	Otoro		au				
-otr	Otoro		ou				
-otr	Otoro		ɔi				
-otr	Otoro		p				
-otr	Otoro		b				
-otr	Otoro		β				
-otr	Otoro		m				
-otr	Otoro		v				
-otr	Otoro		t̪				
-otr	Otoro		d̪				
-otr	Otoro		ð				
-otr	Otoro		tr				
-otr	Otoro		dr				
-otr	Otoro		ɽ				
-otr	Otoro		t				
-otr	Otoro		d				
-otr	Otoro		ɗ				
-otr	Otoro		n				
-otr	Otoro		l				
-otr	Otoro		r				
-otr	Otoro		c				
-otr	Otoro		ɟ				
-otr	Otoro		ɲ				
-otr	Otoro		j				
-otr	Otoro		k				
-otr	Otoro		ɡ				
-otr	Otoro		ŋ				
-otr	Otoro		w				
-otr	Otoro		lː				
-otr	Otoro		rː				
-otr	Otoro		kʷ				
-otr	Otoro		ɡʷ				
-otr	Otoro		ŋʷ				
-							
+otr	Otoro		i		[ɪ]
+otr	Otoro		a		[a]
+otr	Otoro		a		[ɑ]
+otr	Otoro		a		[æ]
+otr	Otoro		o		[o]
+otr	Otoro		o		[o̤]
+otr	Otoro		u		[u]
+otr	Otoro		u		[ʊ]
+otr	Otoro		e̝
+otr	Otoro		ɛ
+otr	Otoro		ɔ
+otr	Otoro		ɜ
+otr	Otoro		ə
+otr	Otoro		ei
+otr	Otoro		ai
+otr	Otoro		au
+otr	Otoro		ou
+otr	Otoro		ɔi
+otr	Otoro		p
+otr	Otoro		b
+otr	Otoro		β
+otr	Otoro		m
+otr	Otoro		v
+otr	Otoro		t̪
+otr	Otoro		d̪
+otr	Otoro		ð
+otr	Otoro		tr
+otr	Otoro		dr
+otr	Otoro		ɽ
+otr	Otoro		t
+otr	Otoro		d
+otr	Otoro		ɗ
+otr	Otoro		n
+otr	Otoro		l
+otr	Otoro		r
+otr	Otoro		c
+otr	Otoro		ɟ
+otr	Otoro		ɲ
+otr	Otoro		j
+otr	Otoro		k
+otr	Otoro		ɡ
+otr	Otoro		ŋ
+otr	Otoro		w
+otr	Otoro		lː
+otr	Otoro		rː
+otr	Otoro		kʷ
+otr	Otoro		ɡʷ
+otr	Otoro		ŋʷ
+
 tic	Tira		i				otr.pdf
-tic	Tira		e̝				
-tic	Tira		e				
-tic	Tira		ɛ				
-tic	Tira		a				
-tic	Tira		ɜ				
-tic	Tira		ə				
-tic	Tira		u				
-tic	Tira		o		[o]		
-tic	Tira		o		[o̤]		
-tic	Tira		ɔ				
-tic	Tira		ei				
-tic	Tira		ai				
-tic	Tira		au				
-tic	Tira		ɔi				
-tic	Tira		oi				
-tic	Tira		ou				
-tic	Tira		p		[p]		
-tic	Tira		p		[b]		
-tic	Tira		b				
-tic	Tira		m				
-tic	Tira		v				
-tic	Tira		t̪		[t̪]		
-tic	Tira		t̪		[d̪]		
-tic	Tira		d̪				
-tic	Tira		ð				
-tic	Tira		θ				
-tic	Tira		ʂ				
-tic	Tira		ʈ				
-tic	Tira		tr				
-tic	Tira		dr				
-tic	Tira		ɽ				
-tic	Tira		t		[t]		
-tic	Tira		t		[d]		
-tic	Tira		d				
-tic	Tira		n				
-tic	Tira		r				
-tic	Tira		l				
-tic	Tira		c				
-tic	Tira		ɟ				
-tic	Tira		ɲ				
-tic	Tira		j				
-tic	Tira		k		[k]		
-tic	Tira		k		[ɡ]		
-tic	Tira		ɡ				
-tic	Tira		ŋ				
-tic	Tira		w				
-							
+tic	Tira		e̝
+tic	Tira		e
+tic	Tira		ɛ
+tic	Tira		a
+tic	Tira		ɜ
+tic	Tira		ə
+tic	Tira		u
+tic	Tira		o		[o]
+tic	Tira		o		[o̤]
+tic	Tira		ɔ
+tic	Tira		ei
+tic	Tira		ai
+tic	Tira		au
+tic	Tira		ɔi
+tic	Tira		oi
+tic	Tira		ou
+tic	Tira		p		[p]
+tic	Tira		p		[b]
+tic	Tira		b
+tic	Tira		m
+tic	Tira		v
+tic	Tira		t̪		[t̪]
+tic	Tira		t̪		[d̪]
+tic	Tira		d̪
+tic	Tira		ð
+tic	Tira		θ
+tic	Tira		ʂ
+tic	Tira		ʈ
+tic	Tira		tr
+tic	Tira		dr
+tic	Tira		ɽ
+tic	Tira		t		[t]
+tic	Tira		t		[d]
+tic	Tira		d
+tic	Tira		n
+tic	Tira		r
+tic	Tira		l
+tic	Tira		c
+tic	Tira		ɟ
+tic	Tira		ɲ
+tic	Tira		j
+tic	Tira		k		[k]
+tic	Tira		k		[ɡ]
+tic	Tira		ɡ
+tic	Tira		ŋ
+tic	Tira		w
+
 nmi	Nyam		i				nmi.pdf
-nmi	Nyam		iː				
-nmi	Nyam		e				
-nmi	Nyam		eː				
-nmi	Nyam		ɛ				
-nmi	Nyam		ɛː				
-nmi	Nyam		a				
-nmi	Nyam		aː				
-nmi	Nyam		o				
-nmi	Nyam		oː				
-nmi	Nyam		ɔ				
-nmi	Nyam		ɔː				
-nmi	Nyam		u				
-nmi	Nyam		uː				
-nmi	Nyam		p				
-nmi	Nyam		b				
-nmi	Nyam		ɓ				
-nmi	Nyam		mb				
-nmi	Nyam		mɓ				
-nmi	Nyam		f				
-nmi	Nyam		m				
-nmi	Nyam		w				
-nmi	Nyam		t				
-nmi	Nyam		d				
-nmi	Nyam		ɗ				
-nmi	Nyam		nd				
-nmi	Nyam		nɗ				
-nmi	Nyam		dʲ				
-nmi	Nyam		ʃ				
-nmi	Nyam		n				
-nmi	Nyam		nz				
-nmi	Nyam		n				
-nmi	Nyam		l				
-nmi	Nyam		r				
-nmi	Nyam		t̠ʃ				
-nmi	Nyam		d̠ʒ				
-nmi	Nyam		n̠d̠ʒ				
-nmi	Nyam		ɲ				
-nmi	Nyam		j				
-nmi	Nyam		k				
-nmi	Nyam		ɡ				
-nmi	Nyam		ŋɡ				
-nmi	Nyam		kʲ				
-nmi	Nyam		x				
-nmi	Nyam		ŋ				
-nmi	Nyam		kʷ				
-nmi	Nyam		ɡʷ				
-nmi	Nyam		ŋɡʷ				
-nmi	Nyam		kp				
-nmi	Nyam		ɡb				
-nmi	Nyam		ɡɓ				
-nmi	Nyam		ʔ				
-nmi	Nyam		h				
-nmi	Nyam		hʷ				
-nmi	Nyam		˦				
-nmi	Nyam		˨				
-nmi	Nyam		˦˨				
-							
+nmi	Nyam		iː
+nmi	Nyam		e
+nmi	Nyam		eː
+nmi	Nyam		ɛ
+nmi	Nyam		ɛː
+nmi	Nyam		a
+nmi	Nyam		aː
+nmi	Nyam		o
+nmi	Nyam		oː
+nmi	Nyam		ɔ
+nmi	Nyam		ɔː
+nmi	Nyam		u
+nmi	Nyam		uː
+nmi	Nyam		p
+nmi	Nyam		b
+nmi	Nyam		ɓ
+nmi	Nyam		mb
+nmi	Nyam		mɓ
+nmi	Nyam		f
+nmi	Nyam		m
+nmi	Nyam		w
+nmi	Nyam		t
+nmi	Nyam		d
+nmi	Nyam		ɗ
+nmi	Nyam		nd
+nmi	Nyam		nɗ
+nmi	Nyam		dʲ
+nmi	Nyam		ʃ
+nmi	Nyam		n
+nmi	Nyam		nz
+nmi	Nyam		n
+nmi	Nyam		l
+nmi	Nyam		r
+nmi	Nyam		t̠ʃ
+nmi	Nyam		d̠ʒ
+nmi	Nyam		n̠d̠ʒ
+nmi	Nyam		ɲ
+nmi	Nyam		j
+nmi	Nyam		k
+nmi	Nyam		ɡ
+nmi	Nyam		ŋɡ
+nmi	Nyam		kʲ
+nmi	Nyam		x
+nmi	Nyam		ŋ
+nmi	Nyam		kʷ
+nmi	Nyam		ɡʷ
+nmi	Nyam		ŋɡʷ
+nmi	Nyam		kp
+nmi	Nyam		ɡb
+nmi	Nyam		ɡɓ
+nmi	Nyam		ʔ
+nmi	Nyam		h
+nmi	Nyam		hʷ
+nmi	Nyam		˦
+nmi	Nyam		˨
+nmi	Nyam		˦˨
+
 fli	Kirya-Konzɘl		i				fli.pdf
-fli	Kirya-Konzɘl		e				
-fli	Kirya-Konzɘl		ə				
-fli	Kirya-Konzɘl		a				
-fli	Kirya-Konzɘl		o				
-fli	Kirya-Konzɘl		u				
-fli	Kirya-Konzɘl		p				
-fli	Kirya-Konzɘl		b				
-fli	Kirya-Konzɘl		m				
-fli	Kirya-Konzɘl		ɓ				
-fli	Kirya-Konzɘl		f				
-fli	Kirya-Konzɘl		v				
-fli	Kirya-Konzɘl		t				
-fli	Kirya-Konzɘl		d				
-fli	Kirya-Konzɘl		n				
-fli	Kirya-Konzɘl		r				
-fli	Kirya-Konzɘl		ɽ				
-fli	Kirya-Konzɘl		s				
-fli	Kirya-Konzɘl		z				
-fli	Kirya-Konzɘl		ts				
-fli	Kirya-Konzɘl		dz				
-fli	Kirya-Konzɘl		l				
-fli	Kirya-Konzɘl		ɗ				
-fli	Kirya-Konzɘl		ʃ				
-fli	Kirya-Konzɘl		ʒ				
-fli	Kirya-Konzɘl		c				
-fli	Kirya-Konzɘl		ɲ				
-fli	Kirya-Konzɘl		t̠ʃ				
-fli	Kirya-Konzɘl		d̠ʒ				
-fli	Kirya-Konzɘl		ɮ				
-fli	Kirya-Konzɘl		ɬ				
-fli	Kirya-Konzɘl		j				
-fli	Kirya-Konzɘl		k				
-fli	Kirya-Konzɘl		ɡ				
-fli	Kirya-Konzɘl		ŋ				
-fli	Kirya-Konzɘl		x				
-fli	Kirya-Konzɘl		ɣ				
-fli	Kirya-Konzɘl		kʼ				
-fli	Kirya-Konzɘl		w				
-fli	Kirya-Konzɘl		ʔ				
-fli	Kirya-Konzɘl		ˀm				
-fli	Kirya-Konzɘl		h				
-fli	Kirya-Konzɘl		ˀl				
-fli	Kirya-Konzɘl		ˀw				
-fli	Kirya-Konzɘl		ˀy				
-fli	Kirya-Konzɘl		˦				
-fli	Kirya-Konzɘl		˨				
-fli	Kirya-Konzɘl		˦˨				
-fli	Kirya-Konzɘl		˨˦				
-fli	Kirya-Konzɘl		↓				
-							
+fli	Kirya-Konzɘl		e
+fli	Kirya-Konzɘl		ə
+fli	Kirya-Konzɘl		a
+fli	Kirya-Konzɘl		o
+fli	Kirya-Konzɘl		u
+fli	Kirya-Konzɘl		p
+fli	Kirya-Konzɘl		b
+fli	Kirya-Konzɘl		m
+fli	Kirya-Konzɘl		ɓ
+fli	Kirya-Konzɘl		f
+fli	Kirya-Konzɘl		v
+fli	Kirya-Konzɘl		t
+fli	Kirya-Konzɘl		d
+fli	Kirya-Konzɘl		n
+fli	Kirya-Konzɘl		r
+fli	Kirya-Konzɘl		ɽ
+fli	Kirya-Konzɘl		s
+fli	Kirya-Konzɘl		z
+fli	Kirya-Konzɘl		ts
+fli	Kirya-Konzɘl		dz
+fli	Kirya-Konzɘl		l
+fli	Kirya-Konzɘl		ɗ
+fli	Kirya-Konzɘl		ʃ
+fli	Kirya-Konzɘl		ʒ
+fli	Kirya-Konzɘl		c
+fli	Kirya-Konzɘl		ɲ
+fli	Kirya-Konzɘl		t̠ʃ
+fli	Kirya-Konzɘl		d̠ʒ
+fli	Kirya-Konzɘl		ɮ
+fli	Kirya-Konzɘl		ɬ
+fli	Kirya-Konzɘl		j
+fli	Kirya-Konzɘl		k
+fli	Kirya-Konzɘl		ɡ
+fli	Kirya-Konzɘl		ŋ
+fli	Kirya-Konzɘl		x
+fli	Kirya-Konzɘl		ɣ
+fli	Kirya-Konzɘl		kʼ
+fli	Kirya-Konzɘl		w
+fli	Kirya-Konzɘl		ʔ
+fli	Kirya-Konzɘl		ˀm
+fli	Kirya-Konzɘl		h
+fli	Kirya-Konzɘl		ˀl
+fli	Kirya-Konzɘl		ˀw
+fli	Kirya-Konzɘl		ˀy
+fli	Kirya-Konzɘl		˦
+fli	Kirya-Konzɘl		˨
+fli	Kirya-Konzɘl		˦˨
+fli	Kirya-Konzɘl		˨˦
+fli	Kirya-Konzɘl		↓
+
 mcw	Mawa		p				mcw.pdf
-mcw	Mawa		b				
-mcw	Mawa		ɓ				
-mcw	Mawa		m				
-mcw	Mawa		w				
-mcw	Mawa		t				
-mcw	Mawa		d				
-mcw	Mawa		ɗ				
-mcw	Mawa		s				
-mcw	Mawa		n				
-mcw	Mawa		l				
-mcw	Mawa		ɾ				
-mcw	Mawa		c				
-mcw	Mawa		ɟ				
-mcw	Mawa		ɲ				
-mcw	Mawa		j				
-mcw	Mawa		k				
-mcw	Mawa		ɡ				
-mcw	Mawa		ŋ				
-mcw	Mawa		ʔ	ʔ ...the glottal stop only occurs phonetically at the beginning of vowel-initial words, and for that reason need not be recognized as a phoneme			
-mcw	Mawa		<ʔw>	marɡinal			
-mcw	Mawa		<h>	loanwords only			
-mcw	Mawa		<f>	loanwords only			
-mcw	Mawa		<z>	loanwords only			
-mcw	Mawa		i				
-mcw	Mawa		e				
-mcw	Mawa		ɘ				
-mcw	Mawa		a				
-mcw	Mawa		u				
-mcw	Mawa		o				
-mcw	Mawa		˦				
-mcw	Mawa		˨				
-mcw	Mawa		˧				
-							
+mcw	Mawa		b
+mcw	Mawa		ɓ
+mcw	Mawa		m
+mcw	Mawa		w
+mcw	Mawa		t
+mcw	Mawa		d
+mcw	Mawa		ɗ
+mcw	Mawa		s
+mcw	Mawa		n
+mcw	Mawa		l
+mcw	Mawa		ɾ
+mcw	Mawa		c
+mcw	Mawa		ɟ
+mcw	Mawa		ɲ
+mcw	Mawa		j
+mcw	Mawa		k
+mcw	Mawa		ɡ
+mcw	Mawa		ŋ
+mcw	Mawa		ʔ	ʔ ...the glottal stop only occurs phonetically at the beginning of vowel-initial words, and for that reason need not be recognized as a phoneme
+mcw	Mawa		<ʔw>	marɡinal
+mcw	Mawa		<h>	loanwords only
+mcw	Mawa		<f>	loanwords only
+mcw	Mawa		<z>	loanwords only
+mcw	Mawa		i
+mcw	Mawa		e
+mcw	Mawa		ɘ
+mcw	Mawa		a
+mcw	Mawa		u
+mcw	Mawa		o
+mcw	Mawa		˦
+mcw	Mawa		˨
+mcw	Mawa		˧
+
 nmn	!Xóõ		kʘ	ʘ	kʘ		nmn.pdf
-nmn	!Xóõ		kǀ	ǀ	kǀ		
-nmn	!Xóõ		kǁ	ǁ	kǁ		
-nmn	!Xóõ		kǂ	ǂ	kǂ		
-nmn	!Xóõ		ɡʘ	ʘɡ	ɡʘ		
-nmn	!Xóõ		ɡǀ	ǀɡ	ɡǀ		
-nmn	!Xóõ		kǃ	ǃ	kǃ		
-nmn	!Xóõ		ɡǃ	ǃɡ	ɡǃ		
-nmn	!Xóõ		ɡǂ	ǂɡ	ɡǂ		
-nmn	!Xóõ		ɡǁ	ǁɡ	ɡǁ		
-nmn	!Xóõ		kʘx	ʘx	kʘx		
-nmn	!Xóõ		kǀx	ǀx	kǀx		
-nmn	!Xóõ		kǃx	ǃx	kǃx		
-nmn	!Xóõ		kǂx	ǂx	kǂx		
-nmn	!Xóõ		kǁx	ǁx	kǁx		
-nmn	!Xóõ		ɡʘx	ɡʘx	ɡʘx		
-nmn	!Xóõ		ɡǀx	ɡǀx	ɡǀx		
-nmn	!Xóõ		ɡǃx	ɡǃx	ɡǃx		
-nmn	!Xóõ		ɡǁx	ɡǁx	ɡǁx		
-nmn	!Xóõ		ɡǂx	ɡǂx	ɡǂx		
-nmn	!Xóõ		kʘkxʼ	ʘkxʼ	kʘkxʼ		
-nmn	!Xóõ		kǀkxʼ	ǀkxʼ	kǀkxʼ		
-nmn	!Xóõ		kǃkxʼ	ǃkxʼ	kǃkxʼ		
-nmn	!Xóõ		kǁkxʼ	ǁkxʼ	kǁkxʼ		
-nmn	!Xóõ		kǂkxʼ	ǂkxʼ	kǂkxʼ		
-nmn	!Xóõ		ɡʘkxʼ	ɡʘkxʼ	ɡʘkxʼ		
-nmn	!Xóõ		ɡǀkxʼ	ɡǀkxʼ	ɡǀkxʼ		
-nmn	!Xóõ		ɡǃkxʼ	ɡǃkxʼ	ɡǃkxʼ		
-nmn	!Xóõ		ɡǁkxʼ	ɡǁkxʼ	ɡǁkxʼ		
-nmn	!Xóõ		ɡǂkxʼ	ɡǂkxʼ	ɡǂkxʼ		
-nmn	!Xóõ		qʘ	ʘq	qʘ		
-nmn	!Xóõ		qǀ	ǀq	qǀ		
-nmn	!Xóõ		qǃ	ǃq	qǃ		
-nmn	!Xóõ		qǁ	ǁq	qǁ		
-nmn	!Xóõ		qǂ	ǂq	qǂ		
-nmn	!Xóõ		ɢʘ	ʘɢ	ɴʘɢ		
-nmn	!Xóõ		ɢǀ	ǀɢ	ɴǀɢ		
-nmn	!Xóõ		ɢǃ	ǃɢ	ɴǃɢ		
-nmn	!Xóõ		ɢǁ	ǁɢ	ɴǁɢ		
-nmn	!Xóõ		ɢǂ	ǂɢ	ɴǂɢ		
-nmn	!Xóõ		kʘʰ	ʘqʰ	qʘʰ		
-nmn	!Xóõ		kǀʰ	ǀqʰ	qǀʰ		
-nmn	!Xóõ		kǃʰ	ǃqʰ	qǃʰ		
-nmn	!Xóõ		kǁʰ	ǁqʰ	qǁʰ		
-nmn	!Xóõ		kǂʰ	ǂqʰ	qǂʰ		
-nmn	!Xóõ		ɡʘkʰ	ɡʘqʰ	ɡʘqʰ		
-nmn	!Xóõ		ɡǀkʰ	ɡǀqʰ	ɡǀqʰ		
-nmn	!Xóõ		ɡǃkʰ	ɡǃqʱ	ɡǃqʱ		
-nmn	!Xóõ		ɡǁkʰ	ɡǁqʰ	ɡǁqʰ		
-nmn	!Xóõ		ɡǂkʰ	ɡǂqʰ	ɡǂqʰ		
-nmn	!Xóõ		ɢǀqʰ	ɴɢǀqʰ	ɴɢǀqʰ		
-nmn	!Xóõ		ɢǃqʰ	ɴɢǃqʰ	ɴɢǃqʰ		
-nmn	!Xóõ		ɢǁqʰ	ɴɢǁqʰ	ɴɢǁqʰ		
-nmn	!Xóõ		qʘʼ	ʘqʼ	qʘʼ		
-nmn	!Xóõ		qǀʼ	ǀqʼ	qǀʼ		
-nmn	!Xóõ		qǃʼ	ǃqʼ	qǃʼ		
-nmn	!Xóõ		qǁʼ	ǁqʼ	qǁʼ		
-nmn	!Xóõ		qǂʼ	ǂqʼ	qǂʼ		
-nmn	!Xóõ		kʘh	ʘʰ	kʘh		
-nmn	!Xóõ		kǀh	ǀʰ	kǀh		
-nmn	!Xóõ		kǃh	ǃʰ	kǃh		
-nmn	!Xóõ		kǁh	ǁʰ	kǁh		
-nmn	!Xóõ		kǂh	ǂʰ	kǂh		
-nmn	!Xóõ		ŋ̊ʘ	ʘn̥	ŋ̊ʘ		
-nmn	!Xóõ		ŋ̊ǀ	ǀn̥	ŋ̊ǀ		
-nmn	!Xóõ		ŋ̊ǃ	ǃn̥	ŋ̊ǃ		
-nmn	!Xóõ		ŋ̊ǁ	ǁn̥	ŋ̊ǁ		
-nmn	!Xóõ		ŋ̊ǂ	ǂn̥	ŋ̊ǂ		
-nmn	!Xóõ		ŋʘ	ʘn	ŋʘ		
-nmn	!Xóõ		ŋǀ	ǀn	ŋǀ		
-nmn	!Xóõ		ŋǃ	ǃn	ŋǃ		
-nmn	!Xóõ		ŋǁ	ǁn	ŋǁ		
-nmn	!Xóõ		ŋǂ	ǂn	ŋǂ		
-nmn	!Xóõ		ʔŋʘ	ˀnʘ	ʔŋʘ		
-nmn	!Xóõ		ʔŋǀ	ˀnǀ	ʔŋǀ		
-nmn	!Xóõ		ʔŋǃ	ˀnǃ	ʔŋǃ		
-nmn	!Xóõ		ʔŋǁ	ˀnǁ	ʔŋǁ		
-nmn	!Xóõ		ʔŋǂ	ˀnǂ	ʔŋǂ		
-nmn	!Xóõ		kʘʔ	ʘʼ	kʘʔ		
-nmn	!Xóõ		kǀʔ	ǀʼ	kǀʔ		
-nmn	!Xóõ		kǃʔ	ǃʼ	kǃʔ		
-nmn	!Xóõ		kǁʔ	ǁʼ	kǁʔ		
-nmn	!Xóõ		kǂʔ	ǂʼ	kǂʔ		
-nmn	!Xóõ		p				
-nmn	!Xóõ		t̪				
-nmn	!Xóõ		t				
-nmn	!Xóõ		k				
-nmn	!Xóõ		q				
-nmn	!Xóõ		ʔ				
-nmn	!Xóõ		b				
-nmn	!Xóõ		d̪				
-nmn	!Xóõ		d				
-nmn	!Xóõ		ɟ				
-nmn	!Xóõ		ɡ				
-nmn	!Xóõ		ɢ				
-nmn	!Xóõ		pʰ				
-nmn	!Xóõ		t̪ʰ				
-nmn	!Xóõ		tʰ				
-nmn	!Xóõ		kʰ				
-nmn	!Xóõ		qʰ				
-nmn	!Xóõ		d̪ʱ				
-nmn	!Xóõ		dʱ				
-nmn	!Xóõ		ɡʱ				
-nmn	!Xóõ		ɢʱ				
-nmn	!Xóõ		t̪x				
-nmn	!Xóõ		tx				
-nmn	!Xóõ		d̪x				
-nmn	!Xóõ		dx				
-nmn	!Xóõ		t̪ʼ				
-nmn	!Xóõ		tʼ				
-nmn	!Xóõ		kʼ				
-nmn	!Xóõ		kxʼ				
-nmn	!Xóõ		qʼ				
-nmn	!Xóõ		pʼkxʼ				
-nmn	!Xóõ		t̪ʼkxʼ				
-nmn	!Xóõ		tʼkxʼ				
-nmn	!Xóõ		d̪ʼkxʼ				
-nmn	!Xóõ		dʼkxʼ				
-nmn	!Xóõ		ɡʼkxʼ				
-nmn	!Xóõ		f				
-nmn	!Xóõ		ɸ				
-nmn	!Xóõ		s				
-nmn	!Xóõ		x				
-nmn	!Xóõ		h				
-nmn	!Xóõ		l				
-nmn	!Xóõ		m				
-nmn	!Xóõ		n̪				
-nmn	!Xóõ		ɲ				
-nmn	!Xóõ		ˀm				
-nmn	!Xóõ		ˀn				
-nmn	!Xóõ		i				
-nmn	!Xóõ		e				
-nmn	!Xóõ		a				
-nmn	!Xóõ		o				
-nmn	!Xóõ		u				
-nmn	!Xóõ		ĩ				
-nmn	!Xóõ		ẽ				
-nmn	!Xóõ		ã				
-nmn	!Xóõ		õ				
-nmn	!Xóõ		ũ				
-nmn	!Xóõ		iˤ				
-nmn	!Xóõ		eˤ				
-nmn	!Xóõ		aˤ				
-nmn	!Xóõ		oˤ				
-nmn	!Xóõ		uˤ				
-nmn	!Xóõ		i̤				
-nmn	!Xóõ		e̤				
-nmn	!Xóõ		a̤				
-nmn	!Xóõ		o̤				
-nmn	!Xóõ		ṳ				
-nmn	!Xóõ		ḭ				
-nmn	!Xóõ		ḛ				
-nmn	!Xóõ		a̰				
-nmn	!Xóõ		o̰				
-nmn	!Xóõ		ṵ				
-nmn	!Xóõ		aᴱ				
-nmn	!Xóõ		oᴱ				
-nmn	!Xóõ		uᴱ				
-nmn	!Xóõ		˦				
-nmn	!Xóõ		˨				
-nmn	!Xóõ		˧				
-							
+nmn	!Xóõ		kǀ	ǀ	kǀ
+nmn	!Xóõ		kǁ	ǁ	kǁ
+nmn	!Xóõ		kǂ	ǂ	kǂ
+nmn	!Xóõ		ɡʘ	ʘɡ	ɡʘ
+nmn	!Xóõ		ɡǀ	ǀɡ	ɡǀ
+nmn	!Xóõ		kǃ	ǃ	kǃ
+nmn	!Xóõ		ɡǃ	ǃɡ	ɡǃ
+nmn	!Xóõ		ɡǂ	ǂɡ	ɡǂ
+nmn	!Xóõ		ɡǁ	ǁɡ	ɡǁ
+nmn	!Xóõ		kʘx	ʘx	kʘx
+nmn	!Xóõ		kǀx	ǀx	kǀx
+nmn	!Xóõ		kǃx	ǃx	kǃx
+nmn	!Xóõ		kǂx	ǂx	kǂx
+nmn	!Xóõ		kǁx	ǁx	kǁx
+nmn	!Xóõ		ɡʘx	ɡʘx	ɡʘx
+nmn	!Xóõ		ɡǀx	ɡǀx	ɡǀx
+nmn	!Xóõ		ɡǃx	ɡǃx	ɡǃx
+nmn	!Xóõ		ɡǁx	ɡǁx	ɡǁx
+nmn	!Xóõ		ɡǂx	ɡǂx	ɡǂx
+nmn	!Xóõ		kʘkxʼ	ʘkxʼ	kʘkxʼ
+nmn	!Xóõ		kǀkxʼ	ǀkxʼ	kǀkxʼ
+nmn	!Xóõ		kǃkxʼ	ǃkxʼ	kǃkxʼ
+nmn	!Xóõ		kǁkxʼ	ǁkxʼ	kǁkxʼ
+nmn	!Xóõ		kǂkxʼ	ǂkxʼ	kǂkxʼ
+nmn	!Xóõ		ɡʘkxʼ	ɡʘkxʼ	ɡʘkxʼ
+nmn	!Xóõ		ɡǀkxʼ	ɡǀkxʼ	ɡǀkxʼ
+nmn	!Xóõ		ɡǃkxʼ	ɡǃkxʼ	ɡǃkxʼ
+nmn	!Xóõ		ɡǁkxʼ	ɡǁkxʼ	ɡǁkxʼ
+nmn	!Xóõ		ɡǂkxʼ	ɡǂkxʼ	ɡǂkxʼ
+nmn	!Xóõ		qʘ	ʘq	qʘ
+nmn	!Xóõ		qǀ	ǀq	qǀ
+nmn	!Xóõ		qǃ	ǃq	qǃ
+nmn	!Xóõ		qǁ	ǁq	qǁ
+nmn	!Xóõ		qǂ	ǂq	qǂ
+nmn	!Xóõ		ɢʘ	ʘɢ	ɴʘɢ
+nmn	!Xóõ		ɢǀ	ǀɢ	ɴǀɢ
+nmn	!Xóõ		ɢǃ	ǃɢ	ɴǃɢ
+nmn	!Xóõ		ɢǁ	ǁɢ	ɴǁɢ
+nmn	!Xóõ		ɢǂ	ǂɢ	ɴǂɢ
+nmn	!Xóõ		kʘʰ	ʘqʰ	qʘʰ
+nmn	!Xóõ		kǀʰ	ǀqʰ	qǀʰ
+nmn	!Xóõ		kǃʰ	ǃqʰ	qǃʰ
+nmn	!Xóõ		kǁʰ	ǁqʰ	qǁʰ
+nmn	!Xóõ		kǂʰ	ǂqʰ	qǂʰ
+nmn	!Xóõ		ɡʘkʰ	ɡʘqʰ	ɡʘqʰ
+nmn	!Xóõ		ɡǀkʰ	ɡǀqʰ	ɡǀqʰ
+nmn	!Xóõ		ɡǃkʰ	ɡǃqʱ	ɡǃqʱ
+nmn	!Xóõ		ɡǁkʰ	ɡǁqʰ	ɡǁqʰ
+nmn	!Xóõ		ɡǂkʰ	ɡǂqʰ	ɡǂqʰ
+nmn	!Xóõ		ɢǀqʰ	ɴɢǀqʰ	ɴɢǀqʰ
+nmn	!Xóõ		ɢǃqʰ	ɴɢǃqʰ	ɴɢǃqʰ
+nmn	!Xóõ		ɢǁqʰ	ɴɢǁqʰ	ɴɢǁqʰ
+nmn	!Xóõ		qʘʼ	ʘqʼ	qʘʼ
+nmn	!Xóõ		qǀʼ	ǀqʼ	qǀʼ
+nmn	!Xóõ		qǃʼ	ǃqʼ	qǃʼ
+nmn	!Xóõ		qǁʼ	ǁqʼ	qǁʼ
+nmn	!Xóõ		qǂʼ	ǂqʼ	qǂʼ
+nmn	!Xóõ		kʘh	ʘʰ	kʘh
+nmn	!Xóõ		kǀh	ǀʰ	kǀh
+nmn	!Xóõ		kǃh	ǃʰ	kǃh
+nmn	!Xóõ		kǁh	ǁʰ	kǁh
+nmn	!Xóõ		kǂh	ǂʰ	kǂh
+nmn	!Xóõ		ŋ̊ʘ	ʘn̥	ŋ̊ʘ
+nmn	!Xóõ		ŋ̊ǀ	ǀn̥	ŋ̊ǀ
+nmn	!Xóõ		ŋ̊ǃ	ǃn̥	ŋ̊ǃ
+nmn	!Xóõ		ŋ̊ǁ	ǁn̥	ŋ̊ǁ
+nmn	!Xóõ		ŋ̊ǂ	ǂn̥	ŋ̊ǂ
+nmn	!Xóõ		ŋʘ	ʘn	ŋʘ
+nmn	!Xóõ		ŋǀ	ǀn	ŋǀ
+nmn	!Xóõ		ŋǃ	ǃn	ŋǃ
+nmn	!Xóõ		ŋǁ	ǁn	ŋǁ
+nmn	!Xóõ		ŋǂ	ǂn	ŋǂ
+nmn	!Xóõ		ʔŋʘ	ˀnʘ	ʔŋʘ
+nmn	!Xóõ		ʔŋǀ	ˀnǀ	ʔŋǀ
+nmn	!Xóõ		ʔŋǃ	ˀnǃ	ʔŋǃ
+nmn	!Xóõ		ʔŋǁ	ˀnǁ	ʔŋǁ
+nmn	!Xóõ		ʔŋǂ	ˀnǂ	ʔŋǂ
+nmn	!Xóõ		kʘʔ	ʘʼ	kʘʔ
+nmn	!Xóõ		kǀʔ	ǀʼ	kǀʔ
+nmn	!Xóõ		kǃʔ	ǃʼ	kǃʔ
+nmn	!Xóõ		kǁʔ	ǁʼ	kǁʔ
+nmn	!Xóõ		kǂʔ	ǂʼ	kǂʔ
+nmn	!Xóõ		p
+nmn	!Xóõ		t̪
+nmn	!Xóõ		t
+nmn	!Xóõ		k
+nmn	!Xóõ		q
+nmn	!Xóõ		ʔ
+nmn	!Xóõ		b
+nmn	!Xóõ		d̪
+nmn	!Xóõ		d
+nmn	!Xóõ		ɟ
+nmn	!Xóõ		ɡ
+nmn	!Xóõ		ɢ
+nmn	!Xóõ		pʰ
+nmn	!Xóõ		t̪ʰ
+nmn	!Xóõ		tʰ
+nmn	!Xóõ		kʰ
+nmn	!Xóõ		qʰ
+nmn	!Xóõ		d̪ʱ
+nmn	!Xóõ		dʱ
+nmn	!Xóõ		ɡʱ
+nmn	!Xóõ		ɢʱ
+nmn	!Xóõ		t̪x
+nmn	!Xóõ		tx
+nmn	!Xóõ		d̪x
+nmn	!Xóõ		dx
+nmn	!Xóõ		t̪ʼ
+nmn	!Xóõ		tʼ
+nmn	!Xóõ		kʼ
+nmn	!Xóõ		kxʼ
+nmn	!Xóõ		qʼ
+nmn	!Xóõ		pʼkxʼ
+nmn	!Xóõ		t̪ʼkxʼ
+nmn	!Xóõ		tʼkxʼ
+nmn	!Xóõ		d̪ʼkxʼ
+nmn	!Xóõ		dʼkxʼ
+nmn	!Xóõ		ɡʼkxʼ
+nmn	!Xóõ		f
+nmn	!Xóõ		ɸ
+nmn	!Xóõ		s
+nmn	!Xóõ		x
+nmn	!Xóõ		h
+nmn	!Xóõ		l
+nmn	!Xóõ		m
+nmn	!Xóõ		n̪
+nmn	!Xóõ		ɲ
+nmn	!Xóõ		ˀm
+nmn	!Xóõ		ˀn
+nmn	!Xóõ		i
+nmn	!Xóõ		e
+nmn	!Xóõ		a
+nmn	!Xóõ		o
+nmn	!Xóõ		u
+nmn	!Xóõ		ĩ
+nmn	!Xóõ		ẽ
+nmn	!Xóõ		ã
+nmn	!Xóõ		õ
+nmn	!Xóõ		ũ
+nmn	!Xóõ		iˤ
+nmn	!Xóõ		eˤ
+nmn	!Xóõ		aˤ
+nmn	!Xóõ		oˤ
+nmn	!Xóõ		uˤ
+nmn	!Xóõ		i̤
+nmn	!Xóõ		e̤
+nmn	!Xóõ		a̤
+nmn	!Xóõ		o̤
+nmn	!Xóõ		ṳ
+nmn	!Xóõ		ḭ
+nmn	!Xóõ		ḛ
+nmn	!Xóõ		a̰
+nmn	!Xóõ		o̰
+nmn	!Xóõ		ṵ
+nmn	!Xóõ		aᴱ
+nmn	!Xóõ		oᴱ
+nmn	!Xóõ		uᴱ
+nmn	!Xóõ		˦
+nmn	!Xóõ		˨
+nmn	!Xóõ		˧
+
 kib	Koalib		i				kib.pdf
-kib	Koalib		e				
-kib	Koalib		ɛ				
-kib	Koalib		ɐ				
-kib	Koalib		a				
-kib	Koalib		u				
-kib	Koalib		o				
-kib	Koalib		ɔ				
-kib	Koalib		iː				
-kib	Koalib		eː				
-kib	Koalib		ɛː				
-kib	Koalib		ɐː				
-kib	Koalib		aː				
-kib	Koalib		uː				
-kib	Koalib		oː				
-kib	Koalib		ɔː				
-kib	Koalib		b		[b]		
-kib	Koalib		b		[bː]		
-kib	Koalib		p		[p]		
-kib	Koalib		p		[pː]		
-kib	Koalib		f		[f]		
-kib	Koalib		f		[v]		
-kib	Koalib		mb				
-kib	Koalib		m		[m]		
-kib	Koalib		m		[mː]		
-kib	Koalib		d̪				
-kib	Koalib		t̪		[t̪]		
-kib	Koalib		t̪		[t̪ː]		
-kib	Koalib		t̪		[ð]		
-kib	Koalib		n̪d̪				
-kib	Koalib		n̪		[n̪]		
-kib	Koalib		n̪		[n̪ː]		
-kib	Koalib		l̪		[l̪]		
-kib	Koalib		l̪		[l̪ː]		
-kib	Koalib		r̪		[r̪		
-kib	Koalib		r̪		[r̪ː]		
-kib	Koalib		ɗ		[ɗ]		
-kib	Koalib		ɗ		[ɗː]		
-kib	Koalib		ʈ		[ʈ]		
-kib	Koalib		ʈ		[ʈː]		
-kib	Koalib		ɳɖ				
-kib	Koalib		ɽ				
-kib	Koalib		ɟ		[ɟ]		
-kib	Koalib		ɟ		[c]		
-kib	Koalib		ɟ		[ɟː]		
-kib	Koalib		c		[c]		
-kib	Koalib		c		[cː]		
-kib	Koalib		ʃ		[ʃ]		
-kib	Koalib		ʃ		[ʒ]		
-kib	Koalib		ɲɟ				
-kib	Koalib		ɲ		[ɲ]		
-kib	Koalib		ɲ		[ɲː]		
-kib	Koalib		j		[j]		
-kib	Koalib		j		[jː]		
-kib	Koalib		k		[k]		
-kib	Koalib		k		[ɡ]		
-kib	Koalib		k		[kː]		
-kib	Koalib		ɡ				
-kib	Koalib		ŋɡ				
-kib	Koalib		ŋ				
-kib	Koalib		kʷ		[kʷ]		
-kib	Koalib		kʷ		[kʷː]		
-kib	Koalib		kʷ		[ɡʷ]		
-kib	Koalib		ŋɡʷ				
-kib	Koalib		ŋʷ				
-kib	Koalib		w		[w]		
-kib	Koalib		w		[wː]		
-							
+kib	Koalib		e
+kib	Koalib		ɛ
+kib	Koalib		ɐ
+kib	Koalib		a
+kib	Koalib		u
+kib	Koalib		o
+kib	Koalib		ɔ
+kib	Koalib		iː
+kib	Koalib		eː
+kib	Koalib		ɛː
+kib	Koalib		ɐː
+kib	Koalib		aː
+kib	Koalib		uː
+kib	Koalib		oː
+kib	Koalib		ɔː
+kib	Koalib		b		[b]
+kib	Koalib		b		[bː]
+kib	Koalib		p		[p]
+kib	Koalib		p		[pː]
+kib	Koalib		f		[f]
+kib	Koalib		f		[v]
+kib	Koalib		mb
+kib	Koalib		m		[m]
+kib	Koalib		m		[mː]
+kib	Koalib		d̪
+kib	Koalib		t̪		[t̪]
+kib	Koalib		t̪		[t̪ː]
+kib	Koalib		t̪		[ð]
+kib	Koalib		n̪d̪
+kib	Koalib		n̪		[n̪]
+kib	Koalib		n̪		[n̪ː]
+kib	Koalib		l̪		[l̪]
+kib	Koalib		l̪		[l̪ː]
+kib	Koalib		r̪		[r̪
+kib	Koalib		r̪		[r̪ː]
+kib	Koalib		ɗ		[ɗ]
+kib	Koalib		ɗ		[ɗː]
+kib	Koalib		ʈ		[ʈ]
+kib	Koalib		ʈ		[ʈː]
+kib	Koalib		ɳɖ
+kib	Koalib		ɽ
+kib	Koalib		ɟ		[ɟ]
+kib	Koalib		ɟ		[c]
+kib	Koalib		ɟ		[ɟː]
+kib	Koalib		c		[c]
+kib	Koalib		c		[cː]
+kib	Koalib		ʃ		[ʃ]
+kib	Koalib		ʃ		[ʒ]
+kib	Koalib		ɲɟ
+kib	Koalib		ɲ		[ɲ]
+kib	Koalib		ɲ		[ɲː]
+kib	Koalib		j		[j]
+kib	Koalib		j		[jː]
+kib	Koalib		k		[k]
+kib	Koalib		k		[ɡ]
+kib	Koalib		k		[kː]
+kib	Koalib		ɡ
+kib	Koalib		ŋɡ
+kib	Koalib		ŋ
+kib	Koalib		kʷ		[kʷ]
+kib	Koalib		kʷ		[kʷː]
+kib	Koalib		kʷ		[ɡʷ]
+kib	Koalib		ŋɡʷ
+kib	Koalib		ŋʷ
+kib	Koalib		w		[w]
+kib	Koalib		w		[wː]
+
 kki	Kagulu		i		[i]		kki.pdf
-kki	Kagulu		i		[ĩ]		
-kki	Kagulu		e		[e]		
-kki	Kagulu		e		[ẽ]		
-kki	Kagulu		a		[a]		
-kki	Kagulu		a		[ã]		
-kki	Kagulu		o		[o]		
-kki	Kagulu		o		[õ]		
-kki	Kagulu		u		[u]		
-kki	Kagulu		u		[ũ]		
-kki	Kagulu		p				
-kki	Kagulu		b				
-kki	Kagulu		m̥				
-kki	Kagulu		m				
-kki	Kagulu		w				
-kki	Kagulu		f				
-kki	Kagulu		t				
-kki	Kagulu		d				
-kki	Kagulu		n̥				
-kki	Kagulu		n				
-kki	Kagulu		s				
-kki	Kagulu		l				
-kki	Kagulu		ɲ				
-kki	Kagulu		ʃ				
-kki	Kagulu		t̠ʃ				
-kki	Kagulu		d̠ʒ				
-kki	Kagulu		j				
-kki	Kagulu		k				
-kki	Kagulu		ɡ				
-kki	Kagulu		ŋ̥				
-kki	Kagulu		ŋ				
-kki	Kagulu		h				
-kki	Kagulu		mb				
-kki	Kagulu		nd				
-kki	Kagulu		n̠d̠ʒ				
-kki	Kagulu		ŋɡ				
-							
+kki	Kagulu		i		[ĩ]
+kki	Kagulu		e		[e]
+kki	Kagulu		e		[ẽ]
+kki	Kagulu		a		[a]
+kki	Kagulu		a		[ã]
+kki	Kagulu		o		[o]
+kki	Kagulu		o		[õ]
+kki	Kagulu		u		[u]
+kki	Kagulu		u		[ũ]
+kki	Kagulu		p
+kki	Kagulu		b
+kki	Kagulu		m̥
+kki	Kagulu		m
+kki	Kagulu		w
+kki	Kagulu		f
+kki	Kagulu		t
+kki	Kagulu		d
+kki	Kagulu		n̥
+kki	Kagulu		n
+kki	Kagulu		s
+kki	Kagulu		l
+kki	Kagulu		ɲ
+kki	Kagulu		ʃ
+kki	Kagulu		t̠ʃ
+kki	Kagulu		d̠ʒ
+kki	Kagulu		j
+kki	Kagulu		k
+kki	Kagulu		ɡ
+kki	Kagulu		ŋ̥
+kki	Kagulu		ŋ
+kki	Kagulu		h
+kki	Kagulu		mb
+kki	Kagulu		nd
+kki	Kagulu		n̠d̠ʒ
+kki	Kagulu		ŋɡ
+
 oks	Oko		m				oks.pdf
-oks	Oko		p				
-oks	Oko		t				
-oks	Oko		kp				
-oks	Oko		b				
-oks	Oko		n				
-oks	Oko		d				
-oks	Oko		ɡb				
-oks	Oko		f				
-oks	Oko		v				
-oks	Oko		s				
-oks	Oko		t̠ʃ				
-oks	Oko		d̠ʒ				
-oks	Oko		r				
-oks	Oko		l				
-oks	Oko		j		[j]		
-oks	Oko		j		[ɲ]		
-oks	Oko		w		[w]		
-oks	Oko		w		[ŋʷ]		
-oks	Oko		h				
-oks	Oko		i		[i]		
-oks	Oko		i		[ĩ]		
-oks	Oko		i		[j]		
-oks	Oko		u		[u]		
-oks	Oko		u		[ũ]		
-oks	Oko		u		[w]		
-oks	Oko		e		[e]		
-oks	Oko		e		[ẽ]		
-oks	Oko		ɛ		[ɛ]		
-oks	Oko		ɛ		[ɛ̃]		
-oks	Oko		ɔ		[ɔ]		
-oks	Oko		ɔ		[ɔ̃]		
-oks	Oko		o		[o]		
-oks	Oko		o		[õ]		
-oks	Oko		a		[a]		
-oks	Oko		a		[ã]		
-oks	Oko		˦				
-oks	Oko		˨				
-oks	Oko		˧				
-oks	Oko		˧˨				
-oks	Oko		˨˦				
-							
+oks	Oko		p
+oks	Oko		t
+oks	Oko		kp
+oks	Oko		b
+oks	Oko		n
+oks	Oko		d
+oks	Oko		ɡb
+oks	Oko		f
+oks	Oko		v
+oks	Oko		s
+oks	Oko		t̠ʃ
+oks	Oko		d̠ʒ
+oks	Oko		r
+oks	Oko		l
+oks	Oko		j		[j]
+oks	Oko		j		[ɲ]
+oks	Oko		w		[w]
+oks	Oko		w		[ŋʷ]
+oks	Oko		h
+oks	Oko		i		[i]
+oks	Oko		i		[ĩ]
+oks	Oko		i		[j]
+oks	Oko		u		[u]
+oks	Oko		u		[ũ]
+oks	Oko		u		[w]
+oks	Oko		e		[e]
+oks	Oko		e		[ẽ]
+oks	Oko		ɛ		[ɛ]
+oks	Oko		ɛ		[ɛ̃]
+oks	Oko		ɔ		[ɔ]
+oks	Oko		ɔ		[ɔ̃]
+oks	Oko		o		[o]
+oks	Oko		o		[õ]
+oks	Oko		a		[a]
+oks	Oko		a		[ã]
+oks	Oko		˦
+oks	Oko		˨
+oks	Oko		˧
+oks	Oko		˧˨
+oks	Oko		˨˦
+
 xuu	!Xun	W2	e				xuu.pdf
-xuu	!Xun	W2	a				
-xuu	!Xun	W2	o				
-xuu	!Xun	W2	u				
-xuu	!Xun	W2	ḭ				
-xuu	!Xun	W2	i				
-xuu	!Xun	W2	a̰				
-xuu	!Xun	W2	ḛ				
-xuu	!Xun	W2	o̰				
-xuu	!Xun	W2	ṵ				
-xuu	!Xun	W2	aˤ				
-xuu	!Xun	W2	oˤ				
-xuu	!Xun	W2	uˤ				
-xuu	!Xun	W2	ĩ				
-xuu	!Xun	W2	ã				
-xuu	!Xun	W2	ũ				
-xuu	!Xun	W2	ã̰				
-xuu	!Xun	W2	õ̰				
-xuu	!Xun	W2	ãˤ				
-xuu	!Xun	W2	õˤ				
-xuu	!Xun	W2	ũˤ				
-xuu	!Xun	W2	w				
-xuu	!Xun	W2	l				
-xuu	!Xun	W2	j				
-xuu	!Xun	W2	ç				
-xuu	!Xun	W2	x				
-xuu	!Xun	W2	ɦ				
-xuu	!Xun	W2	p				
-xuu	!Xun	W2	b				
-xuu	!Xun	W2	t				
-xuu	!Xun	W2	d				
-xuu	!Xun	W2	t̠ʃ				
-xuu	!Xun	W2	d̠ʒː	ddj in text			
-xuu	!Xun	W2	d̠ʒ				
-xuu	!Xun	W2	kǁ	kǁ			
-xuu	!Xun	W2	ɡǁ	ɡǁ			
-xuu	!Xun	W2	kǀ	kǀ			
-xuu	!Xun	W2	ɡǀ	ɡǀ			
-xuu	!Xun	W2	kǃ	kǃ			
-xuu	!Xun	W2	ɡǃ	ɡǃ			
-xuu	!Xun	W2	k‼	k‼			
-xuu	!Xun	W2	ɡ‼	ɡ‼			
-xuu	!Xun	W2	k				
-xuu	!Xun	W2	ɡ				
-xuu	!Xun	W2	ʔ				
-xuu	!Xun	W2	dʼ				
-xuu	!Xun	W2	ɡʼ				
-xuu	!Xun	W2	pʰ				
-xuu	!Xun	W2	bʱ				
-xuu	!Xun	W2	tʰʼ				
-xuu	!Xun	W2	tʰ				
-xuu	!Xun	W2	dʱ				
-xuu	!Xun	W2	t̠ʃʼ				
-xuu	!Xun	W2	d̠ʒʼ				
-xuu	!Xun	W2	t̠ʃʰ				
-xuu	!Xun	W2	d̠ʒʰ				
-xuu	!Xun	W2	kǁʼ				
-xuu	!Xun	W2	kǁʼʰ				
-xuu	!Xun	W2	kǀʼ				
-xuu	!Xun	W2	kǀʰʼ				
-xuu	!Xun	W2	kǃʼ				
-xuu	!Xun	W2	kǃʰʼ				
-xuu	!Xun	W2	k‼ʼ				
-xuu	!Xun	W2	k‼ʰʼ				
-xuu	!Xun	W2	kxʼ				
-xuu	!Xun	W2	kʰ				
-xuu	!Xun	W2	ɡʱ				
-xuu	!Xun	W2	tx				
-xuu	!Xun	W2	dx				
-xuu	!Xun	W2	t̠ʃx				
-xuu	!Xun	W2	d̠ʒxʼ				
-xuu	!Xun	W2	kǁx				
-xuu	!Xun	W2	ɡǁx				
-xuu	!Xun	W2	kǀx				
-xuu	!Xun	W2	ɡǀx				
-xuu	!Xun	W2	kǃx				
-xuu	!Xun	W2	ɡǃx				
-xuu	!Xun	W2	k‼x				
-xuu	!Xun	W2	ɡ‼x				
-xuu	!Xun	W2	kǁxʼ				
-xuu	!Xun	W2	kǀxʼ				
-xuu	!Xun	W2	kǃxʼ				
-xuu	!Xun	W2	k‼xʼ				
-xuu	!Xun	W2	ɡǁxʼ				
-xuu	!Xun	W2	ɡǀxʼ				
-xuu	!Xun	W2	ɡǃxʼ				
-xuu	!Xun	W2	ɡ‼xʼ				
-xuu	!Xun	W2	kǁʰ				
-xuu	!Xun	W2	kǀʰ				
-xuu	!Xun	W2	kǃʰ				
-xuu	!Xun	W2	k‼ʰ				
-xuu	!Xun	W2	ɡǀʱ				
-xuu	!Xun	W2	ɡǃʱ				
-xuu	!Xun	W2	ɡ‼ʱ				
-xuu	!Xun	W2	m				
-xuu	!Xun	W2	n				
-xuu	!Xun	W2	ɲ				
-xuu	!Xun	W2	ŋǁ				
-xuu	!Xun	W2	ŋǀ				
-xuu	!Xun	W2	ŋǃ				
-xuu	!Xun	W2	ŋ‼				
-xuu	!Xun	W2	ŋ				
-xuu	!Xun	W2	mb				
-xuu	!Xun	W2	nd				
-xuu	!Xun	W2	ŋɡ				
-xuu	!Xun	W2	mʱ				
-xuu	!Xun	W2	nʱ				
-xuu	!Xun	W2	ŋǀʱ				
-xuu	!Xun	W2	ŋǃʱ				
-xuu	!Xun	W2	ŋ‼ʱ				
-xuu	!Xun	W2	ʼm				
-xuu	!Xun	W2	ʼn				
-xuu	!Xun	W2	ʼŋǀ				
-xuu	!Xun	W2	ʼŋǃ				
-xuu	!Xun	W2	qm				
-xuu	!Xun	W2	qn				
-xuu	!Xun	W2	˩				
-xuu	!Xun	W2	˦				
-xuu	!Xun	W2	˨				
-xuu	!Xun	W2	˧				
-							
+xuu	!Xun	W2	a
+xuu	!Xun	W2	o
+xuu	!Xun	W2	u
+xuu	!Xun	W2	ḭ
+xuu	!Xun	W2	i
+xuu	!Xun	W2	a̰
+xuu	!Xun	W2	ḛ
+xuu	!Xun	W2	o̰
+xuu	!Xun	W2	ṵ
+xuu	!Xun	W2	aˤ
+xuu	!Xun	W2	oˤ
+xuu	!Xun	W2	uˤ
+xuu	!Xun	W2	ĩ
+xuu	!Xun	W2	ã
+xuu	!Xun	W2	ũ
+xuu	!Xun	W2	ã̰
+xuu	!Xun	W2	õ̰
+xuu	!Xun	W2	ãˤ
+xuu	!Xun	W2	õˤ
+xuu	!Xun	W2	ũˤ
+xuu	!Xun	W2	w
+xuu	!Xun	W2	l
+xuu	!Xun	W2	j
+xuu	!Xun	W2	ç
+xuu	!Xun	W2	x
+xuu	!Xun	W2	ɦ
+xuu	!Xun	W2	p
+xuu	!Xun	W2	b
+xuu	!Xun	W2	t
+xuu	!Xun	W2	d
+xuu	!Xun	W2	t̠ʃ
+xuu	!Xun	W2	d̠ʒː	ddj in text
+xuu	!Xun	W2	d̠ʒ
+xuu	!Xun	W2	kǁ	kǁ
+xuu	!Xun	W2	ɡǁ	ɡǁ
+xuu	!Xun	W2	kǀ	kǀ
+xuu	!Xun	W2	ɡǀ	ɡǀ
+xuu	!Xun	W2	kǃ	kǃ
+xuu	!Xun	W2	ɡǃ	ɡǃ
+xuu	!Xun	W2	k‼	k‼
+xuu	!Xun	W2	ɡ‼	ɡ‼
+xuu	!Xun	W2	k
+xuu	!Xun	W2	ɡ
+xuu	!Xun	W2	ʔ
+xuu	!Xun	W2	dʼ
+xuu	!Xun	W2	ɡʼ
+xuu	!Xun	W2	pʰ
+xuu	!Xun	W2	bʱ
+xuu	!Xun	W2	tʰʼ
+xuu	!Xun	W2	tʰ
+xuu	!Xun	W2	dʱ
+xuu	!Xun	W2	t̠ʃʼ
+xuu	!Xun	W2	d̠ʒʼ
+xuu	!Xun	W2	t̠ʃʰ
+xuu	!Xun	W2	d̠ʒʰ
+xuu	!Xun	W2	kǁʼ
+xuu	!Xun	W2	kǁʼʰ
+xuu	!Xun	W2	kǀʼ
+xuu	!Xun	W2	kǀʰʼ
+xuu	!Xun	W2	kǃʼ
+xuu	!Xun	W2	kǃʰʼ
+xuu	!Xun	W2	k‼ʼ
+xuu	!Xun	W2	k‼ʰʼ
+xuu	!Xun	W2	kxʼ
+xuu	!Xun	W2	kʰ
+xuu	!Xun	W2	ɡʱ
+xuu	!Xun	W2	tx
+xuu	!Xun	W2	dx
+xuu	!Xun	W2	t̠ʃx
+xuu	!Xun	W2	d̠ʒxʼ
+xuu	!Xun	W2	kǁx
+xuu	!Xun	W2	ɡǁx
+xuu	!Xun	W2	kǀx
+xuu	!Xun	W2	ɡǀx
+xuu	!Xun	W2	kǃx
+xuu	!Xun	W2	ɡǃx
+xuu	!Xun	W2	k‼x
+xuu	!Xun	W2	ɡ‼x
+xuu	!Xun	W2	kǁxʼ
+xuu	!Xun	W2	kǀxʼ
+xuu	!Xun	W2	kǃxʼ
+xuu	!Xun	W2	k‼xʼ
+xuu	!Xun	W2	ɡǁxʼ
+xuu	!Xun	W2	ɡǀxʼ
+xuu	!Xun	W2	ɡǃxʼ
+xuu	!Xun	W2	ɡ‼xʼ
+xuu	!Xun	W2	kǁʰ
+xuu	!Xun	W2	kǀʰ
+xuu	!Xun	W2	kǃʰ
+xuu	!Xun	W2	k‼ʰ
+xuu	!Xun	W2	ɡǀʱ
+xuu	!Xun	W2	ɡǃʱ
+xuu	!Xun	W2	ɡ‼ʱ
+xuu	!Xun	W2	m
+xuu	!Xun	W2	n
+xuu	!Xun	W2	ɲ
+xuu	!Xun	W2	ŋǁ
+xuu	!Xun	W2	ŋǀ
+xuu	!Xun	W2	ŋǃ
+xuu	!Xun	W2	ŋ‼
+xuu	!Xun	W2	ŋ
+xuu	!Xun	W2	mb
+xuu	!Xun	W2	nd
+xuu	!Xun	W2	ŋɡ
+xuu	!Xun	W2	mʱ
+xuu	!Xun	W2	nʱ
+xuu	!Xun	W2	ŋǀʱ
+xuu	!Xun	W2	ŋǃʱ
+xuu	!Xun	W2	ŋ‼ʱ
+xuu	!Xun	W2	ʼm
+xuu	!Xun	W2	ʼn
+xuu	!Xun	W2	ʼŋǀ
+xuu	!Xun	W2	ʼŋǃ
+xuu	!Xun	W2	qm
+xuu	!Xun	W2	qn
+xuu	!Xun	W2	˩
+xuu	!Xun	W2	˦
+xuu	!Xun	W2	˨
+xuu	!Xun	W2	˧
+
 bbj	Banjun		p				bbj.pdf
-bbj	Banjun		b		[b]		
-bbj	Banjun		b		[mb]		
-bbj	Banjun		f				
-bbj	Banjun		pf		[pf]		
-bbj	Banjun		pf		[bf]		
-bbj	Banjun		m				
-bbj	Banjun		pɸ				
-bbj	Banjun		bβ				
-bbj	Banjun		t̪θ	tθ			
-bbj	Banjun		d̪ð	dð			
-bbj	Banjun		bv				
-bbj	Banjun		v				
-bbj	Banjun		ts				
-bbj	Banjun		dz				
-bbj	Banjun		t̠ʃ				
-bbj	Banjun		d̠ʒ				
-bbj	Banjun		t		[t]		
-bbj	Banjun		t		[tʲ]		
-bbj	Banjun		d		[d]		
-bbj	Banjun		d		[nd]		
-bbj	Banjun		n				
-bbj	Banjun		d		[d]		
-bbj	Banjun		d		[dʲ]		
-bbj	Banjun		ɕ				
-bbj	Banjun		h		[h]		
-bbj	Banjun		h		[ɸ]		
-bbj	Banjun		h		[x]		
-bbj	Banjun		x				
-bbj	Banjun		ʃ				
-bbj	Banjun		ɲ				
-bbj	Banjun		s				
-bbj	Banjun		z				
-bbj	Banjun		ʒ				
-bbj	Banjun		ɣ				
-bbj	Banjun		j				
-bbj	Banjun		k		[k]		
-bbj	Banjun		k		[kx]		
-bbj	Banjun		k		[q]		
-bbj	Banjun		k		[qχ]		
-bbj	Banjun		χ				
-bbj	Banjun		ɡ		[ɡ]		
-bbj	Banjun		ɡ		[ŋɡ]		
-bbj	Banjun		ʔ				
-bbj	Banjun		ŋ				
-bbj	Banjun		l				
-bbj	Banjun		i		[i]		
-bbj	Banjun		i		[j]		
-bbj	Banjun		e		[e]		
-bbj	Banjun		e		[ẽ]		
-bbj	Banjun		e		[ɪ]		
-bbj	Banjun		u		[u]		
-bbj	Banjun		u		[w]		
-bbj	Banjun		u		[ũ]		
-bbj	Banjun		w				
-bbj	Banjun		ʉ		[ʉ]		
-bbj	Banjun		ʉ		[ʉ̃]		
-bbj	Banjun		ɥ				
-bbj	Banjun		o		[o]		
-bbj	Banjun		o		[ɔ̃]		
-bbj	Banjun		o		[ʊ]		
-bbj	Banjun		o		[õ]		
-bbj	Banjun		ɛ		[ɛ]		
-bbj	Banjun		ɛ		[ɛ̃]		
-bbj	Banjun		ə		[ə]		
-bbj	Banjun		ə		[ə̃]		
-bbj	Banjun		ɐ		[ɐ]		
-bbj	Banjun		ɐ		[ɐ̃]		
-bbj	Banjun		ɔ		[ɔ]		
-bbj	Banjun		ɔ		[ɔ̃]		
-bbj	Banjun		a		[a]		
-bbj	Banjun		a		[ã]		
-bbj	Banjun		ʉː				
-bbj	Banjun		ɛː				
-bbj	Banjun		aː				
-bbj	Banjun		oː				
-bbj	Banjun		ɔː				
-bbj	Banjun		iː				
-bbj	Banjun		uː				
-bbj	Banjun		ɐː				
-bbj	Banjun		˦				
-bbj	Banjun		˨				
-bbj	Banjun		˧				
-bbj	Banjun		˦˨				
-bbj	Banjun		˨˦				
-							
+bbj	Banjun		b		[b]
+bbj	Banjun		b		[mb]
+bbj	Banjun		f
+bbj	Banjun		pf		[pf]
+bbj	Banjun		pf		[bf]
+bbj	Banjun		m
+bbj	Banjun		pɸ
+bbj	Banjun		bβ
+bbj	Banjun		t̪θ	tθ
+bbj	Banjun		d̪ð	dð
+bbj	Banjun		bv
+bbj	Banjun		v
+bbj	Banjun		ts
+bbj	Banjun		dz
+bbj	Banjun		t̠ʃ
+bbj	Banjun		d̠ʒ
+bbj	Banjun		t		[t]
+bbj	Banjun		t		[tʲ]
+bbj	Banjun		d		[d]
+bbj	Banjun		d		[nd]
+bbj	Banjun		n
+bbj	Banjun		d		[d]
+bbj	Banjun		d		[dʲ]
+bbj	Banjun		ɕ
+bbj	Banjun		h		[h]
+bbj	Banjun		h		[ɸ]
+bbj	Banjun		h		[x]
+bbj	Banjun		x
+bbj	Banjun		ʃ
+bbj	Banjun		ɲ
+bbj	Banjun		s
+bbj	Banjun		z
+bbj	Banjun		ʒ
+bbj	Banjun		ɣ
+bbj	Banjun		j
+bbj	Banjun		k		[k]
+bbj	Banjun		k		[kx]
+bbj	Banjun		k		[q]
+bbj	Banjun		k		[qχ]
+bbj	Banjun		χ
+bbj	Banjun		ɡ		[ɡ]
+bbj	Banjun		ɡ		[ŋɡ]
+bbj	Banjun		ʔ
+bbj	Banjun		ŋ
+bbj	Banjun		l
+bbj	Banjun		i		[i]
+bbj	Banjun		i		[j]
+bbj	Banjun		e		[e]
+bbj	Banjun		e		[ẽ]
+bbj	Banjun		e		[ɪ]
+bbj	Banjun		u		[u]
+bbj	Banjun		u		[w]
+bbj	Banjun		u		[ũ]
+bbj	Banjun		w
+bbj	Banjun		ʉ		[ʉ]
+bbj	Banjun		ʉ		[ʉ̃]
+bbj	Banjun		ɥ
+bbj	Banjun		o		[o]
+bbj	Banjun		o		[ɔ̃]
+bbj	Banjun		o		[ʊ]
+bbj	Banjun		o		[õ]
+bbj	Banjun		ɛ		[ɛ]
+bbj	Banjun		ɛ		[ɛ̃]
+bbj	Banjun		ə		[ə]
+bbj	Banjun		ə		[ə̃]
+bbj	Banjun		ɐ		[ɐ]
+bbj	Banjun		ɐ		[ɐ̃]
+bbj	Banjun		ɔ		[ɔ]
+bbj	Banjun		ɔ		[ɔ̃]
+bbj	Banjun		a		[a]
+bbj	Banjun		a		[ã]
+bbj	Banjun		ʉː
+bbj	Banjun		ɛː
+bbj	Banjun		aː
+bbj	Banjun		oː
+bbj	Banjun		ɔː
+bbj	Banjun		iː
+bbj	Banjun		uː
+bbj	Banjun		ɐː
+bbj	Banjun		˦
+bbj	Banjun		˨
+bbj	Banjun		˧
+bbj	Banjun		˦˨
+bbj	Banjun		˨˦
+
 afn	Defaka		i		[i]		afn.pdf
-afn	Defaka		i		[ĩ]		
-afn	Defaka		e		[e]		
-afn	Defaka		e		[ẽ]		
-afn	Defaka		ɛ		[ɛ]		
-afn	Defaka		ɛ		[ɛ̃]		
-afn	Defaka		a		[a]		
-afn	Defaka		a		[ã]		
-afn	Defaka		ɔ		[ɔ]		
-afn	Defaka		ɔ		[ɔ̃]		
-afn	Defaka		o		[o]		
-afn	Defaka		o		[õ]		
-afn	Defaka		u		[u]		
-afn	Defaka		u		[ũ]		
-afn	Defaka		ĩ				
-afn	Defaka		ẽ				
-afn	Defaka		ã				
-afn	Defaka		õ				
-afn	Defaka		ũ				
-afn	Defaka		iː				
-afn	Defaka		eː				
-afn	Defaka		ɛː				
-afn	Defaka		aː				
-afn	Defaka		ɔː				
-afn	Defaka		oː				
-afn	Defaka		uː				
-afn	Defaka		p				
-afn	Defaka		b				
-afn	Defaka		ɓ				
-afn	Defaka		m				
-afn	Defaka		w				
-afn	Defaka		f				
-afn	Defaka		v				
-afn	Defaka		t				
-afn	Defaka		d				
-afn	Defaka		ɾ		[ɾ]	variation	
-afn	Defaka		ɾ		[ɹ]	variation	
-afn	Defaka		s		[s]		
-afn	Defaka		s		[z]		
-afn	Defaka		l		[l]		
-afn	Defaka		l		[n]		
-afn	Defaka		d̠ʒ				
-afn	Defaka		j				
-afn	Defaka		k				
-afn	Defaka		ɡ		[ɡ]		
-afn	Defaka		ɡ		[ŋɡ]		
-afn	Defaka		kp				
-afn	Defaka		ɡb		[ɡb]		
-afn	Defaka		ɡb		[ŋmɡb]		
-afn	Defaka		˦				
-afn	Defaka		˨				
-afn	Defaka		˦˨				
-afn	Defaka		˨˦				
-afn	Defaka		↓˦				
-							
+afn	Defaka		i		[ĩ]
+afn	Defaka		e		[e]
+afn	Defaka		e		[ẽ]
+afn	Defaka		ɛ		[ɛ]
+afn	Defaka		ɛ		[ɛ̃]
+afn	Defaka		a		[a]
+afn	Defaka		a		[ã]
+afn	Defaka		ɔ		[ɔ]
+afn	Defaka		ɔ		[ɔ̃]
+afn	Defaka		o		[o]
+afn	Defaka		o		[õ]
+afn	Defaka		u		[u]
+afn	Defaka		u		[ũ]
+afn	Defaka		ĩ
+afn	Defaka		ẽ
+afn	Defaka		ã
+afn	Defaka		õ
+afn	Defaka		ũ
+afn	Defaka		iː
+afn	Defaka		eː
+afn	Defaka		ɛː
+afn	Defaka		aː
+afn	Defaka		ɔː
+afn	Defaka		oː
+afn	Defaka		uː
+afn	Defaka		p
+afn	Defaka		b
+afn	Defaka		ɓ
+afn	Defaka		m
+afn	Defaka		w
+afn	Defaka		f
+afn	Defaka		v
+afn	Defaka		t
+afn	Defaka		d
+afn	Defaka		ɾ		[ɾ]	variation
+afn	Defaka		ɾ		[ɹ]	variation
+afn	Defaka		s		[s]
+afn	Defaka		s		[z]
+afn	Defaka		l		[l]
+afn	Defaka		l		[n]
+afn	Defaka		d̠ʒ
+afn	Defaka		j
+afn	Defaka		k
+afn	Defaka		ɡ		[ɡ]
+afn	Defaka		ɡ		[ŋɡ]
+afn	Defaka		kp
+afn	Defaka		ɡb		[ɡb]
+afn	Defaka		ɡb		[ŋmɡb]
+afn	Defaka		˦
+afn	Defaka		˨
+afn	Defaka		˦˨
+afn	Defaka		˨˦
+afn	Defaka		↓˦
+
 tkq	Tee		p				tkq.pdf
-tkq	Tee		b				
-tkq	Tee		w				
-tkq	Tee		ʍ				
-tkq	Tee		t				
-tkq	Tee		d				
-tkq	Tee		n̥				
-tkq	Tee		n				
-tkq	Tee		s				
-tkq	Tee		z				
-tkq	Tee		l̥				
-tkq	Tee		l				
-tkq	Tee		ɹ				
-tkq	Tee		ɲ				
-tkq	Tee		j̥				
-tkq	Tee		j				
-tkq	Tee		k				
-tkq	Tee		ɡ				
-tkq	Tee		kʷ				
-tkq	Tee		ɡʷ				
-tkq	Tee		ŋʷ				
-tkq	Tee		kp				
-tkq	Tee		ɡb				
-tkq	Tee		i				
-tkq	Tee		e				
-tkq	Tee		ɛ				
-tkq	Tee		a				
-tkq	Tee		ɔ				
-tkq	Tee		o				
-tkq	Tee		u				
-tkq	Tee		i				
-tkq	Tee		ĩ				
-tkq	Tee		ẽ				
-tkq	Tee		ã				
-tkq	Tee		õ				
-tkq	Tee		ũ				
-tkq	Tee		˦				
-tkq	Tee		˨				
-tkq	Tee		˧				
-							
+tkq	Tee		b
+tkq	Tee		w
+tkq	Tee		ʍ
+tkq	Tee		t
+tkq	Tee		d
+tkq	Tee		n̥
+tkq	Tee		n
+tkq	Tee		s
+tkq	Tee		z
+tkq	Tee		l̥
+tkq	Tee		l
+tkq	Tee		ɹ
+tkq	Tee		ɲ
+tkq	Tee		j̥
+tkq	Tee		j
+tkq	Tee		k
+tkq	Tee		ɡ
+tkq	Tee		kʷ
+tkq	Tee		ɡʷ
+tkq	Tee		ŋʷ
+tkq	Tee		kp
+tkq	Tee		ɡb
+tkq	Tee		i
+tkq	Tee		e
+tkq	Tee		ɛ
+tkq	Tee		a
+tkq	Tee		ɔ
+tkq	Tee		o
+tkq	Tee		u
+tkq	Tee		i
+tkq	Tee		ĩ
+tkq	Tee		ẽ
+tkq	Tee		ã
+tkq	Tee		õ
+tkq	Tee		ũ
+tkq	Tee		˦
+tkq	Tee		˨
+tkq	Tee		˧
+
 sgc	Kipsigis		ɪ				sgc.pdf
-sgc	Kipsigis		ɪː				
-sgc	Kipsigis		ɛ				
-sgc	Kipsigis		ɛː				
-sgc	Kipsigis		i				
-sgc	Kipsigis		ɪː				
-sgc	Kipsigis		e				
-sgc	Kipsigis		eː				
-sgc	Kipsigis		a				
-sgc	Kipsigis		aː				
-sgc	Kipsigis		ʊ				
-sgc	Kipsigis		ʊː				
-sgc	Kipsigis		ɔ				
-sgc	Kipsigis		ɔː				
-sgc	Kipsigis		u				
-sgc	Kipsigis		uː				
-sgc	Kipsigis		o				
-sgc	Kipsigis		oː				
-sgc	Kipsigis		ɑ				
-sgc	Kipsigis		ɑː				
-sgc	Kipsigis		p		[p]	an intervocalic /p/ is voiced and its realisation is between the sound of [b] and [v]	
-sgc	Kipsigis		p		[β]	an intervocalic /p/ is voiced and its realisation is between the sound of [b] and [v]	
-sgc	Kipsigis		tʰ		[tʰ]		
-sgc	Kipsigis		tʰ		[tː]		
-sgc	Kipsigis		kʰ		[kʰ]		
-sgc	Kipsigis		kʰ		[ɣ]		
-sgc	Kipsigis		s		[s]		
-sgc	Kipsigis		s		[sː]		
-sgc	Kipsigis		ç				
-sgc	Kipsigis		w		[w]		
-sgc	Kipsigis		w		[wː]		
-sgc	Kipsigis		t̠ʃ		[t̠ʃ]		
-sgc	Kipsigis		t̠ʃ		[t̠ʃː]		
-sgc	Kipsigis		m		[m]		
-sgc	Kipsigis		m		[mː]		
-sgc	Kipsigis		n		[n]		
-sgc	Kipsigis		n		[nː]		
-sgc	Kipsigis		ɲ		[ɲ]		
-sgc	Kipsigis		ɲ		[ɲː]		
-sgc	Kipsigis		ɲ		[ŋ]		
-sgc	Kipsigis		ŋ		[ŋ]		
-sgc	Kipsigis		ŋ		[ŋː]		
-sgc	Kipsigis		l		[l]		
-sgc	Kipsigis		l		[lː]		
-sgc	Kipsigis		r				
-sgc	Kipsigis		h				
-sgc	Kipsigis		˦				
-sgc	Kipsigis		˨				
-sgc	Kipsigis		˦˨				
-sgc	Kipsigis		˨˦				
-							
+sgc	Kipsigis		ɪː
+sgc	Kipsigis		ɛ
+sgc	Kipsigis		ɛː
+sgc	Kipsigis		i
+sgc	Kipsigis		ɪː
+sgc	Kipsigis		e
+sgc	Kipsigis		eː
+sgc	Kipsigis		a
+sgc	Kipsigis		aː
+sgc	Kipsigis		ʊ
+sgc	Kipsigis		ʊː
+sgc	Kipsigis		ɔ
+sgc	Kipsigis		ɔː
+sgc	Kipsigis		u
+sgc	Kipsigis		uː
+sgc	Kipsigis		o
+sgc	Kipsigis		oː
+sgc	Kipsigis		ɑ
+sgc	Kipsigis		ɑː
+sgc	Kipsigis		p		[p]	an intervocalic /p/ is voiced and its realisation is between the sound of [b] and [v]
+sgc	Kipsigis		p		[β]	an intervocalic /p/ is voiced and its realisation is between the sound of [b] and [v]
+sgc	Kipsigis		tʰ		[tʰ]
+sgc	Kipsigis		tʰ		[tː]
+sgc	Kipsigis		kʰ		[kʰ]
+sgc	Kipsigis		kʰ		[ɣ]
+sgc	Kipsigis		s		[s]
+sgc	Kipsigis		s		[sː]
+sgc	Kipsigis		ç
+sgc	Kipsigis		w		[w]
+sgc	Kipsigis		w		[wː]
+sgc	Kipsigis		t̠ʃ		[t̠ʃ]
+sgc	Kipsigis		t̠ʃ		[t̠ʃː]
+sgc	Kipsigis		m		[m]
+sgc	Kipsigis		m		[mː]
+sgc	Kipsigis		n		[n]
+sgc	Kipsigis		n		[nː]
+sgc	Kipsigis		ɲ		[ɲ]
+sgc	Kipsigis		ɲ		[ɲː]
+sgc	Kipsigis		ɲ		[ŋ]
+sgc	Kipsigis		ŋ		[ŋ]
+sgc	Kipsigis		ŋ		[ŋː]
+sgc	Kipsigis		l		[l]
+sgc	Kipsigis		l		[lː]
+sgc	Kipsigis		r
+sgc	Kipsigis		h
+sgc	Kipsigis		˦
+sgc	Kipsigis		˨
+sgc	Kipsigis		˦˨
+sgc	Kipsigis		˨˦
+
 pbr	Pangwa		a		[a]		pbr.pdf
-pbr	Pangwa		a		[ɑ]		
-pbr	Pangwa		e				
-pbr	Pangwa		i		[i]		
-pbr	Pangwa		i		[ɪ]		
-pbr	Pangwa		u		[u]		
-pbr	Pangwa		u		[ʊ]		
-pbr	Pangwa		o				
-pbr	Pangwa		ə				
-pbr	Pangwa		aː				
-pbr	Pangwa		eː				
-pbr	Pangwa		iː				
-pbr	Pangwa		uː				
-pbr	Pangwa		oː				
-pbr	Pangwa		əː				
-pbr	Pangwa		pʰ				
-pbr	Pangwa		ɓ				
-pbr	Pangwa		β				
-pbr	Pangwa		tʰ				
-pbr	Pangwa		k				
-pbr	Pangwa		ɗ				
-pbr	Pangwa		t̠ʃ				
-pbr	Pangwa		tɕ				
-pbr	Pangwa		f				
-pbr	Pangwa		s				
-pbr	Pangwa		ʃ				
-pbr	Pangwa		x				
-pbr	Pangwa		h				
-pbr	Pangwa		j				
-pbr	Pangwa		l				
-pbr	Pangwa		m				
-pbr	Pangwa		n				
-pbr	Pangwa		ɲ				
-pbr	Pangwa		ŋ				
-pbr	Pangwa		mb				
-pbr	Pangwa		nd				
-pbr	Pangwa		n̠d̠ʒ				
-pbr	Pangwa		ŋɡ				
-							
+pbr	Pangwa		a		[ɑ]
+pbr	Pangwa		e
+pbr	Pangwa		i		[i]
+pbr	Pangwa		i		[ɪ]
+pbr	Pangwa		u		[u]
+pbr	Pangwa		u		[ʊ]
+pbr	Pangwa		o
+pbr	Pangwa		ə
+pbr	Pangwa		aː
+pbr	Pangwa		eː
+pbr	Pangwa		iː
+pbr	Pangwa		uː
+pbr	Pangwa		oː
+pbr	Pangwa		əː
+pbr	Pangwa		pʰ
+pbr	Pangwa		ɓ
+pbr	Pangwa		β
+pbr	Pangwa		tʰ
+pbr	Pangwa		k
+pbr	Pangwa		ɗ
+pbr	Pangwa		t̠ʃ
+pbr	Pangwa		tɕ
+pbr	Pangwa		f
+pbr	Pangwa		s
+pbr	Pangwa		ʃ
+pbr	Pangwa		x
+pbr	Pangwa		h
+pbr	Pangwa		j
+pbr	Pangwa		l
+pbr	Pangwa		m
+pbr	Pangwa		n
+pbr	Pangwa		ɲ
+pbr	Pangwa		ŋ
+pbr	Pangwa		mb
+pbr	Pangwa		nd
+pbr	Pangwa		n̠d̠ʒ
+pbr	Pangwa		ŋɡ
+
 hoo	Holoholo		ɪ				hoo.pdf
-hoo	Holoholo		i				
-hoo	Holoholo		e				
-hoo	Holoholo		j				
-hoo	Holoholo		a				
-hoo	Holoholo		ʊ				
-hoo	Holoholo		u				
-hoo	Holoholo		o				
-hoo	Holoholo		w				
-hoo	Holoholo		<f>	loanwords only			
-hoo	Holoholo		<d>	loanwords only	r		
-hoo	Holoholo		<p>	loanwords only			
-hoo	Holoholo		m				
-hoo	Holoholo		b				
-hoo	Holoholo		ɸ		[ɸ]		
-hoo	Holoholo		ɸ		[p]		
-hoo	Holoholo		n̪				
-hoo	Holoholo		l̪		[l̪]		
-hoo	Holoholo		l̪		[d]		
-hoo	Holoholo		t̪				
-hoo	Holoholo		ɲ				
-hoo	Holoholo		d̠ʒ				
-hoo	Holoholo		ʃ				
-hoo	Holoholo		ɡ		[ɡ]		
-hoo	Holoholo		ɡ		[ɣ]		
-hoo	Holoholo		k				
-hoo	Holoholo		ŋ				
-hoo	Holoholo		˦				
-hoo	Holoholo		˨				
-							
+hoo	Holoholo		i
+hoo	Holoholo		e
+hoo	Holoholo		j
+hoo	Holoholo		a
+hoo	Holoholo		ʊ
+hoo	Holoholo		u
+hoo	Holoholo		o
+hoo	Holoholo		w
+hoo	Holoholo		<f>	loanwords only
+hoo	Holoholo		<d>	loanwords only	r
+hoo	Holoholo		<p>	loanwords only
+hoo	Holoholo		m
+hoo	Holoholo		b
+hoo	Holoholo		ɸ		[ɸ]
+hoo	Holoholo		ɸ		[p]
+hoo	Holoholo		n̪
+hoo	Holoholo		l̪		[l̪]
+hoo	Holoholo		l̪		[d]
+hoo	Holoholo		t̪
+hoo	Holoholo		ɲ
+hoo	Holoholo		d̠ʒ
+hoo	Holoholo		ʃ
+hoo	Holoholo		ɡ		[ɡ]
+hoo	Holoholo		ɡ		[ɣ]
+hoo	Holoholo		k
+hoo	Holoholo		ŋ
+hoo	Holoholo		˦
+hoo	Holoholo		˨
+
 bwu	Buli		o		[o]		bwu.pdf
-bwu	Buli		o		[ɔ]		
-bwu	Buli		o		[o̞]		
-bwu	Buli		e		[e]		
-bwu	Buli		e		[ɛ]		
-bwu	Buli		e		[ẽ]		
-bwu	Buli		e		[e]		
-bwu	Buli		e		[e̞]		
-bwu	Buli		<ø>	rare			
-bwu	Buli		u		[u]		
-bwu	Buli		u		[ɥ]		
-bwu	Buli		a		[a]		
-bwu	Buli		a		[ã]		
-bwu	Buli		i				
-bwu	Buli		ɘ				
-bwu	Buli		oː		[oː]		
-bwu	Buli		oː		[ɔːʉ		
-bwu	Buli		oː		[õː]		
-bwu	Buli		oː		[o̞ː]		
-bwu	Buli		eː		[eː]		
-bwu	Buli		eː		[ɛː]		
-bwu	Buli		eː		[e̞ː]		
-bwu	Buli		<øː>	rare			
-bwu	Buli		uː		[uː]		
-bwu	Buli		uː		[ɥː]		
-bwu	Buli		aː		[aː]		
-bwu	Buli		aː		[ãː]		
-bwu	Buli		iː		[iː]		
-bwu	Buli		iː		[ĩː]		
-bwu	Buli		b		[b]		
-bwu	Buli		b		[p]		
-bwu	Buli		f				
-bwu	Buli		v				
-bwu	Buli		m				
-bwu	Buli		w				
-bwu	Buli		t				
-bwu	Buli		d				
-bwu	Buli		s				
-bwu	Buli		z				
-bwu	Buli		l				
-bwu	Buli		n				
-bwu	Buli		r		[r]		
-bwu	Buli		r		[ɾ]		
-bwu	Buli		t̠ʃ				
-bwu	Buli		d̠ʒ				
-bwu	Buli		ɲ				
-bwu	Buli		j				
-bwu	Buli		k				
-bwu	Buli		ɡ		[ɡ]		
-bwu	Buli		ɡ		[ɣ]		
-bwu	Buli		p				
-bwu	Buli		ŋ				
-bwu	Buli		kp				
-bwu	Buli		ɡb				
-bwu	Buli		ŋm				
-bwu	Buli		˦				
-bwu	Buli		˨				
-bwu	Buli		˧				
-bwu	Buli		˨˧				
-bwu	Buli		˨˧				
-bwu	Buli		˨˦				
-bwu	Buli		˧˨				
-bwu	Buli		˦˧				
-bwu	Buli		˦˨				
-bwu	Buli		˧˦˧	MHM			
-bwu	Buli		˧˨˧	MLM			
-							
+bwu	Buli		o		[ɔ]
+bwu	Buli		o		[o̞]
+bwu	Buli		e		[e]
+bwu	Buli		e		[ɛ]
+bwu	Buli		e		[ẽ]
+bwu	Buli		e		[e]
+bwu	Buli		e		[e̞]
+bwu	Buli		<ø>	rare
+bwu	Buli		u		[u]
+bwu	Buli		u		[ɥ]
+bwu	Buli		a		[a]
+bwu	Buli		a		[ã]
+bwu	Buli		i
+bwu	Buli		ɘ
+bwu	Buli		oː		[oː]
+bwu	Buli		oː		[ɔːʉ
+bwu	Buli		oː		[õː]
+bwu	Buli		oː		[o̞ː]
+bwu	Buli		eː		[eː]
+bwu	Buli		eː		[ɛː]
+bwu	Buli		eː		[e̞ː]
+bwu	Buli		<øː>	rare
+bwu	Buli		uː		[uː]
+bwu	Buli		uː		[ɥː]
+bwu	Buli		aː		[aː]
+bwu	Buli		aː		[ãː]
+bwu	Buli		iː		[iː]
+bwu	Buli		iː		[ĩː]
+bwu	Buli		b		[b]
+bwu	Buli		b		[p]
+bwu	Buli		f
+bwu	Buli		v
+bwu	Buli		m
+bwu	Buli		w
+bwu	Buli		t
+bwu	Buli		d
+bwu	Buli		s
+bwu	Buli		z
+bwu	Buli		l
+bwu	Buli		n
+bwu	Buli		r		[r]
+bwu	Buli		r		[ɾ]
+bwu	Buli		t̠ʃ
+bwu	Buli		d̠ʒ
+bwu	Buli		ɲ
+bwu	Buli		j
+bwu	Buli		k
+bwu	Buli		ɡ		[ɡ]
+bwu	Buli		ɡ		[ɣ]
+bwu	Buli		p
+bwu	Buli		ŋ
+bwu	Buli		kp
+bwu	Buli		ɡb
+bwu	Buli		ŋm
+bwu	Buli		˦
+bwu	Buli		˨
+bwu	Buli		˧
+bwu	Buli		˨˧
+bwu	Buli		˨˧
+bwu	Buli		˨˦
+bwu	Buli		˧˨
+bwu	Buli		˦˧
+bwu	Buli		˦˨
+bwu	Buli		˧˦˧	MHM
+bwu	Buli		˧˨˧	MLM
+
 bjt	Balante	Ganja	i				bjt.pdf
-bjt	Balante	Ganja	e				
-bjt	Balante	Ganja	ɛ				
-bjt	Balante	Ganja	a				
-bjt	Balante	Ganja	ɔ				
-bjt	Balante	Ganja	o				
-bjt	Balante	Ganja	u				
-bjt	Balante	Ganja	iː				
-bjt	Balante	Ganja	eː				
-bjt	Balante	Ganja	ɛː				
-bjt	Balante	Ganja	aː				
-bjt	Balante	Ganja	ɔː				
-bjt	Balante	Ganja	oː				
-bjt	Balante	Ganja	uː				
-bjt	Balante	Ganja	p				
-bjt	Balante	Ganja	b				
-bjt	Balante	Ganja	ɗ				
-bjt	Balante	Ganja	tʰ				
-bjt	Balante	Ganja	d̠ʒ				
-bjt	Balante	Ganja	t̠ʃ				
-bjt	Balante	Ganja	ɡ				
-bjt	Balante	Ganja	k				
-bjt	Balante	Ganja	kp				
-bjt	Balante	Ganja	ɡb				
-bjt	Balante	Ganja	ʔ				
-bjt	Balante	Ganja	f				
-bjt	Balante	Ganja	θ				
-bjt	Balante	Ganja	ʃ				
-bjt	Balante	Ganja	m				
-bjt	Balante	Ganja	n				
-bjt	Balante	Ganja	ɲ				
-bjt	Balante	Ganja	ŋ				
-bjt	Balante	Ganja	l				
-bjt	Balante	Ganja	r				
-bjt	Balante	Ganja	j				
-bjt	Balante	Ganja	w				
-bjt	Balante	Ganja	˦				
-bjt	Balante	Ganja	˨				
-bjt	Balante	Ganja	˧				
-bjt	Balante	Ganja	mb				
-bjt	Balante	Ganja	ɱf				
-bjt	Balante	Ganja	nt				
-bjt	Balante	Ganja	nθ				
-bjt	Balante	Ganja	ns				
-bjt	Balante	Ganja	nd				
-bjt	Balante	Ganja	n̠d̠ʒ				
-bjt	Balante	Ganja	ŋɡ				
-bjt	Balante	Ganja	ŋmɡb				
-bjt	Balante	Ganja	ŋʱ				
-bjt	Balante	Ganja	ŋʷ				
-							
+bjt	Balante	Ganja	e
+bjt	Balante	Ganja	ɛ
+bjt	Balante	Ganja	a
+bjt	Balante	Ganja	ɔ
+bjt	Balante	Ganja	o
+bjt	Balante	Ganja	u
+bjt	Balante	Ganja	iː
+bjt	Balante	Ganja	eː
+bjt	Balante	Ganja	ɛː
+bjt	Balante	Ganja	aː
+bjt	Balante	Ganja	ɔː
+bjt	Balante	Ganja	oː
+bjt	Balante	Ganja	uː
+bjt	Balante	Ganja	p
+bjt	Balante	Ganja	b
+bjt	Balante	Ganja	ɗ
+bjt	Balante	Ganja	tʰ
+bjt	Balante	Ganja	d̠ʒ
+bjt	Balante	Ganja	t̠ʃ
+bjt	Balante	Ganja	ɡ
+bjt	Balante	Ganja	k
+bjt	Balante	Ganja	kp
+bjt	Balante	Ganja	ɡb
+bjt	Balante	Ganja	ʔ
+bjt	Balante	Ganja	f
+bjt	Balante	Ganja	θ
+bjt	Balante	Ganja	ʃ
+bjt	Balante	Ganja	m
+bjt	Balante	Ganja	n
+bjt	Balante	Ganja	ɲ
+bjt	Balante	Ganja	ŋ
+bjt	Balante	Ganja	l
+bjt	Balante	Ganja	r
+bjt	Balante	Ganja	j
+bjt	Balante	Ganja	w
+bjt	Balante	Ganja	˦
+bjt	Balante	Ganja	˨
+bjt	Balante	Ganja	˧
+bjt	Balante	Ganja	mb
+bjt	Balante	Ganja	ɱf
+bjt	Balante	Ganja	nt
+bjt	Balante	Ganja	nθ
+bjt	Balante	Ganja	ns
+bjt	Balante	Ganja	nd
+bjt	Balante	Ganja	n̠d̠ʒ
+bjt	Balante	Ganja	ŋɡ
+bjt	Balante	Ganja	ŋmɡb
+bjt	Balante	Ganja	ŋʱ
+bjt	Balante	Ganja	ŋʷ
+
 now	Kinyambo		i				now.pdf
-now	Kinyambo		e				
-now	Kinyambo		a				
-now	Kinyambo		o				
-now	Kinyambo		u				
-now	Kinyambo		iː				
-now	Kinyambo		eː				
-now	Kinyambo		aː				
-now	Kinyambo		uː				
-now	Kinyambo		oː				
-now	Kinyambo		p				
-now	Kinyambo		b				
-now	Kinyambo		t				
-now	Kinyambo		d				
-now	Kinyambo		t̠ʃ				
-now	Kinyambo		d̠ʒ				
-now	Kinyambo		k				
-now	Kinyambo		ɡ				
-now	Kinyambo		m				
-now	Kinyambo		n				
-now	Kinyambo		ŋ				
-now	Kinyambo		r				
-now	Kinyambo		f				
-now	Kinyambo		s				
-now	Kinyambo		h				
-now	Kinyambo		z				
-now	Kinyambo		ɲ				
-now	Kinyambo		ɱ				
-now	Kinyambo		w				
-now	Kinyambo		j				
-now	Kinyambo		˦				
-now	Kinyambo		˨				
-now	Kinyambo		˦˨				
-							
+now	Kinyambo		e
+now	Kinyambo		a
+now	Kinyambo		o
+now	Kinyambo		u
+now	Kinyambo		iː
+now	Kinyambo		eː
+now	Kinyambo		aː
+now	Kinyambo		uː
+now	Kinyambo		oː
+now	Kinyambo		p
+now	Kinyambo		b
+now	Kinyambo		t
+now	Kinyambo		d
+now	Kinyambo		t̠ʃ
+now	Kinyambo		d̠ʒ
+now	Kinyambo		k
+now	Kinyambo		ɡ
+now	Kinyambo		m
+now	Kinyambo		n
+now	Kinyambo		ŋ
+now	Kinyambo		r
+now	Kinyambo		f
+now	Kinyambo		s
+now	Kinyambo		h
+now	Kinyambo		z
+now	Kinyambo		ɲ
+now	Kinyambo		ɱ
+now	Kinyambo		w
+now	Kinyambo		j
+now	Kinyambo		˦
+now	Kinyambo		˨
+now	Kinyambo		˦˨
+
 lda	Dan	Santa	p				dan_santa.pdf
-lda	Dan	Santa	b				
-lda	Dan	Santa	ɓ				
-lda	Dan	Santa	kp				
-lda	Dan	Santa	t				
-lda	Dan	Santa	d				
-lda	Dan	Santa	ɗ				
-lda	Dan	Santa	ɡb				
-lda	Dan	Santa	ᶑ				
-lda	Dan	Santa	f				
-lda	Dan	Santa	v				
-lda	Dan	Santa	w		[w]		
-lda	Dan	Santa	w		[w̃]		
-lda	Dan	Santa	s				
-lda	Dan	Santa	z				
-lda	Dan	Santa	l		[l]		
-lda	Dan	Santa	l		[ɾ]		
-lda	Dan	Santa	j		[j]		
-lda	Dan	Santa	j		[j̃]		
-lda	Dan	Santa	u				
-lda	Dan	Santa	i				
-lda	Dan	Santa	j				
-lda	Dan	Santa	ɲ				
-lda	Dan	Santa	k				
-lda	Dan	Santa	ɡ				
-lda	Dan	Santa	n				
-lda	Dan	Santa	pʲ				
-lda	Dan	Santa	bʲ				
-lda	Dan	Santa	ɓʲ				
-lda	Dan	Santa	tʲ				
-lda	Dan	Santa	dʲ				
-lda	Dan	Santa	ɗʲ				
-lda	Dan	Santa	ɡbʲ				
-lda	Dan	Santa	sʷ				
-lda	Dan	Santa	sʲ				
-lda	Dan	Santa	zʷ				
-lda	Dan	Santa	zʲ				
-lda	Dan	Santa	kʷ				
-lda	Dan	Santa	kʲ				
-lda	Dan	Santa	ɡʷ				
-lda	Dan	Santa	ɡʲ				
-lda	Dan	Santa	nʷ				
-lda	Dan	Santa	nʲ				
-lda	Dan	Santa	kpʲ				
-lda	Dan	Santa	fʲ				
-lda	Dan	Santa	vʲ				
-lda	Dan	Santa	wʲ				
-lda	Dan	Santa	m				
-lda	Dan	Santa	mʲ				
-lda	Dan	Santa	ŋ		[ŋ]		
-lda	Dan	Santa	ŋ		[m]		
-lda	Dan	Santa	ŋ		[n]		
-lda	Dan	Santa	ŋ		[ɲ]		
-lda	Dan	Santa	ŋ		[ŋm]		
-lda	Dan	Santa	i				
-lda	Dan	Santa	eː				
-lda	Dan	Santa	ɨ				
-lda	Dan	Santa	ɛː				
-lda	Dan	Santa	e				
-lda	Dan	Santa	iː				
-lda	Dan	Santa	ɵ				
-lda	Dan	Santa	æː				
-lda	Dan	Santa	ɨː				
-lda	Dan	Santa	əː				
-lda	Dan	Santa	æ				
-lda	Dan	Santa	ɛ				
-lda	Dan	Santa	aː				
-lda	Dan	Santa	ɵː				
-lda	Dan	Santa	ə				
-lda	Dan	Santa	o				
-lda	Dan	Santa	oː				
-lda	Dan	Santa	ɔ				
-lda	Dan	Santa	ɔː				
-lda	Dan	Santa	a				
-lda	Dan	Santa	ɒ				
-lda	Dan	Santa	ɒː				
-lda	Dan	Santa	u				
-lda	Dan	Santa	uː				
-lda	Dan	Santa	ĩ				
-lda	Dan	Santa	ɛ̃				
-lda	Dan	Santa	ɛ̃ː				
-lda	Dan	Santa	ĩː				
-lda	Dan	Santa	æ̃ː				
-lda	Dan	Santa	ə̃ː				
-lda	Dan	Santa	ə̃				
-lda	Dan	Santa	æ̃				
-lda	Dan	Santa	ã				
-lda	Dan	Santa	ãː				
-lda	Dan	Santa	ɔ̃				
-lda	Dan	Santa	ɔ̃ː				
-lda	Dan	Santa	ɒ̃				
-lda	Dan	Santa	ɒ̃ː				
-lda	Dan	Santa	ũ				
-lda	Dan	Santa	ũː				
-lda	Dan	Santa	˥				
-lda	Dan	Santa	˩				
-lda	Dan	Santa	˦				
-lda	Dan	Santa	˨				
-lda	Dan	Santa	˧				
-lda	Dan	Santa	˧˨				
-lda	Dan	Santa	˧˥˨	MSL			
-lda	Dan	Santa	˥˨˧	SLM			
-							
+lda	Dan	Santa	b
+lda	Dan	Santa	ɓ
+lda	Dan	Santa	kp
+lda	Dan	Santa	t
+lda	Dan	Santa	d
+lda	Dan	Santa	ɗ
+lda	Dan	Santa	ɡb
+lda	Dan	Santa	ᶑ
+lda	Dan	Santa	f
+lda	Dan	Santa	v
+lda	Dan	Santa	w		[w]
+lda	Dan	Santa	w		[w̃]
+lda	Dan	Santa	s
+lda	Dan	Santa	z
+lda	Dan	Santa	l		[l]
+lda	Dan	Santa	l		[ɾ]
+lda	Dan	Santa	j		[j]
+lda	Dan	Santa	j		[j̃]
+lda	Dan	Santa	u
+lda	Dan	Santa	i
+lda	Dan	Santa	j
+lda	Dan	Santa	ɲ
+lda	Dan	Santa	k
+lda	Dan	Santa	ɡ
+lda	Dan	Santa	n
+lda	Dan	Santa	pʲ
+lda	Dan	Santa	bʲ
+lda	Dan	Santa	ɓʲ
+lda	Dan	Santa	tʲ
+lda	Dan	Santa	dʲ
+lda	Dan	Santa	ɗʲ
+lda	Dan	Santa	ɡbʲ
+lda	Dan	Santa	sʷ
+lda	Dan	Santa	sʲ
+lda	Dan	Santa	zʷ
+lda	Dan	Santa	zʲ
+lda	Dan	Santa	kʷ
+lda	Dan	Santa	kʲ
+lda	Dan	Santa	ɡʷ
+lda	Dan	Santa	ɡʲ
+lda	Dan	Santa	nʷ
+lda	Dan	Santa	nʲ
+lda	Dan	Santa	kpʲ
+lda	Dan	Santa	fʲ
+lda	Dan	Santa	vʲ
+lda	Dan	Santa	wʲ
+lda	Dan	Santa	m
+lda	Dan	Santa	mʲ
+lda	Dan	Santa	ŋ		[ŋ]
+lda	Dan	Santa	ŋ		[m]
+lda	Dan	Santa	ŋ		[n]
+lda	Dan	Santa	ŋ		[ɲ]
+lda	Dan	Santa	ŋ		[ŋm]
+lda	Dan	Santa	i
+lda	Dan	Santa	eː
+lda	Dan	Santa	ɨ
+lda	Dan	Santa	ɛː
+lda	Dan	Santa	e
+lda	Dan	Santa	iː
+lda	Dan	Santa	ɵ
+lda	Dan	Santa	æː
+lda	Dan	Santa	ɨː
+lda	Dan	Santa	əː
+lda	Dan	Santa	æ
+lda	Dan	Santa	ɛ
+lda	Dan	Santa	aː
+lda	Dan	Santa	ɵː
+lda	Dan	Santa	ə
+lda	Dan	Santa	o
+lda	Dan	Santa	oː
+lda	Dan	Santa	ɔ
+lda	Dan	Santa	ɔː
+lda	Dan	Santa	a
+lda	Dan	Santa	ɒ
+lda	Dan	Santa	ɒː
+lda	Dan	Santa	u
+lda	Dan	Santa	uː
+lda	Dan	Santa	ĩ
+lda	Dan	Santa	ɛ̃
+lda	Dan	Santa	ɛ̃ː
+lda	Dan	Santa	ĩː
+lda	Dan	Santa	æ̃ː
+lda	Dan	Santa	ə̃ː
+lda	Dan	Santa	ə̃
+lda	Dan	Santa	æ̃
+lda	Dan	Santa	ã
+lda	Dan	Santa	ãː
+lda	Dan	Santa	ɔ̃
+lda	Dan	Santa	ɔ̃ː
+lda	Dan	Santa	ɒ̃
+lda	Dan	Santa	ɒ̃ː
+lda	Dan	Santa	ũ
+lda	Dan	Santa	ũː
+lda	Dan	Santa	˥
+lda	Dan	Santa	˩
+lda	Dan	Santa	˦
+lda	Dan	Santa	˨
+lda	Dan	Santa	˧
+lda	Dan	Santa	˧˨
+lda	Dan	Santa	˧˥˨	MSL
+lda	Dan	Santa	˥˨˧	SLM
+
 pko	Pokot		a				pko.pdf
-pko	Pokot		e				
-pko	Pokot		i				
-pko	Pokot		o				
-pko	Pokot		u				
-pko	Pokot		aː				
-pko	Pokot		eː				
-pko	Pokot		iː				
-pko	Pokot		oː				
-pko	Pokot		uː				
-pko	Pokot		ɛ				
-pko	Pokot		ɔ				
-pko	Pokot		ɛː				
-pko	Pokot		ɔː				
-pko	Pokot		ə				
-pko	Pokot		a̤				
-pko	Pokot		e̤				
-pko	Pokot		i̤				
-pko	Pokot		o̤				
-pko	Pokot		w				
-pko	Pokot		j				
-pko	Pokot		<b>	rare			
-pko	Pokot		<d>	rare			
-pko	Pokot		ɡ				
-pko	Pokot		k				
-pko	Pokot		l				
-pko	Pokot		m				
-pko	Pokot		n				
-pko	Pokot		p				
-pko	Pokot		r				
-pko	Pokot		s		[s]		
-pko	Pokot		s		[ʃ]		
-pko	Pokot		t̪ʃ|t̠ʃ		[t̪ʃ|t̠ʃ]		
-pko	Pokot		x		[x]		
-pko	Pokot		t̪ʃ|t̠ʃ		[d̪ʒ|d̠ʒ]		
-pko	Pokot		x		[ɣ]		
-pko	Pokot		ŋ				
-pko	Pokot		ɲ				
-pko	Pokot		t		[t]		
-pko	Pokot		t		[θ]		
-pko	Pokot		˦				
-pko	Pokot		˨				
-pko	Pokot		˧				
-							
+pko	Pokot		e
+pko	Pokot		i
+pko	Pokot		o
+pko	Pokot		u
+pko	Pokot		aː
+pko	Pokot		eː
+pko	Pokot		iː
+pko	Pokot		oː
+pko	Pokot		uː
+pko	Pokot		ɛ
+pko	Pokot		ɔ
+pko	Pokot		ɛː
+pko	Pokot		ɔː
+pko	Pokot		ə
+pko	Pokot		a̤
+pko	Pokot		e̤
+pko	Pokot		i̤
+pko	Pokot		o̤
+pko	Pokot		w
+pko	Pokot		j
+pko	Pokot		<b>	rare
+pko	Pokot		<d>	rare
+pko	Pokot		ɡ
+pko	Pokot		k
+pko	Pokot		l
+pko	Pokot		m
+pko	Pokot		n
+pko	Pokot		p
+pko	Pokot		r
+pko	Pokot		s		[s]
+pko	Pokot		s		[ʃ]
+pko	Pokot		t̪ʃ|t̠ʃ		[t̪ʃ|t̠ʃ]
+pko	Pokot		x		[x]
+pko	Pokot		t̪ʃ|t̠ʃ		[d̪ʒ|d̠ʒ]
+pko	Pokot		x		[ɣ]
+pko	Pokot		ŋ
+pko	Pokot		ɲ
+pko	Pokot		t		[t]
+pko	Pokot		t		[θ]
+pko	Pokot		˦
+pko	Pokot		˨
+pko	Pokot		˧
+
 afr	Afrikaans		i		[i]		afr.pdf
-afr	Afrikaans		i		[iː]		
-afr	Afrikaans		y		[y]		
-afr	Afrikaans		y		[yː]		
-afr	Afrikaans		u				
-afr	Afrikaans		ɪ̝				
-afr	Afrikaans		ɛ		[ɛ]		
-afr	Afrikaans		ɛ		[æː]		
-afr	Afrikaans		ɛ		[ɛ̃ː]		
-afr	Afrikaans		œ				
-afr	Afrikaans		ɔ		[ɔ]		
-afr	Afrikaans		ɔ		[ɔ̃ː]		
-afr	Afrikaans		a		[a]		
-afr	Afrikaans		a		[ãː]		
-afr	Afrikaans		iː				
-afr	Afrikaans		yː				
-afr	Afrikaans		uː				
-afr	Afrikaans		ɛː				
-afr	Afrikaans		œː				
-afr	Afrikaans		ɔː				
-afr	Afrikaans		aː				
-afr	Afrikaans		<ɪ̝ː>	rare			
-afr	Afrikaans		ɘi				
-afr	Afrikaans		œi				
-afr	Afrikaans		eɘ				
-afr	Afrikaans		œu				
-afr	Afrikaans		øɘ				
-afr	Afrikaans		oɘ				
-afr	Afrikaans		ai				
-afr	Afrikaans		p				
-afr	Afrikaans		b		[b]		
-afr	Afrikaans		b		[p]		
-afr	Afrikaans		f		[f]		
-afr	Afrikaans		f		[v]		
-afr	Afrikaans		v		[v]		
-afr	Afrikaans		v		[w]		
-afr	Afrikaans		m				
-afr	Afrikaans		t				
-afr	Afrikaans		d		[d]		
-afr	Afrikaans		d		[t]		
-afr	Afrikaans		s				
-afr	Afrikaans		n				
-afr	Afrikaans		k		[k]		
-afr	Afrikaans		k		[c]		
-afr	Afrikaans		x		[x]		
-afr	Afrikaans		x		[ɡ]		
-afr	Afrikaans		ŋ				
-afr	Afrikaans		ɦ				
-afr	Afrikaans		l				
-afr	Afrikaans		r				
-afr	Afrikaans		j				
-							
+afr	Afrikaans		i		[iː]
+afr	Afrikaans		y		[y]
+afr	Afrikaans		y		[yː]
+afr	Afrikaans		u
+afr	Afrikaans		ɪ̝
+afr	Afrikaans		ɛ		[ɛ]
+afr	Afrikaans		ɛ		[æː]
+afr	Afrikaans		ɛ		[ɛ̃ː]
+afr	Afrikaans		œ
+afr	Afrikaans		ɔ		[ɔ]
+afr	Afrikaans		ɔ		[ɔ̃ː]
+afr	Afrikaans		a		[a]
+afr	Afrikaans		a		[ãː]
+afr	Afrikaans		iː
+afr	Afrikaans		yː
+afr	Afrikaans		uː
+afr	Afrikaans		ɛː
+afr	Afrikaans		œː
+afr	Afrikaans		ɔː
+afr	Afrikaans		aː
+afr	Afrikaans		<ɪ̝ː>	rare
+afr	Afrikaans		ɘi
+afr	Afrikaans		œi
+afr	Afrikaans		eɘ
+afr	Afrikaans		œu
+afr	Afrikaans		øɘ
+afr	Afrikaans		oɘ
+afr	Afrikaans		ai
+afr	Afrikaans		p
+afr	Afrikaans		b		[b]
+afr	Afrikaans		b		[p]
+afr	Afrikaans		f		[f]
+afr	Afrikaans		f		[v]
+afr	Afrikaans		v		[v]
+afr	Afrikaans		v		[w]
+afr	Afrikaans		m
+afr	Afrikaans		t
+afr	Afrikaans		d		[d]
+afr	Afrikaans		d		[t]
+afr	Afrikaans		s
+afr	Afrikaans		n
+afr	Afrikaans		k		[k]
+afr	Afrikaans		k		[c]
+afr	Afrikaans		x		[x]
+afr	Afrikaans		x		[ɡ]
+afr	Afrikaans		ŋ
+afr	Afrikaans		ɦ
+afr	Afrikaans		l
+afr	Afrikaans		r
+afr	Afrikaans		j
+
 agj	Argobba		<pʰ>	rare	[pʰ]		hertzon.pdf
-agj	Argobba		<pʰ>	rare	[p̚]		
-agj	Argobba		<pʰ>	rare	[pː]		
-agj	Argobba		b		[b]		
-agj	Argobba		b		[β]		
-agj	Argobba		b		[bʷ]		
-agj	Argobba		b		[bː]		
-agj	Argobba		tʰ		[tʰ]		
-agj	Argobba		tʰ		[t̚]		
-agj	Argobba		tʰ		[tː]		
-agj	Argobba		kʰ		[kʰ]		
-agj	Argobba		kʰ		[k̚]		
-agj	Argobba		kʰ		[kː]		
-agj	Argobba		kʷ		[kʷ]		
-agj	Argobba		kʷ		[kʷː]		
-agj	Argobba		ʔ		[ʔ]		
-agj	Argobba		ʔ		[ʔː]		
-agj	Argobba		d		[d]		
-agj	Argobba		d		[dː]		
-agj	Argobba		ɡ		[ɡ]		
-agj	Argobba		ɡ		[ɣ]		
-agj	Argobba		ɡ		[ɣː]		
-agj	Argobba		ɡʷ		[ɡʷ]		
-agj	Argobba		ɡʷ		[ɡʷː]		
-agj	Argobba		<pʼ>	rare	[pʼ]		
-agj	Argobba		<pʼ>	rare	[pʼː]		
-agj	Argobba		tʼ		[tʼ]		
-agj	Argobba		tʼ		[tʼː]		
-agj	Argobba		kʼ		[kʼ]		
-agj	Argobba		kʼ		[kʷʼ]		
-agj	Argobba		kʼ		[kʼː]		
-agj	Argobba		kʷʼ		[kʷʼ]		
-agj	Argobba		kʷʼ		[kʷʼː]		
-agj	Argobba		t̠ʃ		[t̠ʃ]		
-agj	Argobba		t̠ʃ		[t̠ʃː]		
-agj	Argobba		d̠ʒ		[d̠ʒ]		
-agj	Argobba		d̠ʒ		[d̠ʒː]		
-agj	Argobba		t̠ʃʼ		[t̠ʃʼ]		
-agj	Argobba		t̠ʃʼ		[t̠ʃʼː]		
-agj	Argobba		f		[f]		
-agj	Argobba		f		[fː]		
-agj	Argobba		s		[s]		
-agj	Argobba		s		[sː]		
-agj	Argobba		ʃ		[ʃ]		
-agj	Argobba		ʃ		[ʃː]		
-agj	Argobba		h				
-agj	Argobba		hʷ				
-agj	Argobba		z		[z]		
-agj	Argobba		z		[zː]		
-agj	Argobba		ʒ		[ʒ]		
-agj	Argobba		ʒ		[ʒː]		
-agj	Argobba		m		[m]		
-agj	Argobba		m		[mː]		
-agj	Argobba		n		[n]		
-agj	Argobba		n		[nː]		
-agj	Argobba		ɲ		[ɲ]		
-agj	Argobba		ɲ		[ɲː]		
-agj	Argobba		l		[l]		
-agj	Argobba		l		[lː]		
-agj	Argobba		ɽ		[ɽ]		
-agj	Argobba		ɽ		[r]		
-agj	Argobba		w		[w]		
-agj	Argobba		w		[wː]		
-agj	Argobba		j		[j]		
-agj	Argobba		j		[jː]		
-agj	Argobba		i				
-agj	Argobba		ɨ				
-agj	Argobba		e		[e]		
-agj	Argobba		e		[ɛ]		
-agj	Argobba		ʌ				
-agj	Argobba		a				
-agj	Argobba		u				
-agj	Argobba		o				
-agj	Argobba		<aː>	loanwords only			
-							
+agj	Argobba		<pʰ>	rare	[p̚]
+agj	Argobba		<pʰ>	rare	[pː]
+agj	Argobba		b		[b]
+agj	Argobba		b		[β]
+agj	Argobba		b		[bʷ]
+agj	Argobba		b		[bː]
+agj	Argobba		tʰ		[tʰ]
+agj	Argobba		tʰ		[t̚]
+agj	Argobba		tʰ		[tː]
+agj	Argobba		kʰ		[kʰ]
+agj	Argobba		kʰ		[k̚]
+agj	Argobba		kʰ		[kː]
+agj	Argobba		kʷ		[kʷ]
+agj	Argobba		kʷ		[kʷː]
+agj	Argobba		ʔ		[ʔ]
+agj	Argobba		ʔ		[ʔː]
+agj	Argobba		d		[d]
+agj	Argobba		d		[dː]
+agj	Argobba		ɡ		[ɡ]
+agj	Argobba		ɡ		[ɣ]
+agj	Argobba		ɡ		[ɣː]
+agj	Argobba		ɡʷ		[ɡʷ]
+agj	Argobba		ɡʷ		[ɡʷː]
+agj	Argobba		<pʼ>	rare	[pʼ]
+agj	Argobba		<pʼ>	rare	[pʼː]
+agj	Argobba		tʼ		[tʼ]
+agj	Argobba		tʼ		[tʼː]
+agj	Argobba		kʼ		[kʼ]
+agj	Argobba		kʼ		[kʷʼ]
+agj	Argobba		kʼ		[kʼː]
+agj	Argobba		kʷʼ		[kʷʼ]
+agj	Argobba		kʷʼ		[kʷʼː]
+agj	Argobba		t̠ʃ		[t̠ʃ]
+agj	Argobba		t̠ʃ		[t̠ʃː]
+agj	Argobba		d̠ʒ		[d̠ʒ]
+agj	Argobba		d̠ʒ		[d̠ʒː]
+agj	Argobba		t̠ʃʼ		[t̠ʃʼ]
+agj	Argobba		t̠ʃʼ		[t̠ʃʼː]
+agj	Argobba		f		[f]
+agj	Argobba		f		[fː]
+agj	Argobba		s		[s]
+agj	Argobba		s		[sː]
+agj	Argobba		ʃ		[ʃ]
+agj	Argobba		ʃ		[ʃː]
+agj	Argobba		h
+agj	Argobba		hʷ
+agj	Argobba		z		[z]
+agj	Argobba		z		[zː]
+agj	Argobba		ʒ		[ʒ]
+agj	Argobba		ʒ		[ʒː]
+agj	Argobba		m		[m]
+agj	Argobba		m		[mː]
+agj	Argobba		n		[n]
+agj	Argobba		n		[nː]
+agj	Argobba		ɲ		[ɲ]
+agj	Argobba		ɲ		[ɲː]
+agj	Argobba		l		[l]
+agj	Argobba		l		[lː]
+agj	Argobba		ɽ		[ɽ]
+agj	Argobba		ɽ		[r]
+agj	Argobba		w		[w]
+agj	Argobba		w		[wː]
+agj	Argobba		j		[j]
+agj	Argobba		j		[jː]
+agj	Argobba		i
+agj	Argobba		ɨ
+agj	Argobba		e		[e]
+agj	Argobba		e		[ɛ]
+agj	Argobba		ʌ
+agj	Argobba		a
+agj	Argobba		u
+agj	Argobba		o
+agj	Argobba		<aː>	loanwords only
+
 har	Harari		p				hertzon.pdf
-har	Harari		m				
-har	Harari		w				
-har	Harari		f				
-har	Harari		d				
-har	Harari		t				
-har	Harari		tʼ				
-har	Harari		z				
-har	Harari		s				
-har	Harari		n				
-har	Harari		l				
-har	Harari		r				
-har	Harari		cç				
-har	Harari		ɟʝ				
-har	Harari		cçʼ				
-har	Harari		ɲ				
-har	Harari		ʃ				
-har	Harari		j				
-har	Harari		ɡ				
-har	Harari		k				
-har	Harari		q				
-har	Harari		<ɣ>	loanwords only			
-har	Harari		x				
-har	Harari		hʼ				
-har	Harari		ʔ				
-har	Harari		a				
-har	Harari		aː				
-har	Harari		i				
-har	Harari		iː				
-har	Harari		u				
-har	Harari		e				
-har	Harari		eː				
-har	Harari		o				
-har	Harari		oː				
-							
+har	Harari		m
+har	Harari		w
+har	Harari		f
+har	Harari		d
+har	Harari		t
+har	Harari		tʼ
+har	Harari		z
+har	Harari		s
+har	Harari		n
+har	Harari		l
+har	Harari		r
+har	Harari		cç
+har	Harari		ɟʝ
+har	Harari		cçʼ
+har	Harari		ɲ
+har	Harari		ʃ
+har	Harari		j
+har	Harari		ɡ
+har	Harari		k
+har	Harari		q
+har	Harari		<ɣ>	loanwords only
+har	Harari		x
+har	Harari		hʼ
+har	Harari		ʔ
+har	Harari		a
+har	Harari		aː
+har	Harari		i
+har	Harari		iː
+har	Harari		u
+har	Harari		e
+har	Harari		eː
+har	Harari		o
+har	Harari		oː
+
 din	Dinka	macrolanguage	p		[p]		din.pdf
-din	Dinka	macrolanguage	p		[p̚]		
-din	Dinka	macrolanguage	b				
-din	Dinka	macrolanguage	m				
-din	Dinka	macrolanguage	w				
-din	Dinka	macrolanguage	t̪		[t̪]		
-din	Dinka	macrolanguage	t̪		[t̪̚]		
-din	Dinka	macrolanguage	d̪				
-din	Dinka	macrolanguage	n̪				
-din	Dinka	macrolanguage	t		[t]		
-din	Dinka	macrolanguage	t		[t̚]		
-din	Dinka	macrolanguage	d				
-din	Dinka	macrolanguage	n				
-din	Dinka	macrolanguage	l		[l]		
-din	Dinka	macrolanguage	l		[l̚]		
-din	Dinka	macrolanguage	ɾ		[ɾ]		
-din	Dinka	macrolanguage	ɾ		[ɾ̚]		
-din	Dinka	macrolanguage	c		[c]		
-din	Dinka	macrolanguage	c		[c̚]		
-din	Dinka	macrolanguage	ɟ				
-din	Dinka	macrolanguage	ɲ				
-din	Dinka	macrolanguage	j				
-din	Dinka	macrolanguage	k		[k]		
-din	Dinka	macrolanguage	k		[k̚]		
-din	Dinka	macrolanguage	ɡ				
-din	Dinka	macrolanguage	ŋ				
-din	Dinka	macrolanguage	ɣ	approximate based upon description			
-din	Dinka	macrolanguage	i		[i]		
-din	Dinka	macrolanguage	e		[e]		
-din	Dinka	macrolanguage	ɛ		[ɛ]		
-din	Dinka	macrolanguage	a		[a]		
-din	Dinka	macrolanguage	u		[u]		
-din	Dinka	macrolanguage	o		[o]		
-din	Dinka	macrolanguage	ɔ		[ɔ]		
-din	Dinka	macrolanguage	i̤		[i̤]		
-din	Dinka	macrolanguage	e̤		[e̤]		
-din	Dinka	macrolanguage	ɛ̤		[ɛ̤]		
-din	Dinka	macrolanguage	a̤		[a̤]		
-din	Dinka	macrolanguage	ɔ̤		[ɔ̤]		
-din	Dinka	macrolanguage	o̤		[o̤]		
-din	Dinka	macrolanguage	i		[ĭ]		
-din	Dinka	macrolanguage	e		[ĕ]		
-din	Dinka	macrolanguage	ɛ		[ɛ̆]		
-din	Dinka	macrolanguage	a		[ă]		
-din	Dinka	macrolanguage	u		[ŭ]		
-din	Dinka	macrolanguage	o		[ŏ]		
-din	Dinka	macrolanguage	ɔ		[ɔ̆]		
-din	Dinka	macrolanguage	i̤		[ĭ̤]		
-din	Dinka	macrolanguage	e̤		[ĕ̤]		
-din	Dinka	macrolanguage	ɛ̤		[ɛ̤̆]		
-din	Dinka	macrolanguage	a̤		[ă̤]		
-din	Dinka	macrolanguage	ɔ̤		[ɔ̤̆]		
-din	Dinka	macrolanguage	o̤		[ŏ̤]		
-din	Dinka	macrolanguage	˦				
-din	Dinka	macrolanguage	˨				
-din	Dinka	macrolanguage	˧				
-din	Dinka	macrolanguage	eː				
-din	Dinka	macrolanguage	e̤ː				
-din	Dinka	macrolanguage	iː				
-din	Dinka	macrolanguage	ɛ̤ː				
-din	Dinka	macrolanguage	aː				
-din	Dinka	macrolanguage	ɔː				
-din	Dinka	macrolanguage	oː				
-din	Dinka	macrolanguage	o̤ː				
-din	Dinka	macrolanguage	uː				
-din	Dinka	macrolanguage	i̤ː				
-din	Dinka	macrolanguage	ɛː				
-din	Dinka	macrolanguage	a̤ː				
-din	Dinka	macrolanguage	ɔ̤ː				
-							
+din	Dinka	macrolanguage	p		[p̚]
+din	Dinka	macrolanguage	b
+din	Dinka	macrolanguage	m
+din	Dinka	macrolanguage	w
+din	Dinka	macrolanguage	t̪		[t̪]
+din	Dinka	macrolanguage	t̪		[t̪̚]
+din	Dinka	macrolanguage	d̪
+din	Dinka	macrolanguage	n̪
+din	Dinka	macrolanguage	t		[t]
+din	Dinka	macrolanguage	t		[t̚]
+din	Dinka	macrolanguage	d
+din	Dinka	macrolanguage	n
+din	Dinka	macrolanguage	l		[l]
+din	Dinka	macrolanguage	l		[l̚]
+din	Dinka	macrolanguage	ɾ		[ɾ]
+din	Dinka	macrolanguage	ɾ		[ɾ̚]
+din	Dinka	macrolanguage	c		[c]
+din	Dinka	macrolanguage	c		[c̚]
+din	Dinka	macrolanguage	ɟ
+din	Dinka	macrolanguage	ɲ
+din	Dinka	macrolanguage	j
+din	Dinka	macrolanguage	k		[k]
+din	Dinka	macrolanguage	k		[k̚]
+din	Dinka	macrolanguage	ɡ
+din	Dinka	macrolanguage	ŋ
+din	Dinka	macrolanguage	ɣ	approximate based upon description
+din	Dinka	macrolanguage	i		[i]
+din	Dinka	macrolanguage	e		[e]
+din	Dinka	macrolanguage	ɛ		[ɛ]
+din	Dinka	macrolanguage	a		[a]
+din	Dinka	macrolanguage	u		[u]
+din	Dinka	macrolanguage	o		[o]
+din	Dinka	macrolanguage	ɔ		[ɔ]
+din	Dinka	macrolanguage	i̤		[i̤]
+din	Dinka	macrolanguage	e̤		[e̤]
+din	Dinka	macrolanguage	ɛ̤		[ɛ̤]
+din	Dinka	macrolanguage	a̤		[a̤]
+din	Dinka	macrolanguage	ɔ̤		[ɔ̤]
+din	Dinka	macrolanguage	o̤		[o̤]
+din	Dinka	macrolanguage	i		[ĭ]
+din	Dinka	macrolanguage	e		[ĕ]
+din	Dinka	macrolanguage	ɛ		[ɛ̆]
+din	Dinka	macrolanguage	a		[ă]
+din	Dinka	macrolanguage	u		[ŭ]
+din	Dinka	macrolanguage	o		[ŏ]
+din	Dinka	macrolanguage	ɔ		[ɔ̆]
+din	Dinka	macrolanguage	i̤		[ĭ̤]
+din	Dinka	macrolanguage	e̤		[ĕ̤]
+din	Dinka	macrolanguage	ɛ̤		[ɛ̤̆]
+din	Dinka	macrolanguage	a̤		[ă̤]
+din	Dinka	macrolanguage	ɔ̤		[ɔ̤̆]
+din	Dinka	macrolanguage	o̤		[ŏ̤]
+din	Dinka	macrolanguage	˦
+din	Dinka	macrolanguage	˨
+din	Dinka	macrolanguage	˧
+din	Dinka	macrolanguage	eː
+din	Dinka	macrolanguage	e̤ː
+din	Dinka	macrolanguage	iː
+din	Dinka	macrolanguage	ɛ̤ː
+din	Dinka	macrolanguage	aː
+din	Dinka	macrolanguage	ɔː
+din	Dinka	macrolanguage	oː
+din	Dinka	macrolanguage	o̤ː
+din	Dinka	macrolanguage	uː
+din	Dinka	macrolanguage	i̤ː
+din	Dinka	macrolanguage	ɛː
+din	Dinka	macrolanguage	a̤ː
+din	Dinka	macrolanguage	ɔ̤ː
+
 nzi	Nzema		i				tano.pdf
-nzi	Nzema		ɪ				
-nzi	Nzema		e				
-nzi	Nzema		ɛ				
-nzi	Nzema		a		[a]		
-nzi	Nzema		a		[ɜ]		
-nzi	Nzema		ɔ				
-nzi	Nzema		o				
-nzi	Nzema		ʊ				
-nzi	Nzema		u				
-nzi	Nzema		ɪ̃				
-nzi	Nzema		ĩ				
-nzi	Nzema		ã				
-nzi	Nzema		ʊ̃				
-nzi	Nzema		ũ				
-nzi	Nzema		kp		[kp]		
-nzi	Nzema		kp		[ɡb]		
-nzi	Nzema		b		[b]		
-nzi	Nzema		b		[ɣ]		
-nzi	Nzema		m				
-nzi	Nzema		w				
-nzi	Nzema		f		[f]		
-nzi	Nzema		f		[v]		
-nzi	Nzema		t̪		[t̪]		
-nzi	Nzema		t̪		[d̪]		
-nzi	Nzema		d̪				
-nzi	Nzema		n		[n]		
-nzi	Nzema		n		[l̃]		
-nzi	Nzema		s		[s]		
-nzi	Nzema		s		[z]		
-nzi	Nzema		l				
-nzi	Nzema		cç		[cç]		
-nzi	Nzema		cç		[ɟʝ]		
-nzi	Nzema		cç		[ʃ]		
-nzi	Nzema		cçʷ		[cçʷ]		
-nzi	Nzema		cçʷ		[ɟʝʷ]		
-nzi	Nzema		ɟʝ				
-nzi	Nzema		ɟʝʷ				
-nzi	Nzema		ɲ				
-nzi	Nzema		ɲʷ				
-nzi	Nzema		ʃ				
-nzi	Nzema		ʃʷ				
-nzi	Nzema		j				
-nzi	Nzema		k		[k]		
-nzi	Nzema		k		[ɡ]		
-nzi	Nzema		k		[h]		
-nzi	Nzema		ɡ				
-nzi	Nzema		ɡʷ				
-nzi	Nzema		ŋ				
-nzi	Nzema		h				
-nzi	Nzema		˦				
-nzi	Nzema		˨				
-							
+nzi	Nzema		ɪ
+nzi	Nzema		e
+nzi	Nzema		ɛ
+nzi	Nzema		a		[a]
+nzi	Nzema		a		[ɜ]
+nzi	Nzema		ɔ
+nzi	Nzema		o
+nzi	Nzema		ʊ
+nzi	Nzema		u
+nzi	Nzema		ɪ̃
+nzi	Nzema		ĩ
+nzi	Nzema		ã
+nzi	Nzema		ʊ̃
+nzi	Nzema		ũ
+nzi	Nzema		kp		[kp]
+nzi	Nzema		kp		[ɡb]
+nzi	Nzema		b		[b]
+nzi	Nzema		b		[ɣ]
+nzi	Nzema		m
+nzi	Nzema		w
+nzi	Nzema		f		[f]
+nzi	Nzema		f		[v]
+nzi	Nzema		t̪		[t̪]
+nzi	Nzema		t̪		[d̪]
+nzi	Nzema		d̪
+nzi	Nzema		n		[n]
+nzi	Nzema		n		[l̃]
+nzi	Nzema		s		[s]
+nzi	Nzema		s		[z]
+nzi	Nzema		l
+nzi	Nzema		cç		[cç]
+nzi	Nzema		cç		[ɟʝ]
+nzi	Nzema		cç		[ʃ]
+nzi	Nzema		cçʷ		[cçʷ]
+nzi	Nzema		cçʷ		[ɟʝʷ]
+nzi	Nzema		ɟʝ
+nzi	Nzema		ɟʝʷ
+nzi	Nzema		ɲ
+nzi	Nzema		ɲʷ
+nzi	Nzema		ʃ
+nzi	Nzema		ʃʷ
+nzi	Nzema		j
+nzi	Nzema		k		[k]
+nzi	Nzema		k		[ɡ]
+nzi	Nzema		k		[h]
+nzi	Nzema		ɡ
+nzi	Nzema		ɡʷ
+nzi	Nzema		ŋ
+nzi	Nzema		h
+nzi	Nzema		˦
+nzi	Nzema		˨
+
 aha	Ahanta		i				tano.pdf
-aha	Ahanta		ɪ				
-aha	Ahanta		e				
-aha	Ahanta		ɛ				
-aha	Ahanta		a		[a]		
-aha	Ahanta		a		[ɜ]		
-aha	Ahanta		ɔ				
-aha	Ahanta		o				
-aha	Ahanta		ʊ				
-aha	Ahanta		u				
-aha	Ahanta		ɪ̃				
-aha	Ahanta		ĩ				
-aha	Ahanta		ã				
-aha	Ahanta		ʊ̃				
-aha	Ahanta		ũ				
-aha	Ahanta		kp		[kp]		
-aha	Ahanta		kp		[ɡb]		
-aha	Ahanta		b		[b]		
-aha	Ahanta		b		[ɣ]		
-aha	Ahanta		m				
-aha	Ahanta		w				
-aha	Ahanta		f		[f]		
-aha	Ahanta		f		[v]		
-aha	Ahanta		t̪		[t̪]		
-aha	Ahanta		t̪		[d̪]		
-aha	Ahanta		d̪				
-aha	Ahanta		n		[n]		
-aha	Ahanta		n		[l̃]		
-aha	Ahanta		s		[s]		
-aha	Ahanta		s		[z]		
-aha	Ahanta		l				
-aha	Ahanta		cç		[cç]		
-aha	Ahanta		cç		[ɟʝ]		
-aha	Ahanta		cç		[ʃ]		
-aha	Ahanta		cçʷ		[cçʷ]		
-aha	Ahanta		cçʷ		[ɟʝʷ]		
-aha	Ahanta		ɟʝ				
-aha	Ahanta		ɟʝʷ				
-aha	Ahanta		ɲ				
-aha	Ahanta		ɲʷ				
-aha	Ahanta		ʃ				
-aha	Ahanta		ʃʷ				
-aha	Ahanta		j				
-aha	Ahanta		k		[k]		
-aha	Ahanta		k		[ɡ]		
-aha	Ahanta		k		[h]		
-aha	Ahanta		ɡ				
-aha	Ahanta		ɡʷ				
-aha	Ahanta		ŋ				
-aha	Ahanta		h				
-aha	Ahanta		˦				
-aha	Ahanta		˨				
-							
+aha	Ahanta		ɪ
+aha	Ahanta		e
+aha	Ahanta		ɛ
+aha	Ahanta		a		[a]
+aha	Ahanta		a		[ɜ]
+aha	Ahanta		ɔ
+aha	Ahanta		o
+aha	Ahanta		ʊ
+aha	Ahanta		u
+aha	Ahanta		ɪ̃
+aha	Ahanta		ĩ
+aha	Ahanta		ã
+aha	Ahanta		ʊ̃
+aha	Ahanta		ũ
+aha	Ahanta		kp		[kp]
+aha	Ahanta		kp		[ɡb]
+aha	Ahanta		b		[b]
+aha	Ahanta		b		[ɣ]
+aha	Ahanta		m
+aha	Ahanta		w
+aha	Ahanta		f		[f]
+aha	Ahanta		f		[v]
+aha	Ahanta		t̪		[t̪]
+aha	Ahanta		t̪		[d̪]
+aha	Ahanta		d̪
+aha	Ahanta		n		[n]
+aha	Ahanta		n		[l̃]
+aha	Ahanta		s		[s]
+aha	Ahanta		s		[z]
+aha	Ahanta		l
+aha	Ahanta		cç		[cç]
+aha	Ahanta		cç		[ɟʝ]
+aha	Ahanta		cç		[ʃ]
+aha	Ahanta		cçʷ		[cçʷ]
+aha	Ahanta		cçʷ		[ɟʝʷ]
+aha	Ahanta		ɟʝ
+aha	Ahanta		ɟʝʷ
+aha	Ahanta		ɲ
+aha	Ahanta		ɲʷ
+aha	Ahanta		ʃ
+aha	Ahanta		ʃʷ
+aha	Ahanta		j
+aha	Ahanta		k		[k]
+aha	Ahanta		k		[ɡ]
+aha	Ahanta		k		[h]
+aha	Ahanta		ɡ
+aha	Ahanta		ɡʷ
+aha	Ahanta		ŋ
+aha	Ahanta		h
+aha	Ahanta		˦
+aha	Ahanta		˨
+
 hna	Besleri		i		[i]		hna.pdf
-hna	Besleri		i		[ɨ]		
-hna	Besleri		ɛ		[ɛ]		
-hna	Besleri		ɛ		[æ]		
-hna	Besleri		ɛː				
-hna	Besleri		ɘ				
-hna	Besleri		a				
-hna	Besleri		aː				
-hna	Besleri		u		[u]		
-hna	Besleri		u		[ʉ]		
-hna	Besleri		uː				
-hna	Besleri		ɔ				
-hna	Besleri		˦				
-hna	Besleri		˨				
-hna	Besleri		p				
-hna	Besleri		b				
-hna	Besleri		bʷ				
-hna	Besleri		ɓ				
-hna	Besleri		f				
-hna	Besleri		v				
-hna	Besleri		m				
-hna	Besleri		mp				
-hna	Besleri		mb				
-hna	Besleri		ɱv				
-hna	Besleri		w				
-hna	Besleri		t				
-hna	Besleri		d				
-hna	Besleri		ɗ				
-hna	Besleri		s		[s]		
-hna	Besleri		s		[ʃ]		
-hna	Besleri		z		[z]		
-hna	Besleri		z		[ʒ]		
-hna	Besleri		ts		[ts]		
-hna	Besleri		ts		[t̠ʃ]		
-hna	Besleri		dz		[dz]		
-hna	Besleri		dz		[d̠ʒ]		
-hna	Besleri		n				
-hna	Besleri		nt				
-hna	Besleri		nd				
-hna	Besleri		nts				
-hna	Besleri		ndz		[ndz]		
-hna	Besleri		ndz		[n̠d̠ʒ]		
-hna	Besleri		l				
-hna	Besleri		r				
-hna	Besleri		ɬ				
-hna	Besleri		ɮ				
-hna	Besleri		j				
-hna	Besleri		k				
-hna	Besleri		ɡ				
-hna	Besleri		kʷ				
-hna	Besleri		ɡʷ				
-hna	Besleri		ŋ				
-hna	Besleri		ŋk				
-hna	Besleri		ŋɡ				
-hna	Besleri		ŋkʷ				
-hna	Besleri		ŋɡʷ				
-hna	Besleri		ʔ				
-hna	Besleri		h				
-							
+hna	Besleri		i		[ɨ]
+hna	Besleri		ɛ		[ɛ]
+hna	Besleri		ɛ		[æ]
+hna	Besleri		ɛː
+hna	Besleri		ɘ
+hna	Besleri		a
+hna	Besleri		aː
+hna	Besleri		u		[u]
+hna	Besleri		u		[ʉ]
+hna	Besleri		uː
+hna	Besleri		ɔ
+hna	Besleri		˦
+hna	Besleri		˨
+hna	Besleri		p
+hna	Besleri		b
+hna	Besleri		bʷ
+hna	Besleri		ɓ
+hna	Besleri		f
+hna	Besleri		v
+hna	Besleri		m
+hna	Besleri		mp
+hna	Besleri		mb
+hna	Besleri		ɱv
+hna	Besleri		w
+hna	Besleri		t
+hna	Besleri		d
+hna	Besleri		ɗ
+hna	Besleri		s		[s]
+hna	Besleri		s		[ʃ]
+hna	Besleri		z		[z]
+hna	Besleri		z		[ʒ]
+hna	Besleri		ts		[ts]
+hna	Besleri		ts		[t̠ʃ]
+hna	Besleri		dz		[dz]
+hna	Besleri		dz		[d̠ʒ]
+hna	Besleri		n
+hna	Besleri		nt
+hna	Besleri		nd
+hna	Besleri		nts
+hna	Besleri		ndz		[ndz]
+hna	Besleri		ndz		[n̠d̠ʒ]
+hna	Besleri		l
+hna	Besleri		r
+hna	Besleri		ɬ
+hna	Besleri		ɮ
+hna	Besleri		j
+hna	Besleri		k
+hna	Besleri		ɡ
+hna	Besleri		kʷ
+hna	Besleri		ɡʷ
+hna	Besleri		ŋ
+hna	Besleri		ŋk
+hna	Besleri		ŋɡ
+hna	Besleri		ŋkʷ
+hna	Besleri		ŋɡʷ
+hna	Besleri		ʔ
+hna	Besleri		h
+
 bhs	Buwal		p				bhs.pdf
-bhs	Buwal		b				
-bhs	Buwal		mb				
-bhs	Buwal		ɓ		[ɓ]		
-bhs	Buwal		ɓ		[p̚]		
-bhs	Buwal		f				
-bhs	Buwal		v				
-bhs	Buwal		m				
-bhs	Buwal		t				
-bhs	Buwal		d				
-bhs	Buwal		nd				
-bhs	Buwal		ɗ		[ɗ]		
-bhs	Buwal		ɗ		[t̚]		
-bhs	Buwal		ɬ				
-bhs	Buwal		ɮ				
-bhs	Buwal		n		[n]		
-bhs	Buwal		n		[ŋ]		
-bhs	Buwal		l				
-bhs	Buwal		r		[ɾ]		
-bhs	Buwal		r		[r]		
-bhs	Buwal		ts		[ts]		
-bhs	Buwal		ts		[t̠ʃ]		
-bhs	Buwal		dz		[dz]		
-bhs	Buwal		dz		[d̠ʒ]		
-bhs	Buwal		ndz		[ndz]		
-bhs	Buwal		ndz		[n̠d̠ʒ]		
-bhs	Buwal		s		[s]		
-bhs	Buwal		s		[ʃ]		
-bhs	Buwal		z		[z]		
-bhs	Buwal		z		[ʒ]		
-bhs	Buwal		j				
-bhs	Buwal		k				
-bhs	Buwal		ɡ				
-bhs	Buwal		ŋɡ				
-bhs	Buwal		x		[x]		
-bhs	Buwal		x		[h]		
-bhs	Buwal		ɣ				
-bhs	Buwal		ŋ				
-bhs	Buwal		kʷ				
-bhs	Buwal		ɡʷ				
-bhs	Buwal		ŋɡʷ				
-bhs	Buwal		xʷ				
-bhs	Buwal		ɣʷ				
-bhs	Buwal		ŋʷ				
-bhs	Buwal		w				
-bhs	Buwal		<kp>	rare			
-bhs	Buwal		ɡb				
-bhs	Buwal		ŋmɡb				
-bhs	Buwal		ə		[ə]		
-bhs	Buwal		ə		[ʊ]		
-bhs	Buwal		ə		[i]		
-bhs	Buwal		ə		[ɪ]		
-bhs	Buwal		ə		[ʏ]		
-bhs	Buwal		ɑ		[ɑ]		
-bhs	Buwal		ɑ		[o]		
-bhs	Buwal		ɑ		[ɔ]		
-bhs	Buwal		ɑ		[ɛ]		
-bhs	Buwal		ɑ		[œ]		
-bhs	Buwal		ɑ		[e]		
-bhs	Buwal		˦				
-bhs	Buwal		˨				
-bhs	Buwal		˧				
-							
+bhs	Buwal		b
+bhs	Buwal		mb
+bhs	Buwal		ɓ		[ɓ]
+bhs	Buwal		ɓ		[p̚]
+bhs	Buwal		f
+bhs	Buwal		v
+bhs	Buwal		m
+bhs	Buwal		t
+bhs	Buwal		d
+bhs	Buwal		nd
+bhs	Buwal		ɗ		[ɗ]
+bhs	Buwal		ɗ		[t̚]
+bhs	Buwal		ɬ
+bhs	Buwal		ɮ
+bhs	Buwal		n		[n]
+bhs	Buwal		n		[ŋ]
+bhs	Buwal		l
+bhs	Buwal		r		[ɾ]
+bhs	Buwal		r		[r]
+bhs	Buwal		ts		[ts]
+bhs	Buwal		ts		[t̠ʃ]
+bhs	Buwal		dz		[dz]
+bhs	Buwal		dz		[d̠ʒ]
+bhs	Buwal		ndz		[ndz]
+bhs	Buwal		ndz		[n̠d̠ʒ]
+bhs	Buwal		s		[s]
+bhs	Buwal		s		[ʃ]
+bhs	Buwal		z		[z]
+bhs	Buwal		z		[ʒ]
+bhs	Buwal		j
+bhs	Buwal		k
+bhs	Buwal		ɡ
+bhs	Buwal		ŋɡ
+bhs	Buwal		x		[x]
+bhs	Buwal		x		[h]
+bhs	Buwal		ɣ
+bhs	Buwal		ŋ
+bhs	Buwal		kʷ
+bhs	Buwal		ɡʷ
+bhs	Buwal		ŋɡʷ
+bhs	Buwal		xʷ
+bhs	Buwal		ɣʷ
+bhs	Buwal		ŋʷ
+bhs	Buwal		w
+bhs	Buwal		<kp>	rare
+bhs	Buwal		ɡb
+bhs	Buwal		ŋmɡb
+bhs	Buwal		ə		[ə]
+bhs	Buwal		ə		[ʊ]
+bhs	Buwal		ə		[i]
+bhs	Buwal		ə		[ɪ]
+bhs	Buwal		ə		[ʏ]
+bhs	Buwal		ɑ		[ɑ]
+bhs	Buwal		ɑ		[o]
+bhs	Buwal		ɑ		[ɔ]
+bhs	Buwal		ɑ		[ɛ]
+bhs	Buwal		ɑ		[œ]
+bhs	Buwal		ɑ		[e]
+bhs	Buwal		˦
+bhs	Buwal		˨
+bhs	Buwal		˧
+
 xed	Hide		mb				langermann.pdf;xed.pdf
-xed	Hide		nd				
-xed	Hide		ndz		[ndz]		
-xed	Hide		ndz		[n̠d̠ʒ]		
-xed	Hide		nz				
-xed	Hide		ŋɡ		[ŋɡ]		
-xed	Hide		ŋɡ		[ŋ]		
-xed	Hide		ŋɡʷ				
-xed	Hide		p				
-xed	Hide		b		[b]		
-xed	Hide		b		[p]		
-xed	Hide		t				
-xed	Hide		d				
-xed	Hide		k		[k]		
-xed	Hide		k		[kʷ]		
-xed	Hide		ɡ		[ɡ]		
-xed	Hide		ɡ		[ɡʷ]		
-xed	Hide		ɓ				
-xed	Hide		ɗ				
-xed	Hide		ts		[ts]		
-xed	Hide		ts		[t̠ʃ]		
-xed	Hide		dz		[dz]		
-xed	Hide		dz		[d̠ʒ]		
-xed	Hide		f				
-xed	Hide		v				
-xed	Hide		s		[s]		
-xed	Hide		s		[ʃ]		
-xed	Hide		z				
-xed	Hide		χ				
-xed	Hide		ʁ				
-xed	Hide		ɬ				
-xed	Hide		ɮ				
-xed	Hide		m				
-xed	Hide		n				
-xed	Hide		r				
-xed	Hide		l				
-xed	Hide		j				
-xed	Hide		w				
-xed	Hide		i				
-xed	Hide		a		[a]		
-xed	Hide		a		[ɛ]		
-xed	Hide		a		[ʌ]		
-xed	Hide		a		[e]		
-xed	Hide		a		[o]		
-xed	Hide		ə		[ə]		
-xed	Hide		ə		[œ]		
-xed	Hide		u		[u]		
-xed	Hide		u		[o]		
-xed	Hide		fʷ				
-xed	Hide		vʷ				
-xed	Hide		sʷ				
-xed	Hide		zʷ				
-xed	Hide		χʷ				
-xed	Hide		ʁʷ				
-xed	Hide		ʔ				
-							
+xed	Hide		nd
+xed	Hide		ndz		[ndz]
+xed	Hide		ndz		[n̠d̠ʒ]
+xed	Hide		nz
+xed	Hide		ŋɡ		[ŋɡ]
+xed	Hide		ŋɡ		[ŋ]
+xed	Hide		ŋɡʷ
+xed	Hide		p
+xed	Hide		b		[b]
+xed	Hide		b		[p]
+xed	Hide		t
+xed	Hide		d
+xed	Hide		k		[k]
+xed	Hide		k		[kʷ]
+xed	Hide		ɡ		[ɡ]
+xed	Hide		ɡ		[ɡʷ]
+xed	Hide		ɓ
+xed	Hide		ɗ
+xed	Hide		ts		[ts]
+xed	Hide		ts		[t̠ʃ]
+xed	Hide		dz		[dz]
+xed	Hide		dz		[d̠ʒ]
+xed	Hide		f
+xed	Hide		v
+xed	Hide		s		[s]
+xed	Hide		s		[ʃ]
+xed	Hide		z
+xed	Hide		χ
+xed	Hide		ʁ
+xed	Hide		ɬ
+xed	Hide		ɮ
+xed	Hide		m
+xed	Hide		n
+xed	Hide		r
+xed	Hide		l
+xed	Hide		j
+xed	Hide		w
+xed	Hide		i
+xed	Hide		a		[a]
+xed	Hide		a		[ɛ]
+xed	Hide		a		[ʌ]
+xed	Hide		a		[e]
+xed	Hide		a		[o]
+xed	Hide		ə		[ə]
+xed	Hide		ə		[œ]
+xed	Hide		u		[u]
+xed	Hide		u		[o]
+xed	Hide		fʷ
+xed	Hide		vʷ
+xed	Hide		sʷ
+xed	Hide		zʷ
+xed	Hide		χʷ
+xed	Hide		ʁʷ
+xed	Hide		ʔ
+
 hia	Lamang		mb				langermann.pdf
-hia	Lamang		nd				
-hia	Lamang		ŋɡ				
-hia	Lamang		ŋɡʷ				
-hia	Lamang		ndz				
-hia	Lamang		nz				
-hia	Lamang		ŋʷ				
-hia	Lamang		i		[i]		
-hia	Lamang		i		[ɨ]		
-hia	Lamang		e		[e]		
-hia	Lamang		e		[o]		
-hia	Lamang		e		[ɛ]		
-hia	Lamang		e		[ɔ]		
-hia	Lamang		a		[a]		
-hia	Lamang		a		[ə]		
-hia	Lamang		u		[u]		
-hia	Lamang		u		[ʉ]		
-hia	Lamang		p				
-hia	Lamang		b				
-hia	Lamang		ɓ				
-hia	Lamang		f				
-hia	Lamang		v				
-hia	Lamang		m				
-hia	Lamang		j				
-hia	Lamang		w				
-hia	Lamang		ʔ				
-hia	Lamang		t				
-hia	Lamang		d				
-hia	Lamang		ɗ				
-hia	Lamang		ts				
-hia	Lamang		dz				
-hia	Lamang		s				
-hia	Lamang		z				
-hia	Lamang		θ				
-hia	Lamang		ð				
-hia	Lamang		n				
-hia	Lamang		r				
-hia	Lamang		l				
-hia	Lamang		k				
-hia	Lamang		ɡ				
-hia	Lamang		x				
-hia	Lamang		ɣ				
-hia	Lamang		ŋ				
-hia	Lamang		ɡʷ				
-hia	Lamang		ɣʷ				
-hia	Lamang		xʷ				
-hia	Lamang		kʷ				
-							
+hia	Lamang		nd
+hia	Lamang		ŋɡ
+hia	Lamang		ŋɡʷ
+hia	Lamang		ndz
+hia	Lamang		nz
+hia	Lamang		ŋʷ
+hia	Lamang		i		[i]
+hia	Lamang		i		[ɨ]
+hia	Lamang		e		[e]
+hia	Lamang		e		[o]
+hia	Lamang		e		[ɛ]
+hia	Lamang		e		[ɔ]
+hia	Lamang		a		[a]
+hia	Lamang		a		[ə]
+hia	Lamang		u		[u]
+hia	Lamang		u		[ʉ]
+hia	Lamang		p
+hia	Lamang		b
+hia	Lamang		ɓ
+hia	Lamang		f
+hia	Lamang		v
+hia	Lamang		m
+hia	Lamang		j
+hia	Lamang		w
+hia	Lamang		ʔ
+hia	Lamang		t
+hia	Lamang		d
+hia	Lamang		ɗ
+hia	Lamang		ts
+hia	Lamang		dz
+hia	Lamang		s
+hia	Lamang		z
+hia	Lamang		θ
+hia	Lamang		ð
+hia	Lamang		n
+hia	Lamang		r
+hia	Lamang		l
+hia	Lamang		k
+hia	Lamang		ɡ
+hia	Lamang		x
+hia	Lamang		ɣ
+hia	Lamang		ŋ
+hia	Lamang		ɡʷ
+hia	Lamang		ɣʷ
+hia	Lamang		xʷ
+hia	Lamang		kʷ
+
 ikw	Ikwere		i				ikw.pdf
-ikw	Ikwere		ɪ				
-ikw	Ikwere		e				
-ikw	Ikwere		ɛ				
-ikw	Ikwere		a				
-ikw	Ikwere		u				
-ikw	Ikwere		ʊ				
-ikw	Ikwere		o				
-ikw	Ikwere		ɔ				
-ikw	Ikwere		ĩ				
-ikw	Ikwere		ɪ̃				
-ikw	Ikwere		ẽ				
-ikw	Ikwere		ɛ̃				
-ikw	Ikwere		ã				
-ikw	Ikwere		ũ				
-ikw	Ikwere		ʊ̃				
-ikw	Ikwere		õ				
-ikw	Ikwere		ɔ̃				
-ikw	Ikwere		p				
-ikw	Ikwere		b		[b]		
-ikw	Ikwere		b		[bⁿ]		
-ikw	Ikwere		t				
-ikw	Ikwere		d		[d]		
-ikw	Ikwere		d		[dⁿ]		
-ikw	Ikwere		t̠ʃ				
-ikw	Ikwere		d̠ʒ				
-ikw	Ikwere		k				
-ikw	Ikwere		ɡ				
-ikw	Ikwere		kʷ				
-ikw	Ikwere		ɡʷ				
-ikw	Ikwere		f				
-ikw	Ikwere		v				
-ikw	Ikwere		s				
-ikw	Ikwere		z				
-ikw	Ikwere		l		[l]		
-ikw	Ikwere		l		[n]		
-ikw	Ikwere		ɹ		[ɹ]		
-ikw	Ikwere		ɹ		[ɹ̃]		
-ikw	Ikwere		j		[j]		
-ikw	Ikwere		j		[j̃]		
-ikw	Ikwere		ɣ		[ɣ]		
-ikw	Ikwere		ɣ		[ɣ̃]		
-ikw	Ikwere		w		[w]		
-ikw	Ikwere		w		[w̃]		
-ikw	Ikwere		h		[h]		
-ikw	Ikwere		h		[h̃]		
-ikw	Ikwere		hʷ		[hʷ]		
-ikw	Ikwere		hʷ		[h̃ʷ]		
-ikw	Ikwere		b͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚); previously b̚	[b͉]		
-ikw	Ikwere		b͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚).	[m]		
-ikw	Ikwere		ˀb͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚); previously ʔb̚	[ˀb͉]		
-ikw	Ikwere		ˀb͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚); previously ʔb̚	[ʔm]		
-ikw	Ikwere		˦				
-ikw	Ikwere		˨				
-ikw	Ikwere		˦˨				
-ikw	Ikwere		˨˦				
-ikw	Ikwere		↓˦				
-							
+ikw	Ikwere		ɪ
+ikw	Ikwere		e
+ikw	Ikwere		ɛ
+ikw	Ikwere		a
+ikw	Ikwere		u
+ikw	Ikwere		ʊ
+ikw	Ikwere		o
+ikw	Ikwere		ɔ
+ikw	Ikwere		ĩ
+ikw	Ikwere		ɪ̃
+ikw	Ikwere		ẽ
+ikw	Ikwere		ɛ̃
+ikw	Ikwere		ã
+ikw	Ikwere		ũ
+ikw	Ikwere		ʊ̃
+ikw	Ikwere		õ
+ikw	Ikwere		ɔ̃
+ikw	Ikwere		p
+ikw	Ikwere		b		[b]
+ikw	Ikwere		b		[bⁿ]
+ikw	Ikwere		t
+ikw	Ikwere		d		[d]
+ikw	Ikwere		d		[dⁿ]
+ikw	Ikwere		t̠ʃ
+ikw	Ikwere		d̠ʒ
+ikw	Ikwere		k
+ikw	Ikwere		ɡ
+ikw	Ikwere		kʷ
+ikw	Ikwere		ɡʷ
+ikw	Ikwere		f
+ikw	Ikwere		v
+ikw	Ikwere		s
+ikw	Ikwere		z
+ikw	Ikwere		l		[l]
+ikw	Ikwere		l		[n]
+ikw	Ikwere		ɹ		[ɹ]
+ikw	Ikwere		ɹ		[ɹ̃]
+ikw	Ikwere		j		[j]
+ikw	Ikwere		j		[j̃]
+ikw	Ikwere		ɣ		[ɣ]
+ikw	Ikwere		ɣ		[ɣ̃]
+ikw	Ikwere		w		[w]
+ikw	Ikwere		w		[w̃]
+ikw	Ikwere		h		[h]
+ikw	Ikwere		h		[h̃]
+ikw	Ikwere		hʷ		[hʷ]
+ikw	Ikwere		hʷ		[h̃ʷ]
+ikw	Ikwere		b͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚); previously b̚	[b͉]
+ikw	Ikwere		b͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚).	[m]
+ikw	Ikwere		ˀb͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚); previously ʔb̚	[ˀb͉]
+ikw	Ikwere		ˀb͉	non-explosive, non-implosive stop; after reading this and another paper by the same guys, this would be most accurately represented as [ˀɓ]. However, they are at pains to claim that this is NOT an implosive sound for some reason.  So Richard and I decided the best choice would be to call this sound [ˀb͉] (lenis diacritic) and the corresponding unglottalized version as [b͉] (which the previous person had transcribed as b̚); previously ʔb̚	[ʔm]
+ikw	Ikwere		˦
+ikw	Ikwere		˨
+ikw	Ikwere		˦˨
+ikw	Ikwere		˨˦
+ikw	Ikwere		↓˦
+
 kot	Lagwan		<t̠ʃ>	loanwords only			kot.pdf
-kot	Lagwan		<d̠ʒ>	loanwords only			
-kot	Lagwan		<ʃ>	loanwords only			
-kot	Lagwan		<ʔ>	loanwords only			
-kot	Lagwan		p				
-kot	Lagwan		b				
-kot	Lagwan		f				
-kot	Lagwan		v				
-kot	Lagwan		ɓ				
-kot	Lagwan		m				
-kot	Lagwan		t				
-kot	Lagwan		d				
-kot	Lagwan		s		[s]		
-kot	Lagwan		s		[ʃ]		
-kot	Lagwan		z				
-kot	Lagwan		ɬ				
-kot	Lagwan		<ɮ>	marɡinal			
-kot	Lagwan		ɗ				
-kot	Lagwan		sʼ				
-kot	Lagwan		ɬʼ		[ɬʼ]		
-kot	Lagwan		ɬʼ		[tɬʼ]		
-kot	Lagwan		n		[n]		
-kot	Lagwan		n		[ŋ]		
-kot	Lagwan		n		[ɴ]		
-kot	Lagwan		l				
-kot	Lagwan		ɾ		[ɾ]		
-kot	Lagwan		ɾ		[r̥]		
-kot	Lagwan		j				
-kot	Lagwan		k				
-kot	Lagwan		ɡ				
-kot	Lagwan		x		[x]		
-kot	Lagwan		x		[χ]		
-kot	Lagwan		ʁ				
-kot	Lagwan		kʼ				
-kot	Lagwan		kʷʼ				
-kot	Lagwan		w				
-kot	Lagwan		kʷ				
-kot	Lagwan		ɡʷ				
-kot	Lagwan		xʷ		[xʷ]		
-kot	Lagwan		xʷ		[χʷ]		
-kot	Lagwan		ʁʷ				
-kot	Lagwan		a				
-kot	Lagwan		e				
-kot	Lagwan		i				
-kot	Lagwan		u				
-kot	Lagwan		o				
-kot	Lagwan		˦				
-kot	Lagwan		˨				
-							
+kot	Lagwan		<d̠ʒ>	loanwords only
+kot	Lagwan		<ʃ>	loanwords only
+kot	Lagwan		<ʔ>	loanwords only
+kot	Lagwan		p
+kot	Lagwan		b
+kot	Lagwan		f
+kot	Lagwan		v
+kot	Lagwan		ɓ
+kot	Lagwan		m
+kot	Lagwan		t
+kot	Lagwan		d
+kot	Lagwan		s		[s]
+kot	Lagwan		s		[ʃ]
+kot	Lagwan		z
+kot	Lagwan		ɬ
+kot	Lagwan		<ɮ>	marɡinal
+kot	Lagwan		ɗ
+kot	Lagwan		sʼ
+kot	Lagwan		ɬʼ		[ɬʼ]
+kot	Lagwan		ɬʼ		[tɬʼ]
+kot	Lagwan		n		[n]
+kot	Lagwan		n		[ŋ]
+kot	Lagwan		n		[ɴ]
+kot	Lagwan		l
+kot	Lagwan		ɾ		[ɾ]
+kot	Lagwan		ɾ		[r̥]
+kot	Lagwan		j
+kot	Lagwan		k
+kot	Lagwan		ɡ
+kot	Lagwan		x		[x]
+kot	Lagwan		x		[χ]
+kot	Lagwan		ʁ
+kot	Lagwan		kʼ
+kot	Lagwan		kʷʼ
+kot	Lagwan		w
+kot	Lagwan		kʷ
+kot	Lagwan		ɡʷ
+kot	Lagwan		xʷ		[xʷ]
+kot	Lagwan		xʷ		[χʷ]
+kot	Lagwan		ʁʷ
+kot	Lagwan		a
+kot	Lagwan		e
+kot	Lagwan		i
+kot	Lagwan		u
+kot	Lagwan		o
+kot	Lagwan		˦
+kot	Lagwan		˨
+
 gmm	Mbodomo		p				gmm.pdf
-gmm	Mbodomo		b				
-gmm	Mbodomo		ɓ				
-gmm	Mbodomo		mb				
-gmm	Mbodomo		f				
-gmm	Mbodomo		v				
-gmm	Mbodomo		m				
-gmm	Mbodomo		t				
-gmm	Mbodomo		d				
-gmm	Mbodomo		ɗ				
-gmm	Mbodomo		nd				
-gmm	Mbodomo		s				
-gmm	Mbodomo		z				
-gmm	Mbodomo		n				
-gmm	Mbodomo		l		[l]		
-gmm	Mbodomo		l		[ɺ]		
-gmm	Mbodomo		r				
-gmm	Mbodomo		nz		[nz]	free variation	
-gmm	Mbodomo		nz		[ndz]	free variation	
-gmm	Mbodomo		ɲ				
-gmm	Mbodomo		j				
-gmm	Mbodomo		k		[k]		
-gmm	Mbodomo		k		[χ]		
-gmm	Mbodomo		ɡ		[ɡ]		
-gmm	Mbodomo		ɡ		[ʁ]		
-gmm	Mbodomo		ŋɡ				
-gmm	Mbodomo		ŋ				
-gmm	Mbodomo		h				
-gmm	Mbodomo		kp				
-gmm	Mbodomo		ɡb				
-gmm	Mbodomo		ŋmɡb				
-gmm	Mbodomo		w				
-gmm	Mbodomo		e		[e]		
-gmm	Mbodomo		e		[ɛᵊ]		
-gmm	Mbodomo		a		[a]		
-gmm	Mbodomo		a		[ɑ]		
-gmm	Mbodomo		i		[i]		
-gmm	Mbodomo		i		[iᵊ]		
-gmm	Mbodomo		ɛ				
-gmm	Mbodomo		u				
-gmm	Mbodomo		o				
-gmm	Mbodomo		ɔ				
-gmm	Mbodomo		˦				
-gmm	Mbodomo		˨				
-gmm	Mbodomo		˧				
-							
+gmm	Mbodomo		b
+gmm	Mbodomo		ɓ
+gmm	Mbodomo		mb
+gmm	Mbodomo		f
+gmm	Mbodomo		v
+gmm	Mbodomo		m
+gmm	Mbodomo		t
+gmm	Mbodomo		d
+gmm	Mbodomo		ɗ
+gmm	Mbodomo		nd
+gmm	Mbodomo		s
+gmm	Mbodomo		z
+gmm	Mbodomo		n
+gmm	Mbodomo		l		[l]
+gmm	Mbodomo		l		[ɺ]
+gmm	Mbodomo		r
+gmm	Mbodomo		nz		[nz]	free variation
+gmm	Mbodomo		nz		[ndz]	free variation
+gmm	Mbodomo		ɲ
+gmm	Mbodomo		j
+gmm	Mbodomo		k		[k]
+gmm	Mbodomo		k		[χ]
+gmm	Mbodomo		ɡ		[ɡ]
+gmm	Mbodomo		ɡ		[ʁ]
+gmm	Mbodomo		ŋɡ
+gmm	Mbodomo		ŋ
+gmm	Mbodomo		h
+gmm	Mbodomo		kp
+gmm	Mbodomo		ɡb
+gmm	Mbodomo		ŋmɡb
+gmm	Mbodomo		w
+gmm	Mbodomo		e		[e]
+gmm	Mbodomo		e		[ɛᵊ]
+gmm	Mbodomo		a		[a]
+gmm	Mbodomo		a		[ɑ]
+gmm	Mbodomo		i		[i]
+gmm	Mbodomo		i		[iᵊ]
+gmm	Mbodomo		ɛ
+gmm	Mbodomo		u
+gmm	Mbodomo		o
+gmm	Mbodomo		ɔ
+gmm	Mbodomo		˦
+gmm	Mbodomo		˨
+gmm	Mbodomo		˧
+
 mqb	Mbuko		p				mqb.pdf
-mqb	Mbuko		ɓ				
-mqb	Mbuko		b				
-mqb	Mbuko		f				
-mqb	Mbuko		v				
-mqb	Mbuko		m				
-mqb	Mbuko		mb				
-mqb	Mbuko		t				
-mqb	Mbuko		d				
-mqb	Mbuko		ɗ				
-mqb	Mbuko		ɬ				
-mqb	Mbuko		ɮ				
-mqb	Mbuko		n		[n]		
-mqb	Mbuko		n		[ŋ]		
-mqb	Mbuko		nd				
-mqb	Mbuko		l				
-mqb	Mbuko		r				
-mqb	Mbuko		ts		[ts]		
-mqb	Mbuko		ts		[t̠ʃ]		
-mqb	Mbuko		dz		[dz]		
-mqb	Mbuko		dz		[d̠ʒ]		
-mqb	Mbuko		s		[s]		
-mqb	Mbuko		s		[ʃ]		
-mqb	Mbuko		z		[z]		
-mqb	Mbuko		z		[ʒ]		
-mqb	Mbuko		ndz		[ndz]		
-mqb	Mbuko		ndz		[n̠d̠ʒ]		
-mqb	Mbuko		j				
-mqb	Mbuko		k				
-mqb	Mbuko		ɡ				
-mqb	Mbuko		h		[h]		
-mqb	Mbuko		h		[x]		
-mqb	Mbuko		ŋɡ				
-mqb	Mbuko		ʔ				
-mqb	Mbuko		kp				
-mqb	Mbuko		hʷ				
-mqb	Mbuko		ŋmɡb				
-mqb	Mbuko		w				
-mqb	Mbuko		ə				
-mqb	Mbuko		a				
-mqb	Mbuko		i				
-mqb	Mbuko		e				
-mqb	Mbuko		u				
-mqb	Mbuko		y				
-mqb	Mbuko		œ				
-mqb	Mbuko		u				
-mqb	Mbuko		o				
-mqb	Mbuko		kʷ				
-mqb	Mbuko		ɡʷ				
-mqb	Mbuko		ŋɡʷ				
-mqb	Mbuko		˦				
-mqb	Mbuko		˨				
-mqb	Mbuko		˧				
-							
+mqb	Mbuko		ɓ
+mqb	Mbuko		b
+mqb	Mbuko		f
+mqb	Mbuko		v
+mqb	Mbuko		m
+mqb	Mbuko		mb
+mqb	Mbuko		t
+mqb	Mbuko		d
+mqb	Mbuko		ɗ
+mqb	Mbuko		ɬ
+mqb	Mbuko		ɮ
+mqb	Mbuko		n		[n]
+mqb	Mbuko		n		[ŋ]
+mqb	Mbuko		nd
+mqb	Mbuko		l
+mqb	Mbuko		r
+mqb	Mbuko		ts		[ts]
+mqb	Mbuko		ts		[t̠ʃ]
+mqb	Mbuko		dz		[dz]
+mqb	Mbuko		dz		[d̠ʒ]
+mqb	Mbuko		s		[s]
+mqb	Mbuko		s		[ʃ]
+mqb	Mbuko		z		[z]
+mqb	Mbuko		z		[ʒ]
+mqb	Mbuko		ndz		[ndz]
+mqb	Mbuko		ndz		[n̠d̠ʒ]
+mqb	Mbuko		j
+mqb	Mbuko		k
+mqb	Mbuko		ɡ
+mqb	Mbuko		h		[h]
+mqb	Mbuko		h		[x]
+mqb	Mbuko		ŋɡ
+mqb	Mbuko		ʔ
+mqb	Mbuko		kp
+mqb	Mbuko		hʷ
+mqb	Mbuko		ŋmɡb
+mqb	Mbuko		w
+mqb	Mbuko		ə
+mqb	Mbuko		a
+mqb	Mbuko		i
+mqb	Mbuko		e
+mqb	Mbuko		u
+mqb	Mbuko		y
+mqb	Mbuko		œ
+mqb	Mbuko		u
+mqb	Mbuko		o
+mqb	Mbuko		kʷ
+mqb	Mbuko		ɡʷ
+mqb	Mbuko		ŋɡʷ
+mqb	Mbuko		˦
+mqb	Mbuko		˨
+mqb	Mbuko		˧
+
 mlw	Moloko		mb				mlw.pdf
-mlw	Moloko		nd				
-mlw	Moloko		nz		[nz]		
-mlw	Moloko		nz		[nʒ]		
-mlw	Moloko		ŋɡ		[ŋɡ]		
-mlw	Moloko		ŋɡ		[ŋɡʷ]		
-mlw	Moloko		i				
-mlw	Moloko		ɪ				
-mlw	Moloko		ɛ				
-mlw	Moloko		æ				
-mlw	Moloko		ɘ				
-mlw	Moloko		a				
-mlw	Moloko		u				
-mlw	Moloko		ʊ				
-mlw	Moloko		ɔ				
-mlw	Moloko		œ				
-mlw	Moloko		p				
-mlw	Moloko		b				
-mlw	Moloko		ɓ				
-mlw	Moloko		f				
-mlw	Moloko		v				
-mlw	Moloko		m				
-mlw	Moloko		t				
-mlw	Moloko		d				
-mlw	Moloko		ɗ				
-mlw	Moloko		ts		[ts]		
-mlw	Moloko		ts		[t̠ʃ]		
-mlw	Moloko		dz		[dz]		
-mlw	Moloko		dz		[d̠ʒ]		
-mlw	Moloko		s		[s]		
-mlw	Moloko		s		[ʃ]		
-mlw	Moloko		z		[z]		
-mlw	Moloko		z		[ʒ]		
-mlw	Moloko		ɬ				
-mlw	Moloko		ɮ				
-mlw	Moloko		l				
-mlw	Moloko		r				
-mlw	Moloko		j		[j]		
-mlw	Moloko		j		[i]		
-mlw	Moloko		n		[n]		
-mlw	Moloko		n		[ŋ]		
-mlw	Moloko		k		[k]		
-mlw	Moloko		k		[kʷ]		
-mlw	Moloko		ɡ		[ɡ]		
-mlw	Moloko		ɡ		[ɡʷ]		
-mlw	Moloko		h		[h]		
-mlw	Moloko		h		[x]		
-mlw	Moloko		kʷ				
-mlw	Moloko		ɡʷ				
-mlw	Moloko		ŋɡʷ				
-mlw	Moloko		hʷ				
-mlw	Moloko		w		[w]		
-mlw	Moloko		w		[u]		
-mlw	Moloko		˦				
-mlw	Moloko		˨				
-mlw	Moloko		˦˨˦				
-mlw	Moloko		˨˦˨				
-mlw	Moloko		˦˨				
-mlw	Moloko		˨˦				
-							
+mlw	Moloko		nd
+mlw	Moloko		nz		[nz]
+mlw	Moloko		nz		[nʒ]
+mlw	Moloko		ŋɡ		[ŋɡ]
+mlw	Moloko		ŋɡ		[ŋɡʷ]
+mlw	Moloko		i
+mlw	Moloko		ɪ
+mlw	Moloko		ɛ
+mlw	Moloko		æ
+mlw	Moloko		ɘ
+mlw	Moloko		a
+mlw	Moloko		u
+mlw	Moloko		ʊ
+mlw	Moloko		ɔ
+mlw	Moloko		œ
+mlw	Moloko		p
+mlw	Moloko		b
+mlw	Moloko		ɓ
+mlw	Moloko		f
+mlw	Moloko		v
+mlw	Moloko		m
+mlw	Moloko		t
+mlw	Moloko		d
+mlw	Moloko		ɗ
+mlw	Moloko		ts		[ts]
+mlw	Moloko		ts		[t̠ʃ]
+mlw	Moloko		dz		[dz]
+mlw	Moloko		dz		[d̠ʒ]
+mlw	Moloko		s		[s]
+mlw	Moloko		s		[ʃ]
+mlw	Moloko		z		[z]
+mlw	Moloko		z		[ʒ]
+mlw	Moloko		ɬ
+mlw	Moloko		ɮ
+mlw	Moloko		l
+mlw	Moloko		r
+mlw	Moloko		j		[j]
+mlw	Moloko		j		[i]
+mlw	Moloko		n		[n]
+mlw	Moloko		n		[ŋ]
+mlw	Moloko		k		[k]
+mlw	Moloko		k		[kʷ]
+mlw	Moloko		ɡ		[ɡ]
+mlw	Moloko		ɡ		[ɡʷ]
+mlw	Moloko		h		[h]
+mlw	Moloko		h		[x]
+mlw	Moloko		kʷ
+mlw	Moloko		ɡʷ
+mlw	Moloko		ŋɡʷ
+mlw	Moloko		hʷ
+mlw	Moloko		w		[w]
+mlw	Moloko		w		[u]
+mlw	Moloko		˦
+mlw	Moloko		˨
+mlw	Moloko		˦˨˦
+mlw	Moloko		˨˦˨
+mlw	Moloko		˦˨
+mlw	Moloko		˨˦
+
 muy	Muyang		p				muy.pdf
-muy	Muyang		b				
-muy	Muyang		mb				
-muy	Muyang		ɓ				
-muy	Muyang		f				
-muy	Muyang		v				
-muy	Muyang		m				
-muy	Muyang		t				
-muy	Muyang		d				
-muy	Muyang		nd				
-muy	Muyang		ɗ				
-muy	Muyang		ɬ				
-muy	Muyang		ɮ				
-muy	Muyang		l				
-muy	Muyang		r				
-muy	Muyang		ts		[ts]		
-muy	Muyang		ts		[t̠ʃ]		
-muy	Muyang		dz		[dz]		
-muy	Muyang		dz		[d̠ʒ]		
-muy	Muyang		ndz		[ndz]		
-muy	Muyang		ndz		[n̠d̠ʒ]		
-muy	Muyang		s		[s]		
-muy	Muyang		s		[ʃ]		
-muy	Muyang		z		[z]		
-muy	Muyang		z		[ʒ]		
-muy	Muyang		n		[n]		
-muy	Muyang		n		[ɲ]		
-muy	Muyang		n		[ŋ]		
-muy	Muyang		j				
-muy	Muyang		k		[k]		
-muy	Muyang		k		[kʷ]		
-muy	Muyang		ɡ		[ɡ]		
-muy	Muyang		ɡ		[ɡʷ]		
-muy	Muyang		ŋɡ		[ŋɡ]		
-muy	Muyang		ŋɡ		[ŋɡʷ]		
-muy	Muyang		x		[x]		
-muy	Muyang		x		[xʷ]		
-muy	Muyang		x		[h]		
-muy	Muyang		x		[hʷ]		
-muy	Muyang		w				
-muy	Muyang		ʏ				
-muy	Muyang		y				
-muy	Muyang		ø				
-muy	Muyang		œ				
-muy	Muyang		ɪ				
-muy	Muyang		i				
-muy	Muyang		e				
-muy	Muyang		ɛ		[ɛ]		
-muy	Muyang		ɛ		[æ]		
-muy	Muyang		ə				
-muy	Muyang		a				
-muy	Muyang		ʊ				
-muy	Muyang		u				
-muy	Muyang		o				
-muy	Muyang		ɔ				
-muy	Muyang		˦				
-muy	Muyang		˨				
-muy	Muyang		˧				
-muy	Muyang		˨˦				
-muy	Muyang		˦˨				
-							
+muy	Muyang		b
+muy	Muyang		mb
+muy	Muyang		ɓ
+muy	Muyang		f
+muy	Muyang		v
+muy	Muyang		m
+muy	Muyang		t
+muy	Muyang		d
+muy	Muyang		nd
+muy	Muyang		ɗ
+muy	Muyang		ɬ
+muy	Muyang		ɮ
+muy	Muyang		l
+muy	Muyang		r
+muy	Muyang		ts		[ts]
+muy	Muyang		ts		[t̠ʃ]
+muy	Muyang		dz		[dz]
+muy	Muyang		dz		[d̠ʒ]
+muy	Muyang		ndz		[ndz]
+muy	Muyang		ndz		[n̠d̠ʒ]
+muy	Muyang		s		[s]
+muy	Muyang		s		[ʃ]
+muy	Muyang		z		[z]
+muy	Muyang		z		[ʒ]
+muy	Muyang		n		[n]
+muy	Muyang		n		[ɲ]
+muy	Muyang		n		[ŋ]
+muy	Muyang		j
+muy	Muyang		k		[k]
+muy	Muyang		k		[kʷ]
+muy	Muyang		ɡ		[ɡ]
+muy	Muyang		ɡ		[ɡʷ]
+muy	Muyang		ŋɡ		[ŋɡ]
+muy	Muyang		ŋɡ		[ŋɡʷ]
+muy	Muyang		x		[x]
+muy	Muyang		x		[xʷ]
+muy	Muyang		x		[h]
+muy	Muyang		x		[hʷ]
+muy	Muyang		w
+muy	Muyang		ʏ
+muy	Muyang		y
+muy	Muyang		ø
+muy	Muyang		œ
+muy	Muyang		ɪ
+muy	Muyang		i
+muy	Muyang		e
+muy	Muyang		ɛ		[ɛ]
+muy	Muyang		ɛ		[æ]
+muy	Muyang		ə
+muy	Muyang		a
+muy	Muyang		ʊ
+muy	Muyang		u
+muy	Muyang		o
+muy	Muyang		ɔ
+muy	Muyang		˦
+muy	Muyang		˨
+muy	Muyang		˧
+muy	Muyang		˨˦
+muy	Muyang		˦˨
+
 jgo	Ngomba		p		[p]		jgo.pdf
-jgo	Ngomba		p		[b]		
-jgo	Ngomba		p		[p̚]		
-jgo	Ngomba		p		[bʲ]		
-jgo	Ngomba		f				
-jgo	Ngomba		v				
-jgo	Ngomba		pf		[pf]		
-jgo	Ngomba		pf		[bv]		
-jgo	Ngomba		m				
-jgo	Ngomba		w		[w]		
-jgo	Ngomba		w		[ɥ]		
-jgo	Ngomba		w		[ɰ]		
-jgo	Ngomba		t		[t]		
-jgo	Ngomba		t		[t̚]		
-jgo	Ngomba		t		[d]		
-jgo	Ngomba		t		[ɾ]		
-jgo	Ngomba		t		[tʰ]		
-jgo	Ngomba		t		[t̪̚]		
-jgo	Ngomba		t		[tç]		
-jgo	Ngomba		s		[s]		
-jgo	Ngomba		s		[ʃ]		
-jgo	Ngomba		z		[ʒ]		
-jgo	Ngomba		z		[d̠ʒ]		
-jgo	Ngomba		z		[dz]		
-jgo	Ngomba		z		[ɟʝ]	updated from [dʝ]	
-jgo	Ngomba		z		[z]		
-jgo	Ngomba		ts		[ts]		
-jgo	Ngomba		ts		[t̠ʃ]		
-jgo	Ngomba		n		[n]		
-jgo	Ngomba		n		[ɲ]		
-jgo	Ngomba		n		[ŋ]		
-jgo	Ngomba		l		[l]		
-jgo	Ngomba		l		[d]		
-jgo	Ngomba		j				
-jgo	Ngomba		k		[k]		
-jgo	Ngomba		k		[k̚]		
-jgo	Ngomba		k		[ɡ]		
-jgo	Ngomba		k		[cʰ]		
-jgo	Ngomba		k		[kʰ]		
-jgo	Ngomba		k		[kx]		
-jgo	Ngomba		k		[cç]		
-jgo	Ngomba		ɣ		[ɣ]		
-jgo	Ngomba		ɣ		[ɡ]		
-jgo	Ngomba		ɣ		[ɟ]		
-jgo	Ngomba		ɣ		[ɡɣ]		
-jgo	Ngomba		ŋ				
-jgo	Ngomba		ʔ				
-jgo	Ngomba		i		[i]		
-jgo	Ngomba		i		[ɪ]		
-jgo	Ngomba		i		[iː]		
-jgo	Ngomba		i		[y]		
-jgo	Ngomba		ɛ		[ɛ]		
-jgo	Ngomba		ɛ		[ə]		
-jgo	Ngomba		ɛ		[ɛ̝]		
-jgo	Ngomba		ɛ		[ɛ̝ː]		
-jgo	Ngomba		u		[u]		
-jgo	Ngomba		u		[ʊ]		
-jgo	Ngomba		u		[uː]		
-jgo	Ngomba		ɔ		[ɔ]		
-jgo	Ngomba		ɔ		[ɔ̝]		
-jgo	Ngomba		ɔ		[ɤ]		
-jgo	Ngomba		ɔ		[ɔ̝ː]		
-jgo	Ngomba		a		[a]		
-jgo	Ngomba		a		[aː]		
-jgo	Ngomba		ɨ		[ɨ]		
-jgo	Ngomba		ɨ		[ɨː]		
-jgo	Ngomba		˦		[˦]		
-jgo	Ngomba		˦		[↓˦]		
-jgo	Ngomba		˨				
-jgo	Ngomba		q̚	listed in phone inventory, not in phoneme inventory, but no explanation of its properties/relation to some phoneme			
-jgo	Ngomba		ʁ	listed in phone inventory, not in phoneme inventory, but no explanation of its properties/relation to some phoneme			
-							
+jgo	Ngomba		p		[b]
+jgo	Ngomba		p		[p̚]
+jgo	Ngomba		p		[bʲ]
+jgo	Ngomba		f
+jgo	Ngomba		v
+jgo	Ngomba		pf		[pf]
+jgo	Ngomba		pf		[bv]
+jgo	Ngomba		m
+jgo	Ngomba		w		[w]
+jgo	Ngomba		w		[ɥ]
+jgo	Ngomba		w		[ɰ]
+jgo	Ngomba		t		[t]
+jgo	Ngomba		t		[t̚]
+jgo	Ngomba		t		[d]
+jgo	Ngomba		t		[ɾ]
+jgo	Ngomba		t		[tʰ]
+jgo	Ngomba		t		[t̪̚]
+jgo	Ngomba		t		[tç]
+jgo	Ngomba		s		[s]
+jgo	Ngomba		s		[ʃ]
+jgo	Ngomba		z		[ʒ]
+jgo	Ngomba		z		[d̠ʒ]
+jgo	Ngomba		z		[dz]
+jgo	Ngomba		z		[ɟʝ]	updated from [dʝ]
+jgo	Ngomba		z		[z]
+jgo	Ngomba		ts		[ts]
+jgo	Ngomba		ts		[t̠ʃ]
+jgo	Ngomba		n		[n]
+jgo	Ngomba		n		[ɲ]
+jgo	Ngomba		n		[ŋ]
+jgo	Ngomba		l		[l]
+jgo	Ngomba		l		[d]
+jgo	Ngomba		j
+jgo	Ngomba		k		[k]
+jgo	Ngomba		k		[k̚]
+jgo	Ngomba		k		[ɡ]
+jgo	Ngomba		k		[cʰ]
+jgo	Ngomba		k		[kʰ]
+jgo	Ngomba		k		[kx]
+jgo	Ngomba		k		[cç]
+jgo	Ngomba		ɣ		[ɣ]
+jgo	Ngomba		ɣ		[ɡ]
+jgo	Ngomba		ɣ		[ɟ]
+jgo	Ngomba		ɣ		[ɡɣ]
+jgo	Ngomba		ŋ
+jgo	Ngomba		ʔ
+jgo	Ngomba		i		[i]
+jgo	Ngomba		i		[ɪ]
+jgo	Ngomba		i		[iː]
+jgo	Ngomba		i		[y]
+jgo	Ngomba		ɛ		[ɛ]
+jgo	Ngomba		ɛ		[ə]
+jgo	Ngomba		ɛ		[ɛ̝]
+jgo	Ngomba		ɛ		[ɛ̝ː]
+jgo	Ngomba		u		[u]
+jgo	Ngomba		u		[ʊ]
+jgo	Ngomba		u		[uː]
+jgo	Ngomba		ɔ		[ɔ]
+jgo	Ngomba		ɔ		[ɔ̝]
+jgo	Ngomba		ɔ		[ɤ]
+jgo	Ngomba		ɔ		[ɔ̝ː]
+jgo	Ngomba		a		[a]
+jgo	Ngomba		a		[aː]
+jgo	Ngomba		ɨ		[ɨ]
+jgo	Ngomba		ɨ		[ɨː]
+jgo	Ngomba		˦		[˦]
+jgo	Ngomba		˦		[↓˦]
+jgo	Ngomba		˨
+jgo	Ngomba		q̚	listed in phone inventory, not in phoneme inventory, but no explanation of its properties/relation to some phoneme
+jgo	Ngomba		ʁ	listed in phone inventory, not in phoneme inventory, but no explanation of its properties/relation to some phoneme
+
 dmo	Kemezung		˦				dmo.pdf
-dmo	Kemezung		˨		[˨]		
-dmo	Kemezung		˨		[˩		
-dmo	Kemezung		˧				
-dmo	Kemezung		˨˧				
-dmo	Kemezung		˨˧				
-dmo	Kemezung		˧˨				
-dmo	Kemezung		˥˩				
-dmo	Kemezung		ɜ		[ɜ]		
-dmo	Kemezung		ɜ		[ɜ̃]		
-dmo	Kemezung		ə		[ə]		
-dmo	Kemezung		ə		[ə̃]		
-dmo	Kemezung		b				
-dmo	Kemezung		f				
-dmo	Kemezung		m				
-dmo	Kemezung		t				
-dmo	Kemezung		d				
-dmo	Kemezung		ts		[ts]		
-dmo	Kemezung		ts		[t̠ʃ]		
-dmo	Kemezung		dz		[dz]		
-dmo	Kemezung		dz		[d̠ʒ]		
-dmo	Kemezung		s		[s]		
-dmo	Kemezung		s		[ʃ]		
-dmo	Kemezung		s		[ɾ]		
-dmo	Kemezung		n				
-dmo	Kemezung		l		[l]		
-dmo	Kemezung		l		[d]		
-dmo	Kemezung		ɲ				
-dmo	Kemezung		j		[j]		
-dmo	Kemezung		j		[ʒ]		
-dmo	Kemezung		k				
-dmo	Kemezung		ɡ				
-dmo	Kemezung		ŋ				
-dmo	Kemezung		kp				
-dmo	Kemezung		ɡb				
-dmo	Kemezung		w				
-dmo	Kemezung		<h>	marɡinal			
-dmo	Kemezung		<kpʷ>	questionable			
-dmo	Kemezung		i		[ĩ]		
-dmo	Kemezung		e		[ẽ]		
-dmo	Kemezung		ɛ		[ɛ̃]		
-dmo	Kemezung		u		[ũ]		
-dmo	Kemezung		o		[õ]		
-dmo	Kemezung		ɔ		[ɔ̃]		
-dmo	Kemezung		i		[i]		
-dmo	Kemezung		e		[e]		
-dmo	Kemezung		ɛ		[ɛ]		
-dmo	Kemezung		u		[u]		
-dmo	Kemezung		o		[o]		
-dmo	Kemezung		ɔ		[ɔ]		
-							
+dmo	Kemezung		˨		[˨]
+dmo	Kemezung		˨		[˩
+dmo	Kemezung		˧
+dmo	Kemezung		˨˧
+dmo	Kemezung		˨˧
+dmo	Kemezung		˧˨
+dmo	Kemezung		˥˩
+dmo	Kemezung		ɜ		[ɜ]
+dmo	Kemezung		ɜ		[ɜ̃]
+dmo	Kemezung		ə		[ə]
+dmo	Kemezung		ə		[ə̃]
+dmo	Kemezung		b
+dmo	Kemezung		f
+dmo	Kemezung		m
+dmo	Kemezung		t
+dmo	Kemezung		d
+dmo	Kemezung		ts		[ts]
+dmo	Kemezung		ts		[t̠ʃ]
+dmo	Kemezung		dz		[dz]
+dmo	Kemezung		dz		[d̠ʒ]
+dmo	Kemezung		s		[s]
+dmo	Kemezung		s		[ʃ]
+dmo	Kemezung		s		[ɾ]
+dmo	Kemezung		n
+dmo	Kemezung		l		[l]
+dmo	Kemezung		l		[d]
+dmo	Kemezung		ɲ
+dmo	Kemezung		j		[j]
+dmo	Kemezung		j		[ʒ]
+dmo	Kemezung		k
+dmo	Kemezung		ɡ
+dmo	Kemezung		ŋ
+dmo	Kemezung		kp
+dmo	Kemezung		ɡb
+dmo	Kemezung		w
+dmo	Kemezung		<h>	marɡinal
+dmo	Kemezung		<kpʷ>	questionable
+dmo	Kemezung		i		[ĩ]
+dmo	Kemezung		e		[ẽ]
+dmo	Kemezung		ɛ		[ɛ̃]
+dmo	Kemezung		u		[ũ]
+dmo	Kemezung		o		[õ]
+dmo	Kemezung		ɔ		[ɔ̃]
+dmo	Kemezung		i		[i]
+dmo	Kemezung		e		[e]
+dmo	Kemezung		ɛ		[ɛ]
+dmo	Kemezung		u		[u]
+dmo	Kemezung		o		[o]
+dmo	Kemezung		ɔ		[ɔ]
+
 ntm	Nateni		i		[i]		ntm.pdf
-ntm	Nateni		i		[j]		
-ntm	Nateni		i		[ə]		
-ntm	Nateni		i		[ɨ]		
-ntm	Nateni		e		[e]		
-ntm	Nateni		e		[ə]		
-ntm	Nateni		ɛ				
-ntm	Nateni		a		[a]		
-ntm	Nateni		a		[ʌ]		
-ntm	Nateni		ɔ				
-ntm	Nateni		o				
-ntm	Nateni		u		[u]		
-ntm	Nateni		u		[w]		
-ntm	Nateni		ĩ				
-ntm	Nateni		ɛ̃				
-ntm	Nateni		ã				
-ntm	Nateni		ɔ̃				
-ntm	Nateni		ũ				
-ntm	Nateni		p		[p]		
-ntm	Nateni		p		[b]		
-ntm	Nateni		b		[b]		
-ntm	Nateni		b		[m]		
-ntm	Nateni		t		[t]		
-ntm	Nateni		t		[d]		
-ntm	Nateni		d		[d]		
-ntm	Nateni		d		[r]		
-ntm	Nateni		d		[l]		
-ntm	Nateni		d		[n]		
-ntm	Nateni		c		[c]		
-ntm	Nateni		c		[ɟ]		
-ntm	Nateni		ɟ		[ɟ]		
-ntm	Nateni		ɟ		[ɲ]		
-ntm	Nateni		k		[k]		
-ntm	Nateni		k		[kʷ]		
-ntm	Nateni		k		[ɡ]		
-ntm	Nateni		kp		[kp]		
-ntm	Nateni		kp		[kʷ]		
-ntm	Nateni		f				
-ntm	Nateni		s				
-ntm	Nateni		j				
-ntm	Nateni		h				
-ntm	Nateni		w				
-ntm	Nateni		˦				
-ntm	Nateni		˨				
-ntm	Nateni		˧				
-ntm	Nateni		i				
-ntm	Nateni		e				
-ntm	Nateni		ɛ				
-ntm	Nateni		u				
-ntm	Nateni		o				
-ntm	Nateni		ɔ				
-ntm	Nateni		a				
-ntm	Nateni		ĩ				
-ntm	Nateni		ɛ̃				
-ntm	Nateni		ũ				
-ntm	Nateni		ɔ̃				
-ntm	Nateni		ã				
-ntm	Nateni		iː				
-ntm	Nateni		eː				
-ntm	Nateni		ɛː				
-ntm	Nateni		aː				
-ntm	Nateni		uː				
-ntm	Nateni		oː				
-ntm	Nateni		ɔː				
-ntm	Nateni		ĩː				
-ntm	Nateni		ɛ̃ː				
-ntm	Nateni		ãː				
-ntm	Nateni		ũː				
-ntm	Nateni		ɔ̃ː				
-							
+ntm	Nateni		i		[j]
+ntm	Nateni		i		[ə]
+ntm	Nateni		i		[ɨ]
+ntm	Nateni		e		[e]
+ntm	Nateni		e		[ə]
+ntm	Nateni		ɛ
+ntm	Nateni		a		[a]
+ntm	Nateni		a		[ʌ]
+ntm	Nateni		ɔ
+ntm	Nateni		o
+ntm	Nateni		u		[u]
+ntm	Nateni		u		[w]
+ntm	Nateni		ĩ
+ntm	Nateni		ɛ̃
+ntm	Nateni		ã
+ntm	Nateni		ɔ̃
+ntm	Nateni		ũ
+ntm	Nateni		p		[p]
+ntm	Nateni		p		[b]
+ntm	Nateni		b		[b]
+ntm	Nateni		b		[m]
+ntm	Nateni		t		[t]
+ntm	Nateni		t		[d]
+ntm	Nateni		d		[d]
+ntm	Nateni		d		[r]
+ntm	Nateni		d		[l]
+ntm	Nateni		d		[n]
+ntm	Nateni		c		[c]
+ntm	Nateni		c		[ɟ]
+ntm	Nateni		ɟ		[ɟ]
+ntm	Nateni		ɟ		[ɲ]
+ntm	Nateni		k		[k]
+ntm	Nateni		k		[kʷ]
+ntm	Nateni		k		[ɡ]
+ntm	Nateni		kp		[kp]
+ntm	Nateni		kp		[kʷ]
+ntm	Nateni		f
+ntm	Nateni		s
+ntm	Nateni		j
+ntm	Nateni		h
+ntm	Nateni		w
+ntm	Nateni		˦
+ntm	Nateni		˨
+ntm	Nateni		˧
+ntm	Nateni		i
+ntm	Nateni		e
+ntm	Nateni		ɛ
+ntm	Nateni		u
+ntm	Nateni		o
+ntm	Nateni		ɔ
+ntm	Nateni		a
+ntm	Nateni		ĩ
+ntm	Nateni		ɛ̃
+ntm	Nateni		ũ
+ntm	Nateni		ɔ̃
+ntm	Nateni		ã
+ntm	Nateni		iː
+ntm	Nateni		eː
+ntm	Nateni		ɛː
+ntm	Nateni		aː
+ntm	Nateni		uː
+ntm	Nateni		oː
+ntm	Nateni		ɔː
+ntm	Nateni		ĩː
+ntm	Nateni		ɛ̃ː
+ntm	Nateni		ãː
+ntm	Nateni		ũː
+ntm	Nateni		ɔ̃ː
+
 stv	Silt'i		b		[b]		stv.pdf
-stv	Silt'i		b		[p]		
-stv	Silt'i		b		[pʰ]		
-stv	Silt'i		b		[bʱ]		
-stv	Silt'i		bː				
-stv	Silt'i		f		[f]		
-stv	Silt'i		f		[v]		
-stv	Silt'i		fː				
-stv	Silt'i		m		[m]		
-stv	Silt'i		m		[m̚]		
-stv	Silt'i		mː				
-stv	Silt'i		w				
-stv	Silt'i		wː				
-stv	Silt'i		t		[t]		
-stv	Silt'i		t		[tʰ]		
-stv	Silt'i		tː		[tʰː]		
-stv	Silt'i		tː		[tː]		
-stv	Silt'i		tː		[tʰː]		
-stv	Silt'i		d		[d]		
-stv	Silt'i		d		[dʱ]		
-stv	Silt'i		dː				
-stv	Silt'i		tʼ				
-stv	Silt'i		tʼː				
-stv	Silt'i		s				
-stv	Silt'i		sː				
-stv	Silt'i		z				
-stv	Silt'i		zː				
-stv	Silt'i		n		[n]		
-stv	Silt'i		n		[n̚]		
-stv	Silt'i		n		[n̪]		
-stv	Silt'i		nː				
-stv	Silt'i		l		[l]		
-stv	Silt'i		l		[l̥]		
-stv	Silt'i		lː				
-stv	Silt'i		r		[r]		
-stv	Silt'i		r		[r̥]		
-stv	Silt'i		rː				
-stv	Silt'i		t̠ʃ		[t̠ʃ]		
-stv	Silt'i		t̠ʃ		[t̠ʃʰ]		
-stv	Silt'i		t̠ʃː		[t̠ʃː]		
-stv	Silt'i		t̠ʃː		[t̠ʃʰː]		
-stv	Silt'i		d̠ʒ		[d̠ʒ]		
-stv	Silt'i		d̠ʒ		[d̠ʒʰ]		
-stv	Silt'i		d̠ʒː				
-stv	Silt'i		t̠ʃʼ				
-stv	Silt'i		t̠ʃʼː				
-stv	Silt'i		ʃ				
-stv	Silt'i		ʃː				
-stv	Silt'i		ʒ				
-stv	Silt'i		ʒː				
-stv	Silt'i		ɲ		[ɲ]		
-stv	Silt'i		ɲ		[ɲ̚]		
-stv	Silt'i		ɲː				
-stv	Silt'i		j				
-stv	Silt'i		jː				
-stv	Silt'i		k		[k]		
-stv	Silt'i		k		[kʰ]		
-stv	Silt'i		k		[k̟]		
-stv	Silt'i		k		[k̠]		
-stv	Silt'i		kː		[kː]		
-stv	Silt'i		kː		[kʰː]		
-stv	Silt'i		ɡ		[ɡ]		
-stv	Silt'i		ɡ		[ɡʱ]		
-stv	Silt'i		ɡ		[ɡ̠]		
-stv	Silt'i		ɡ		[ɡ̟]		
-stv	Silt'i		ɡː				
-stv	Silt'i		kʼ		[kʼ]		
-stv	Silt'i		kʼ		[k̟ʼ]		
-stv	Silt'i		kʼ		[k̠ʼ]		
-stv	Silt'i		kʼː				
-stv	Silt'i		h		[h]		
-stv	Silt'i		h		[x]		
-stv	Silt'i		ʔ				
-stv	Silt'i		i		[i]		
-stv	Silt'i		i		[i̥]		
-stv	Silt'i		i		[ɨ]		
-stv	Silt'i		i		[ɨ̥]		
-stv	Silt'i		iː				
-stv	Silt'i		e		[e]		
-stv	Silt'i		e		[e̥]		
-stv	Silt'i		eː				
-stv	Silt'i		ə		[ə]		
-stv	Silt'i		ə		[ɛ]		
-stv	Silt'i		ə		[ə̥]		
-stv	Silt'i		ə		[ɵ]		
-stv	Silt'i		ə		[a]		
-stv	Silt'i		ə		[ḁ]		
-stv	Silt'i		aː				
-stv	Silt'i		u		[u]		
-stv	Silt'i		u		[u̥]		
-stv	Silt'i		uː				
-stv	Silt'i		o		[o]		
-stv	Silt'i		o		[o̥]		
-stv	Silt'i		oː				
-							
+stv	Silt'i		b		[p]
+stv	Silt'i		b		[pʰ]
+stv	Silt'i		b		[bʱ]
+stv	Silt'i		bː
+stv	Silt'i		f		[f]
+stv	Silt'i		f		[v]
+stv	Silt'i		fː
+stv	Silt'i		m		[m]
+stv	Silt'i		m		[m̚]
+stv	Silt'i		mː
+stv	Silt'i		w
+stv	Silt'i		wː
+stv	Silt'i		t		[t]
+stv	Silt'i		t		[tʰ]
+stv	Silt'i		tː		[tʰː]
+stv	Silt'i		tː		[tː]
+stv	Silt'i		tː		[tʰː]
+stv	Silt'i		d		[d]
+stv	Silt'i		d		[dʱ]
+stv	Silt'i		dː
+stv	Silt'i		tʼ
+stv	Silt'i		tʼː
+stv	Silt'i		s
+stv	Silt'i		sː
+stv	Silt'i		z
+stv	Silt'i		zː
+stv	Silt'i		n		[n]
+stv	Silt'i		n		[n̚]
+stv	Silt'i		n		[n̪]
+stv	Silt'i		nː
+stv	Silt'i		l		[l]
+stv	Silt'i		l		[l̥]
+stv	Silt'i		lː
+stv	Silt'i		r		[r]
+stv	Silt'i		r		[r̥]
+stv	Silt'i		rː
+stv	Silt'i		t̠ʃ		[t̠ʃ]
+stv	Silt'i		t̠ʃ		[t̠ʃʰ]
+stv	Silt'i		t̠ʃː		[t̠ʃː]
+stv	Silt'i		t̠ʃː		[t̠ʃʰː]
+stv	Silt'i		d̠ʒ		[d̠ʒ]
+stv	Silt'i		d̠ʒ		[d̠ʒʰ]
+stv	Silt'i		d̠ʒː
+stv	Silt'i		t̠ʃʼ
+stv	Silt'i		t̠ʃʼː
+stv	Silt'i		ʃ
+stv	Silt'i		ʃː
+stv	Silt'i		ʒ
+stv	Silt'i		ʒː
+stv	Silt'i		ɲ		[ɲ]
+stv	Silt'i		ɲ		[ɲ̚]
+stv	Silt'i		ɲː
+stv	Silt'i		j
+stv	Silt'i		jː
+stv	Silt'i		k		[k]
+stv	Silt'i		k		[kʰ]
+stv	Silt'i		k		[k̟]
+stv	Silt'i		k		[k̠]
+stv	Silt'i		kː		[kː]
+stv	Silt'i		kː		[kʰː]
+stv	Silt'i		ɡ		[ɡ]
+stv	Silt'i		ɡ		[ɡʱ]
+stv	Silt'i		ɡ		[ɡ̠]
+stv	Silt'i		ɡ		[ɡ̟]
+stv	Silt'i		ɡː
+stv	Silt'i		kʼ		[kʼ]
+stv	Silt'i		kʼ		[k̟ʼ]
+stv	Silt'i		kʼ		[k̠ʼ]
+stv	Silt'i		kʼː
+stv	Silt'i		h		[h]
+stv	Silt'i		h		[x]
+stv	Silt'i		ʔ
+stv	Silt'i		i		[i]
+stv	Silt'i		i		[i̥]
+stv	Silt'i		i		[ɨ]
+stv	Silt'i		i		[ɨ̥]
+stv	Silt'i		iː
+stv	Silt'i		e		[e]
+stv	Silt'i		e		[e̥]
+stv	Silt'i		eː
+stv	Silt'i		ə		[ə]
+stv	Silt'i		ə		[ɛ]
+stv	Silt'i		ə		[ə̥]
+stv	Silt'i		ə		[ɵ]
+stv	Silt'i		ə		[a]
+stv	Silt'i		ə		[ḁ]
+stv	Silt'i		aː
+stv	Silt'i		u		[u]
+stv	Silt'i		u		[u̥]
+stv	Silt'i		uː
+stv	Silt'i		o		[o]
+stv	Silt'i		o		[o̥]
+stv	Silt'i		oː
+
 weh	Weh		b		[b]		weh.pdf
-weh	Weh		b		[p]		
-weh	Weh		b		[β]		
-weh	Weh		b		[bʷ]		
-weh	Weh		b		[bˠ]		
-weh	Weh		t		[t]		
-weh	Weh		t		[tʷ]		
-weh	Weh		t		[tʲ]		
-weh	Weh		d				
-weh	Weh		k		[k]		
-weh	Weh		k		[ʔ]		
-weh	Weh		k		[kʷ]		
-weh	Weh		k		[kʲ]		
-weh	Weh		ɡ		[ɡ]		
-weh	Weh		ɡ		[ɡʷ]		
-weh	Weh		kp		[kp]		
-weh	Weh		ɡb				
-weh	Weh		pf				
-weh	Weh		bv				
-weh	Weh		ts				
-weh	Weh		dz				
-weh	Weh		t̠ʃ				
-weh	Weh		d̠ʒ				
-weh	Weh		kx				
-weh	Weh		ɡɣ				
-weh	Weh		f		[f]		
-weh	Weh		f		[fʷ]		
-weh	Weh		f		[fˠ]		
-weh	Weh		v				
-weh	Weh		s				
-weh	Weh		z		[z]		
-weh	Weh		z		[zʷ]		
-weh	Weh		ʃ				
-weh	Weh		ʒ				
-weh	Weh		m		[m]		
-weh	Weh		m		[mʷ]		
-weh	Weh		n				
-weh	Weh		ɲ				
-weh	Weh		ŋ				
-weh	Weh		l		[l]		
-weh	Weh		l		[lʲ]		
-weh	Weh		j				
-weh	Weh		w				
-weh	Weh		<ɹ>	loanwords only			
-weh	Weh		<ɾ>	loanwords only			
-weh	Weh		mb				
-weh	Weh		mbv				
-weh	Weh		nd				
-weh	Weh		ndz				
-weh	Weh		n̠d̠ʒ				
-weh	Weh		ŋɡ		[ŋɡ]		
-weh	Weh		ŋɡ		[ŋɡʷ]		
-weh	Weh		ŋmɡb				
-weh	Weh		i		[i]		
-weh	Weh		i		[iː]		
-weh	Weh		i		[ɪ]		
-weh	Weh		e		[e]		
-weh	Weh		e		[ɛː]		
-weh	Weh		ɨ		[ɨ]		
-weh	Weh		ɨ		[əː]		
-weh	Weh		a		[a]		
-weh	Weh		a		[aː]		
-weh	Weh		u		[u]		
-weh	Weh		u		[uː]		
-weh	Weh		u		[ʊ]		
-weh	Weh		o		[o]		
-weh	Weh		o		[oː]		
-weh	Weh		ɔ		[ɔ]		
-weh	Weh		ɔ		[ɔː]		
-weh	Weh		˦˨				
-weh	Weh		˦				
-weh	Weh		˨				
+weh	Weh		b		[p]
+weh	Weh		b		[β]
+weh	Weh		b		[bʷ]
+weh	Weh		b		[bˠ]
+weh	Weh		t		[t]
+weh	Weh		t		[tʷ]
+weh	Weh		t		[tʲ]
+weh	Weh		d
+weh	Weh		k		[k]
+weh	Weh		k		[ʔ]
+weh	Weh		k		[kʷ]
+weh	Weh		k		[kʲ]
+weh	Weh		ɡ		[ɡ]
+weh	Weh		ɡ		[ɡʷ]
+weh	Weh		kp		[kp]
+weh	Weh		ɡb
+weh	Weh		pf
+weh	Weh		bv
+weh	Weh		ts
+weh	Weh		dz
+weh	Weh		t̠ʃ
+weh	Weh		d̠ʒ
+weh	Weh		kx
+weh	Weh		ɡɣ
+weh	Weh		f		[f]
+weh	Weh		f		[fʷ]
+weh	Weh		f		[fˠ]
+weh	Weh		v
+weh	Weh		s
+weh	Weh		z		[z]
+weh	Weh		z		[zʷ]
+weh	Weh		ʃ
+weh	Weh		ʒ
+weh	Weh		m		[m]
+weh	Weh		m		[mʷ]
+weh	Weh		n
+weh	Weh		ɲ
+weh	Weh		ŋ
+weh	Weh		l		[l]
+weh	Weh		l		[lʲ]
+weh	Weh		j
+weh	Weh		w
+weh	Weh		<ɹ>	loanwords only
+weh	Weh		<ɾ>	loanwords only
+weh	Weh		mb
+weh	Weh		mbv
+weh	Weh		nd
+weh	Weh		ndz
+weh	Weh		n̠d̠ʒ
+weh	Weh		ŋɡ		[ŋɡ]
+weh	Weh		ŋɡ		[ŋɡʷ]
+weh	Weh		ŋmɡb
+weh	Weh		i		[i]
+weh	Weh		i		[iː]
+weh	Weh		i		[ɪ]
+weh	Weh		e		[e]
+weh	Weh		e		[ɛː]
+weh	Weh		ɨ		[ɨ]
+weh	Weh		ɨ		[əː]
+weh	Weh		a		[a]
+weh	Weh		a		[aː]
+weh	Weh		u		[u]
+weh	Weh		u		[uː]
+weh	Weh		u		[ʊ]
+weh	Weh		o		[o]
+weh	Weh		o		[oː]
+weh	Weh		ɔ		[ɔ]
+weh	Weh		ɔ		[ɔː]
+weh	Weh		˦˨
+weh	Weh		˦
+weh	Weh		˨
 
 tey	Tulishi	Kamda	t̪				kadugli_krongo.pdf
-tey	Tulishi	Kamda	ʈ				
-tey	Tulishi	Kamda	<c>	questionable			
-tey	Tulishi	Kamda	k				
-tey	Tulishi	Kamda	b				
-tey	Tulishi	Kamda	ɟ				
-tey	Tulishi	Kamda	ɓ				
-tey	Tulishi	Kamda	ɗ				
-tey	Tulishi	Kamda	<ʄ>	questionable			
-tey	Tulishi	Kamda	f				
-tey	Tulishi	Kamda	s				
-tey	Tulishi	Kamda	h				
-tey	Tulishi	Kamda	m		[m]		
-tey	Tulishi	Kamda	m		[ŋ]		
-tey	Tulishi	Kamda	n		[n]		
-tey	Tulishi	Kamda	ɲ		[ɲ]		
-tey	Tulishi	Kamda	n		[ŋ]		
-tey	Tulishi	Kamda	ɲ		[ŋ]		
-tey	Tulishi	Kamda	l				
-tey	Tulishi	Kamda	r				
-tey	Tulishi	Kamda	w				
-tey	Tulishi	Kamda	j				
-tey	Tulishi	Kamda	t̪ː				
-tey	Tulishi	Kamda	ʈː				
-tey	Tulishi	Kamda	kː				
-tey	Tulishi	Kamda	ʔː				
-tey	Tulishi	Kamda	bː				
-tey	Tulishi	Kamda	ɟː				
-tey	Tulishi	Kamda	ɓː				
-tey	Tulishi	Kamda	ɗː				
-tey	Tulishi	Kamda	fː				
-tey	Tulishi	Kamda	sː				
-tey	Tulishi	Kamda	mː				
-tey	Tulishi	Kamda	nː				
-tey	Tulishi	Kamda	ɲː				
-tey	Tulishi	Kamda	ŋː				
-tey	Tulishi	Kamda	lː				
-tey	Tulishi	Kamda	rː				
-tey	Tulishi	Kamda	wː				
-tey	Tulishi	Kamda	jː				
-tey	Tulishi	Kamda	ɪ				
-tey	Tulishi	Kamda	ɛ				
-tey	Tulishi	Kamda	a				
-tey	Tulishi	Kamda	ʊ				
-tey	Tulishi	Kamda	ɔ				
-tey	Tulishi	Kamda	i				
-tey	Tulishi	Kamda	e				
-tey	Tulishi	Kamda	ə				
-tey	Tulishi	Kamda	u				
-tey	Tulishi	Kamda	o				
-tey	Tulishi	Kamda	ɪː				
-tey	Tulishi	Kamda	ɛː				
-tey	Tulishi	Kamda	aː				
-tey	Tulishi	Kamda	ʊː				
-tey	Tulishi	Kamda	ɔː				
-tey	Tulishi	Kamda	iː				
-tey	Tulishi	Kamda	eː				
-tey	Tulishi	Kamda	əː				
-tey	Tulishi	Kamda	ʊː				
-tey	Tulishi	Kamda	oː				
-tey	Tulishi	Kamda	˦				
-tey	Tulishi	Kamda	˨				
-tey	Tulishi	Kamda	˧				
-							
+tey	Tulishi	Kamda	ʈ
+tey	Tulishi	Kamda	<c>	questionable
+tey	Tulishi	Kamda	k
+tey	Tulishi	Kamda	b
+tey	Tulishi	Kamda	ɟ
+tey	Tulishi	Kamda	ɓ
+tey	Tulishi	Kamda	ɗ
+tey	Tulishi	Kamda	<ʄ>	questionable
+tey	Tulishi	Kamda	f
+tey	Tulishi	Kamda	s
+tey	Tulishi	Kamda	h
+tey	Tulishi	Kamda	m		[m]
+tey	Tulishi	Kamda	m		[ŋ]
+tey	Tulishi	Kamda	n		[n]
+tey	Tulishi	Kamda	ɲ		[ɲ]
+tey	Tulishi	Kamda	n		[ŋ]
+tey	Tulishi	Kamda	ɲ		[ŋ]
+tey	Tulishi	Kamda	l
+tey	Tulishi	Kamda	r
+tey	Tulishi	Kamda	w
+tey	Tulishi	Kamda	j
+tey	Tulishi	Kamda	t̪ː
+tey	Tulishi	Kamda	ʈː
+tey	Tulishi	Kamda	kː
+tey	Tulishi	Kamda	ʔː
+tey	Tulishi	Kamda	bː
+tey	Tulishi	Kamda	ɟː
+tey	Tulishi	Kamda	ɓː
+tey	Tulishi	Kamda	ɗː
+tey	Tulishi	Kamda	fː
+tey	Tulishi	Kamda	sː
+tey	Tulishi	Kamda	mː
+tey	Tulishi	Kamda	nː
+tey	Tulishi	Kamda	ɲː
+tey	Tulishi	Kamda	ŋː
+tey	Tulishi	Kamda	lː
+tey	Tulishi	Kamda	rː
+tey	Tulishi	Kamda	wː
+tey	Tulishi	Kamda	jː
+tey	Tulishi	Kamda	ɪ
+tey	Tulishi	Kamda	ɛ
+tey	Tulishi	Kamda	a
+tey	Tulishi	Kamda	ʊ
+tey	Tulishi	Kamda	ɔ
+tey	Tulishi	Kamda	i
+tey	Tulishi	Kamda	e
+tey	Tulishi	Kamda	ə
+tey	Tulishi	Kamda	u
+tey	Tulishi	Kamda	o
+tey	Tulishi	Kamda	ɪː
+tey	Tulishi	Kamda	ɛː
+tey	Tulishi	Kamda	aː
+tey	Tulishi	Kamda	ʊː
+tey	Tulishi	Kamda	ɔː
+tey	Tulishi	Kamda	iː
+tey	Tulishi	Kamda	eː
+tey	Tulishi	Kamda	əː
+tey	Tulishi	Kamda	ʊː
+tey	Tulishi	Kamda	oː
+tey	Tulishi	Kamda	˦
+tey	Tulishi	Kamda	˨
+tey	Tulishi	Kamda	˧
+
 kec	Keiga		p				kadugli_krongo.pdf
-kec	Keiga		t̪				
-kec	Keiga		ʈ				
-kec	Keiga		c				
-kec	Keiga		k				
-kec	Keiga		b				
-kec	Keiga		ɟ				
-kec	Keiga		ɗ				
-kec	Keiga		<ʄ>	questionable			
-kec	Keiga		f				
-kec	Keiga		s				
-kec	Keiga		m				
-kec	Keiga		n				
-kec	Keiga		ɲ				
-kec	Keiga		ŋ				
-kec	Keiga		l				
-kec	Keiga		r				
-kec	Keiga		w				
-kec	Keiga		j				
-kec	Keiga		pː				
-kec	Keiga		t̪ː				
-kec	Keiga		ʈː				
-kec	Keiga		cː				
-kec	Keiga		kː				
-kec	Keiga		bː				
-kec	Keiga		ɟː				
-kec	Keiga		ɗː				
-kec	Keiga		fː				
-kec	Keiga		sː				
-kec	Keiga		mː				
-kec	Keiga		nː				
-kec	Keiga		ɲː				
-kec	Keiga		ŋː				
-kec	Keiga		lː				
-kec	Keiga		rː				
-kec	Keiga		wː				
-kec	Keiga		jː				
-kec	Keiga		ɪ				
-kec	Keiga		ɪː				
-kec	Keiga		ɛ				
-kec	Keiga		ɛː				
-kec	Keiga		a				
-kec	Keiga		aː				
-kec	Keiga		ʊː				
-kec	Keiga		ʊ				
-kec	Keiga		ɔː				
-kec	Keiga		ɔ				
-kec	Keiga		i				
-kec	Keiga		iː				
-kec	Keiga		e				
-kec	Keiga		eː				
-kec	Keiga		ə				
-kec	Keiga		əː				
-kec	Keiga		u				
-kec	Keiga		uː				
-kec	Keiga		o				
-kec	Keiga		oː				
-kec	Keiga		˦				
-kec	Keiga		˨				
-							
+kec	Keiga		t̪
+kec	Keiga		ʈ
+kec	Keiga		c
+kec	Keiga		k
+kec	Keiga		b
+kec	Keiga		ɟ
+kec	Keiga		ɗ
+kec	Keiga		<ʄ>	questionable
+kec	Keiga		f
+kec	Keiga		s
+kec	Keiga		m
+kec	Keiga		n
+kec	Keiga		ɲ
+kec	Keiga		ŋ
+kec	Keiga		l
+kec	Keiga		r
+kec	Keiga		w
+kec	Keiga		j
+kec	Keiga		pː
+kec	Keiga		t̪ː
+kec	Keiga		ʈː
+kec	Keiga		cː
+kec	Keiga		kː
+kec	Keiga		bː
+kec	Keiga		ɟː
+kec	Keiga		ɗː
+kec	Keiga		fː
+kec	Keiga		sː
+kec	Keiga		mː
+kec	Keiga		nː
+kec	Keiga		ɲː
+kec	Keiga		ŋː
+kec	Keiga		lː
+kec	Keiga		rː
+kec	Keiga		wː
+kec	Keiga		jː
+kec	Keiga		ɪ
+kec	Keiga		ɪː
+kec	Keiga		ɛ
+kec	Keiga		ɛː
+kec	Keiga		a
+kec	Keiga		aː
+kec	Keiga		ʊː
+kec	Keiga		ʊ
+kec	Keiga		ɔː
+kec	Keiga		ɔ
+kec	Keiga		i
+kec	Keiga		iː
+kec	Keiga		e
+kec	Keiga		eː
+kec	Keiga		ə
+kec	Keiga		əː
+kec	Keiga		u
+kec	Keiga		uː
+kec	Keiga		o
+kec	Keiga		oː
+kec	Keiga		˦
+kec	Keiga		˨
+
 kgo	Krongo		p				kadugli_krongo.pdf
-kgo	Krongo		t̪		[t̪]		
-kgo	Krongo		t̪		[d̪ʉ		
-kgo	Krongo		ʈ		[ʈ]		
-kgo	Krongo		ʈ		[ɖ]		
-kgo	Krongo		c		[c]		
-kgo	Krongo		c		[ɟ]		
-kgo	Krongo		k		[k]		
-kgo	Krongo		k		[ɡ]		
-kgo	Krongo		ʔ				
-kgo	Krongo		b				
-kgo	Krongo		ɓ				
-kgo	Krongo		ɗ				
-kgo	Krongo		f				
-kgo	Krongo		s				
-kgo	Krongo		<ʃ>	questionable			
-kgo	Krongo		<ʄ>	questionable			
-kgo	Krongo		m				
-kgo	Krongo		n				
-kgo	Krongo		ɲ				
-kgo	Krongo		ŋ				
-kgo	Krongo		l				
-kgo	Krongo		r				
-kgo	Krongo		w				
-kgo	Krongo		j				
-kgo	Krongo		pː				
-kgo	Krongo		t̪ː		[t̪ː]		
-kgo	Krongo		t̪ː		[d̪ː]		
-kgo	Krongo		ʈː		[ʈː]		
-kgo	Krongo		ʈː		[ɖː]		
-kgo	Krongo		cː		[cː]		
-kgo	Krongo		cː		[ɟː]		
-kgo	Krongo		kː		[kː]		
-kgo	Krongo		kː		[ɡː]		
-kgo	Krongo		ʔː				
-kgo	Krongo		bː				
-kgo	Krongo		ɓː				
-kgo	Krongo		ɗː				
-kgo	Krongo		fː				
-kgo	Krongo		sː				
-kgo	Krongo		mː				
-kgo	Krongo		nː				
-kgo	Krongo		ɲː				
-kgo	Krongo		ŋː				
-kgo	Krongo		lː				
-kgo	Krongo		rː				
-kgo	Krongo		wː				
-kgo	Krongo		jː				
-kgo	Krongo		˦				
-kgo	Krongo		˨				
-kgo	Krongo		ɪ	No vowel inventory is given in the article for Krongo, however the article is intended to discuss orthography, for which no standard has been made for Krongo.  The other Kadugli-Krongo languages have identical vowel inventories, and it is safe to assume to Krongo follows suit.			
-kgo	Krongo		ɪː				
-kgo	Krongo		ɛ				
-kgo	Krongo		ɛː				
-kgo	Krongo		a				
-kgo	Krongo		aː				
-kgo	Krongo		ʊː				
-kgo	Krongo		ʊ				
-kgo	Krongo		ɔː				
-kgo	Krongo		ɔ				
-kgo	Krongo		i				
-kgo	Krongo		iː				
-kgo	Krongo		e				
-kgo	Krongo		eː				
-kgo	Krongo		ə				
-kgo	Krongo		əː				
-kgo	Krongo		u				
-kgo	Krongo		uː				
-kgo	Krongo		o				
-kgo	Krongo		oː				
-							
+kgo	Krongo		t̪		[t̪]
+kgo	Krongo		t̪		[d̪ʉ
+kgo	Krongo		ʈ		[ʈ]
+kgo	Krongo		ʈ		[ɖ]
+kgo	Krongo		c		[c]
+kgo	Krongo		c		[ɟ]
+kgo	Krongo		k		[k]
+kgo	Krongo		k		[ɡ]
+kgo	Krongo		ʔ
+kgo	Krongo		b
+kgo	Krongo		ɓ
+kgo	Krongo		ɗ
+kgo	Krongo		f
+kgo	Krongo		s
+kgo	Krongo		<ʃ>	questionable
+kgo	Krongo		<ʄ>	questionable
+kgo	Krongo		m
+kgo	Krongo		n
+kgo	Krongo		ɲ
+kgo	Krongo		ŋ
+kgo	Krongo		l
+kgo	Krongo		r
+kgo	Krongo		w
+kgo	Krongo		j
+kgo	Krongo		pː
+kgo	Krongo		t̪ː		[t̪ː]
+kgo	Krongo		t̪ː		[d̪ː]
+kgo	Krongo		ʈː		[ʈː]
+kgo	Krongo		ʈː		[ɖː]
+kgo	Krongo		cː		[cː]
+kgo	Krongo		cː		[ɟː]
+kgo	Krongo		kː		[kː]
+kgo	Krongo		kː		[ɡː]
+kgo	Krongo		ʔː
+kgo	Krongo		bː
+kgo	Krongo		ɓː
+kgo	Krongo		ɗː
+kgo	Krongo		fː
+kgo	Krongo		sː
+kgo	Krongo		mː
+kgo	Krongo		nː
+kgo	Krongo		ɲː
+kgo	Krongo		ŋː
+kgo	Krongo		lː
+kgo	Krongo		rː
+kgo	Krongo		wː
+kgo	Krongo		jː
+kgo	Krongo		˦
+kgo	Krongo		˨
+kgo	Krongo		ɪ	No vowel inventory is given in the article for Krongo, however the article is intended to discuss orthography, for which no standard has been made for Krongo.  The other Kadugli-Krongo languages have identical vowel inventories, and it is safe to assume to Krongo follows suit.
+kgo	Krongo		ɪː
+kgo	Krongo		ɛ
+kgo	Krongo		ɛː
+kgo	Krongo		a
+kgo	Krongo		aː
+kgo	Krongo		ʊː
+kgo	Krongo		ʊ
+kgo	Krongo		ɔː
+kgo	Krongo		ɔ
+kgo	Krongo		i
+kgo	Krongo		iː
+kgo	Krongo		e
+kgo	Krongo		eː
+kgo	Krongo		ə
+kgo	Krongo		əː
+kgo	Krongo		u
+kgo	Krongo		uː
+kgo	Krongo		o
+kgo	Krongo		oː
+
 kcp	Kanga (Kanga)	Kanga	ɪ				kadugli_krongo.pdf
-kcp	Kanga (Kanga)	Kanga	ɪː				
-kcp	Kanga (Kanga)	Kanga	ɛ				
-kcp	Kanga (Kanga)	Kanga	ɛː				
-kcp	Kanga (Kanga)	Kanga	a				
-kcp	Kanga (Kanga)	Kanga	aː				
-kcp	Kanga (Kanga)	Kanga	ʊː				
-kcp	Kanga (Kanga)	Kanga	ʊ				
-kcp	Kanga (Kanga)	Kanga	ɔː				
-kcp	Kanga (Kanga)	Kanga	ɔ				
-kcp	Kanga (Kanga)	Kanga	i				
-kcp	Kanga (Kanga)	Kanga	iː				
-kcp	Kanga (Kanga)	Kanga	e				
-kcp	Kanga (Kanga)	Kanga	eː				
-kcp	Kanga (Kanga)	Kanga	ə				
-kcp	Kanga (Kanga)	Kanga	əː				
-kcp	Kanga (Kanga)	Kanga	u				
-kcp	Kanga (Kanga)	Kanga	uː				
-kcp	Kanga (Kanga)	Kanga	o				
-kcp	Kanga (Kanga)	Kanga	oː				
-kcp	Kanga (Kanga)	Kanga	˦				
-kcp	Kanga (Kanga)	Kanga	˨				
-kcp	Kanga (Kanga)	Kanga	p				
-kcp	Kanga (Kanga)	Kanga	t̪				
-kcp	Kanga (Kanga)	Kanga	ʈ				
-kcp	Kanga (Kanga)	Kanga	c				
-kcp	Kanga (Kanga)	Kanga	k				
-kcp	Kanga (Kanga)	Kanga	d̪				
-kcp	Kanga (Kanga)	Kanga	ɖ				
-kcp	Kanga (Kanga)	Kanga	ɟ				
-kcp	Kanga (Kanga)	Kanga	ɡ				
-kcp	Kanga (Kanga)	Kanga	ʔ				
-kcp	Kanga (Kanga)	Kanga	b				
-kcp	Kanga (Kanga)	Kanga	ɓ				
-kcp	Kanga (Kanga)	Kanga	ɗ				
-kcp	Kanga (Kanga)	Kanga	<ʄ>	questionable			
-kcp	Kanga (Kanga)	Kanga	f				
-kcp	Kanga (Kanga)	Kanga	s				
-kcp	Kanga (Kanga)	Kanga	ʃ				
-kcp	Kanga (Kanga)	Kanga	v				
-kcp	Kanga (Kanga)	Kanga	z				
-kcp	Kanga (Kanga)	Kanga	ʒ				
-kcp	Kanga (Kanga)	Kanga	m				
-kcp	Kanga (Kanga)	Kanga	n				
-kcp	Kanga (Kanga)	Kanga	ɲ				
-kcp	Kanga (Kanga)	Kanga	ŋ				
-kcp	Kanga (Kanga)	Kanga	l				
-kcp	Kanga (Kanga)	Kanga	r				
-kcp	Kanga (Kanga)	Kanga	w				
-kcp	Kanga (Kanga)	Kanga	j				
-kcp	Kanga (Kanga)	Kanga	pː				
-kcp	Kanga (Kanga)	Kanga	t̪ː				
-kcp	Kanga (Kanga)	Kanga	ʈː				
-kcp	Kanga (Kanga)	Kanga	cː				
-kcp	Kanga (Kanga)	Kanga	kː				
-kcp	Kanga (Kanga)	Kanga	d̪ː				
-kcp	Kanga (Kanga)	Kanga	ɖː				
-kcp	Kanga (Kanga)	Kanga	ɟː				
-kcp	Kanga (Kanga)	Kanga	ɡː				
-kcp	Kanga (Kanga)	Kanga	ʔː				
-kcp	Kanga (Kanga)	Kanga	bː				
-kcp	Kanga (Kanga)	Kanga	ɓː				
-kcp	Kanga (Kanga)	Kanga	ɗː				
-kcp	Kanga (Kanga)	Kanga	fː				
-kcp	Kanga (Kanga)	Kanga	sː				
-kcp	Kanga (Kanga)	Kanga	ʃː				
-kcp	Kanga (Kanga)	Kanga	vː				
-kcp	Kanga (Kanga)	Kanga	zː				
-kcp	Kanga (Kanga)	Kanga	ʒː				
-kcp	Kanga (Kanga)	Kanga	mː				
-kcp	Kanga (Kanga)	Kanga	nː				
-kcp	Kanga (Kanga)	Kanga	ɲː				
-kcp	Kanga (Kanga)	Kanga	ŋː				
-kcp	Kanga (Kanga)	Kanga	lː				
-kcp	Kanga (Kanga)	Kanga	rː				
-kcp	Kanga (Kanga)	Kanga	wː				
-kcp	Kanga (Kanga)	Kanga	ɲː				
-							
+kcp	Kanga (Kanga)	Kanga	ɪː
+kcp	Kanga (Kanga)	Kanga	ɛ
+kcp	Kanga (Kanga)	Kanga	ɛː
+kcp	Kanga (Kanga)	Kanga	a
+kcp	Kanga (Kanga)	Kanga	aː
+kcp	Kanga (Kanga)	Kanga	ʊː
+kcp	Kanga (Kanga)	Kanga	ʊ
+kcp	Kanga (Kanga)	Kanga	ɔː
+kcp	Kanga (Kanga)	Kanga	ɔ
+kcp	Kanga (Kanga)	Kanga	i
+kcp	Kanga (Kanga)	Kanga	iː
+kcp	Kanga (Kanga)	Kanga	e
+kcp	Kanga (Kanga)	Kanga	eː
+kcp	Kanga (Kanga)	Kanga	ə
+kcp	Kanga (Kanga)	Kanga	əː
+kcp	Kanga (Kanga)	Kanga	u
+kcp	Kanga (Kanga)	Kanga	uː
+kcp	Kanga (Kanga)	Kanga	o
+kcp	Kanga (Kanga)	Kanga	oː
+kcp	Kanga (Kanga)	Kanga	˦
+kcp	Kanga (Kanga)	Kanga	˨
+kcp	Kanga (Kanga)	Kanga	p
+kcp	Kanga (Kanga)	Kanga	t̪
+kcp	Kanga (Kanga)	Kanga	ʈ
+kcp	Kanga (Kanga)	Kanga	c
+kcp	Kanga (Kanga)	Kanga	k
+kcp	Kanga (Kanga)	Kanga	d̪
+kcp	Kanga (Kanga)	Kanga	ɖ
+kcp	Kanga (Kanga)	Kanga	ɟ
+kcp	Kanga (Kanga)	Kanga	ɡ
+kcp	Kanga (Kanga)	Kanga	ʔ
+kcp	Kanga (Kanga)	Kanga	b
+kcp	Kanga (Kanga)	Kanga	ɓ
+kcp	Kanga (Kanga)	Kanga	ɗ
+kcp	Kanga (Kanga)	Kanga	<ʄ>	questionable
+kcp	Kanga (Kanga)	Kanga	f
+kcp	Kanga (Kanga)	Kanga	s
+kcp	Kanga (Kanga)	Kanga	ʃ
+kcp	Kanga (Kanga)	Kanga	v
+kcp	Kanga (Kanga)	Kanga	z
+kcp	Kanga (Kanga)	Kanga	ʒ
+kcp	Kanga (Kanga)	Kanga	m
+kcp	Kanga (Kanga)	Kanga	n
+kcp	Kanga (Kanga)	Kanga	ɲ
+kcp	Kanga (Kanga)	Kanga	ŋ
+kcp	Kanga (Kanga)	Kanga	l
+kcp	Kanga (Kanga)	Kanga	r
+kcp	Kanga (Kanga)	Kanga	w
+kcp	Kanga (Kanga)	Kanga	j
+kcp	Kanga (Kanga)	Kanga	pː
+kcp	Kanga (Kanga)	Kanga	t̪ː
+kcp	Kanga (Kanga)	Kanga	ʈː
+kcp	Kanga (Kanga)	Kanga	cː
+kcp	Kanga (Kanga)	Kanga	kː
+kcp	Kanga (Kanga)	Kanga	d̪ː
+kcp	Kanga (Kanga)	Kanga	ɖː
+kcp	Kanga (Kanga)	Kanga	ɟː
+kcp	Kanga (Kanga)	Kanga	ɡː
+kcp	Kanga (Kanga)	Kanga	ʔː
+kcp	Kanga (Kanga)	Kanga	bː
+kcp	Kanga (Kanga)	Kanga	ɓː
+kcp	Kanga (Kanga)	Kanga	ɗː
+kcp	Kanga (Kanga)	Kanga	fː
+kcp	Kanga (Kanga)	Kanga	sː
+kcp	Kanga (Kanga)	Kanga	ʃː
+kcp	Kanga (Kanga)	Kanga	vː
+kcp	Kanga (Kanga)	Kanga	zː
+kcp	Kanga (Kanga)	Kanga	ʒː
+kcp	Kanga (Kanga)	Kanga	mː
+kcp	Kanga (Kanga)	Kanga	nː
+kcp	Kanga (Kanga)	Kanga	ɲː
+kcp	Kanga (Kanga)	Kanga	ŋː
+kcp	Kanga (Kanga)	Kanga	lː
+kcp	Kanga (Kanga)	Kanga	rː
+kcp	Kanga (Kanga)	Kanga	wː
+kcp	Kanga (Kanga)	Kanga	ɲː
+
 kcp	Kanga (Kufa)	Kufa	ɪ				kadugli_krongo.pdf
-kcp	Kanga (Kufa)	Kufa	ɪː				
-kcp	Kanga (Kufa)	Kufa	ɛ				
-kcp	Kanga (Kufa)	Kufa	ɛː				
-kcp	Kanga (Kufa)	Kufa	a				
-kcp	Kanga (Kufa)	Kufa	aː				
-kcp	Kanga (Kufa)	Kufa	ʊː				
-kcp	Kanga (Kufa)	Kufa	ʊ				
-kcp	Kanga (Kufa)	Kufa	ɔː				
-kcp	Kanga (Kufa)	Kufa	ɔ				
-kcp	Kanga (Kufa)	Kufa	i				
-kcp	Kanga (Kufa)	Kufa	iː				
-kcp	Kanga (Kufa)	Kufa	e				
-kcp	Kanga (Kufa)	Kufa	eː				
-kcp	Kanga (Kufa)	Kufa	ə				
-kcp	Kanga (Kufa)	Kufa	əː				
-kcp	Kanga (Kufa)	Kufa	u				
-kcp	Kanga (Kufa)	Kufa	uː				
-kcp	Kanga (Kufa)	Kufa	o				
-kcp	Kanga (Kufa)	Kufa	oː				
-kcp	Kanga (Kufa)	Kufa	˦				
-kcp	Kanga (Kufa)	Kufa	˨				
-kcp	Kanga (Kufa)	Kufa	p				
-kcp	Kanga (Kufa)	Kufa	t̪				
-kcp	Kanga (Kufa)	Kufa	ʈ				
-kcp	Kanga (Kufa)	Kufa	k				
-kcp	Kanga (Kufa)	Kufa	ʔ				
-kcp	Kanga (Kufa)	Kufa	b				
-kcp	Kanga (Kufa)	Kufa	d̪				
-kcp	Kanga (Kufa)	Kufa	ɖ				
-kcp	Kanga (Kufa)	Kufa	ɟ				
-kcp	Kanga (Kufa)	Kufa	ɡ				
-kcp	Kanga (Kufa)	Kufa	ɓ				
-kcp	Kanga (Kufa)	Kufa	ɗ				
-kcp	Kanga (Kufa)	Kufa	<ʄ>	questionable			
-kcp	Kanga (Kufa)	Kufa	f				
-kcp	Kanga (Kufa)	Kufa	s				
-kcp	Kanga (Kufa)	Kufa	ʃ				
-kcp	Kanga (Kufa)	Kufa	v				
-kcp	Kanga (Kufa)	Kufa	z				
-kcp	Kanga (Kufa)	Kufa	ʒ				
-kcp	Kanga (Kufa)	Kufa	m				
-kcp	Kanga (Kufa)	Kufa	n				
-kcp	Kanga (Kufa)	Kufa	ɲ				
-kcp	Kanga (Kufa)	Kufa	ŋ				
-kcp	Kanga (Kufa)	Kufa	l				
-kcp	Kanga (Kufa)	Kufa	r				
-kcp	Kanga (Kufa)	Kufa	w				
-kcp	Kanga (Kufa)	Kufa	j				
-kcp	Kanga (Kufa)	Kufa	pː				
-kcp	Kanga (Kufa)	Kufa	t̪ː				
-kcp	Kanga (Kufa)	Kufa	ʈː				
-kcp	Kanga (Kufa)	Kufa	kː				
-kcp	Kanga (Kufa)	Kufa	ʔː				
-kcp	Kanga (Kufa)	Kufa	bː				
-kcp	Kanga (Kufa)	Kufa	d̪ː				
-kcp	Kanga (Kufa)	Kufa	ɖː				
-kcp	Kanga (Kufa)	Kufa	ɟː				
-kcp	Kanga (Kufa)	Kufa	ɡː				
-kcp	Kanga (Kufa)	Kufa	ɓː				
-kcp	Kanga (Kufa)	Kufa	ɗː				
-kcp	Kanga (Kufa)	Kufa	fː				
-kcp	Kanga (Kufa)	Kufa	sː				
-kcp	Kanga (Kufa)	Kufa	ʃː				
-kcp	Kanga (Kufa)	Kufa	vː				
-kcp	Kanga (Kufa)	Kufa	zː				
-kcp	Kanga (Kufa)	Kufa	ʒː				
-kcp	Kanga (Kufa)	Kufa	mː				
-kcp	Kanga (Kufa)	Kufa	nː				
-kcp	Kanga (Kufa)	Kufa	ɲː				
-kcp	Kanga (Kufa)	Kufa	ŋː				
-kcp	Kanga (Kufa)	Kufa	lː				
-kcp	Kanga (Kufa)	Kufa	rː				
-kcp	Kanga (Kufa)	Kufa	wː				
-kcp	Kanga (Kufa)	Kufa	jː				
-							
+kcp	Kanga (Kufa)	Kufa	ɪː
+kcp	Kanga (Kufa)	Kufa	ɛ
+kcp	Kanga (Kufa)	Kufa	ɛː
+kcp	Kanga (Kufa)	Kufa	a
+kcp	Kanga (Kufa)	Kufa	aː
+kcp	Kanga (Kufa)	Kufa	ʊː
+kcp	Kanga (Kufa)	Kufa	ʊ
+kcp	Kanga (Kufa)	Kufa	ɔː
+kcp	Kanga (Kufa)	Kufa	ɔ
+kcp	Kanga (Kufa)	Kufa	i
+kcp	Kanga (Kufa)	Kufa	iː
+kcp	Kanga (Kufa)	Kufa	e
+kcp	Kanga (Kufa)	Kufa	eː
+kcp	Kanga (Kufa)	Kufa	ə
+kcp	Kanga (Kufa)	Kufa	əː
+kcp	Kanga (Kufa)	Kufa	u
+kcp	Kanga (Kufa)	Kufa	uː
+kcp	Kanga (Kufa)	Kufa	o
+kcp	Kanga (Kufa)	Kufa	oː
+kcp	Kanga (Kufa)	Kufa	˦
+kcp	Kanga (Kufa)	Kufa	˨
+kcp	Kanga (Kufa)	Kufa	p
+kcp	Kanga (Kufa)	Kufa	t̪
+kcp	Kanga (Kufa)	Kufa	ʈ
+kcp	Kanga (Kufa)	Kufa	k
+kcp	Kanga (Kufa)	Kufa	ʔ
+kcp	Kanga (Kufa)	Kufa	b
+kcp	Kanga (Kufa)	Kufa	d̪
+kcp	Kanga (Kufa)	Kufa	ɖ
+kcp	Kanga (Kufa)	Kufa	ɟ
+kcp	Kanga (Kufa)	Kufa	ɡ
+kcp	Kanga (Kufa)	Kufa	ɓ
+kcp	Kanga (Kufa)	Kufa	ɗ
+kcp	Kanga (Kufa)	Kufa	<ʄ>	questionable
+kcp	Kanga (Kufa)	Kufa	f
+kcp	Kanga (Kufa)	Kufa	s
+kcp	Kanga (Kufa)	Kufa	ʃ
+kcp	Kanga (Kufa)	Kufa	v
+kcp	Kanga (Kufa)	Kufa	z
+kcp	Kanga (Kufa)	Kufa	ʒ
+kcp	Kanga (Kufa)	Kufa	m
+kcp	Kanga (Kufa)	Kufa	n
+kcp	Kanga (Kufa)	Kufa	ɲ
+kcp	Kanga (Kufa)	Kufa	ŋ
+kcp	Kanga (Kufa)	Kufa	l
+kcp	Kanga (Kufa)	Kufa	r
+kcp	Kanga (Kufa)	Kufa	w
+kcp	Kanga (Kufa)	Kufa	j
+kcp	Kanga (Kufa)	Kufa	pː
+kcp	Kanga (Kufa)	Kufa	t̪ː
+kcp	Kanga (Kufa)	Kufa	ʈː
+kcp	Kanga (Kufa)	Kufa	kː
+kcp	Kanga (Kufa)	Kufa	ʔː
+kcp	Kanga (Kufa)	Kufa	bː
+kcp	Kanga (Kufa)	Kufa	d̪ː
+kcp	Kanga (Kufa)	Kufa	ɖː
+kcp	Kanga (Kufa)	Kufa	ɟː
+kcp	Kanga (Kufa)	Kufa	ɡː
+kcp	Kanga (Kufa)	Kufa	ɓː
+kcp	Kanga (Kufa)	Kufa	ɗː
+kcp	Kanga (Kufa)	Kufa	fː
+kcp	Kanga (Kufa)	Kufa	sː
+kcp	Kanga (Kufa)	Kufa	ʃː
+kcp	Kanga (Kufa)	Kufa	vː
+kcp	Kanga (Kufa)	Kufa	zː
+kcp	Kanga (Kufa)	Kufa	ʒː
+kcp	Kanga (Kufa)	Kufa	mː
+kcp	Kanga (Kufa)	Kufa	nː
+kcp	Kanga (Kufa)	Kufa	ɲː
+kcp	Kanga (Kufa)	Kufa	ŋː
+kcp	Kanga (Kufa)	Kufa	lː
+kcp	Kanga (Kufa)	Kufa	rː
+kcp	Kanga (Kufa)	Kufa	wː
+kcp	Kanga (Kufa)	Kufa	jː
+
 xtc	Kadugli (Kadugli)	Kadugli	p				kadugli_krongo.pdf
-xtc	Kadugli (Kadugli)	Kadugli	t̪				
-xtc	Kadugli (Kadugli)	Kadugli	ʈ				
-xtc	Kadugli (Kadugli)	Kadugli	k				
-xtc	Kadugli (Kadugli)	Kadugli	ʔ				
-xtc	Kadugli (Kadugli)	Kadugli	b				
-xtc	Kadugli (Kadugli)	Kadugli	ɟ				
-xtc	Kadugli (Kadugli)	Kadugli	ɓ				
-xtc	Kadugli (Kadugli)	Kadugli	ɗ				
-xtc	Kadugli (Kadugli)	Kadugli	<ʄ>	questionable			
-xtc	Kadugli (Kadugli)	Kadugli	f				
-xtc	Kadugli (Kadugli)	Kadugli	s				
-xtc	Kadugli (Kadugli)	Kadugli	m				
-xtc	Kadugli (Kadugli)	Kadugli	n				
-xtc	Kadugli (Kadugli)	Kadugli	ɲ				
-xtc	Kadugli (Kadugli)	Kadugli	ŋ				
-xtc	Kadugli (Kadugli)	Kadugli	l				
-xtc	Kadugli (Kadugli)	Kadugli	r				
-xtc	Kadugli (Kadugli)	Kadugli	w				
-xtc	Kadugli (Kadugli)	Kadugli	j				
-xtc	Kadugli (Kadugli)	Kadugli	pː				
-xtc	Kadugli (Kadugli)	Kadugli	t̪ː				
-xtc	Kadugli (Kadugli)	Kadugli	ʈː				
-xtc	Kadugli (Kadugli)	Kadugli	kː				
-xtc	Kadugli (Kadugli)	Kadugli	ʔː				
-xtc	Kadugli (Kadugli)	Kadugli	bː				
-xtc	Kadugli (Kadugli)	Kadugli	ɟː				
-xtc	Kadugli (Kadugli)	Kadugli	ɓː				
-xtc	Kadugli (Kadugli)	Kadugli	ɗː				
-xtc	Kadugli (Kadugli)	Kadugli	fː				
-xtc	Kadugli (Kadugli)	Kadugli	sː				
-xtc	Kadugli (Kadugli)	Kadugli	mː				
-xtc	Kadugli (Kadugli)	Kadugli	nː				
-xtc	Kadugli (Kadugli)	Kadugli	ɲː				
-xtc	Kadugli (Kadugli)	Kadugli	ŋː				
-xtc	Kadugli (Kadugli)	Kadugli	lː				
-xtc	Kadugli (Kadugli)	Kadugli	rː				
-xtc	Kadugli (Kadugli)	Kadugli	wː				
-xtc	Kadugli (Kadugli)	Kadugli	jː				
-xtc	Kadugli (Kadugli)	Kadugli	ɪ				
-xtc	Kadugli (Kadugli)	Kadugli	ɪː				
-xtc	Kadugli (Kadugli)	Kadugli	ɛ				
-xtc	Kadugli (Kadugli)	Kadugli	ɛː				
-xtc	Kadugli (Kadugli)	Kadugli	a				
-xtc	Kadugli (Kadugli)	Kadugli	aː				
-xtc	Kadugli (Kadugli)	Kadugli	ʊː				
-xtc	Kadugli (Kadugli)	Kadugli	ʊ				
-xtc	Kadugli (Kadugli)	Kadugli	ɔː				
-xtc	Kadugli (Kadugli)	Kadugli	ɔ				
-xtc	Kadugli (Kadugli)	Kadugli	i				
-xtc	Kadugli (Kadugli)	Kadugli	iː				
-xtc	Kadugli (Kadugli)	Kadugli	e				
-xtc	Kadugli (Kadugli)	Kadugli	eː				
-xtc	Kadugli (Kadugli)	Kadugli	ə				
-xtc	Kadugli (Kadugli)	Kadugli	əː				
-xtc	Kadugli (Kadugli)	Kadugli	u				
-xtc	Kadugli (Kadugli)	Kadugli	uː				
-xtc	Kadugli (Kadugli)	Kadugli	o				
-xtc	Kadugli (Kadugli)	Kadugli	oː				
-xtc	Kadugli (Kadugli)	Kadugli	˦				
-xtc	Kadugli (Kadugli)	Kadugli	˨				
-xtc	Kadugli (Kadugli)	Kadugli	˧				
-							
+xtc	Kadugli (Kadugli)	Kadugli	t̪
+xtc	Kadugli (Kadugli)	Kadugli	ʈ
+xtc	Kadugli (Kadugli)	Kadugli	k
+xtc	Kadugli (Kadugli)	Kadugli	ʔ
+xtc	Kadugli (Kadugli)	Kadugli	b
+xtc	Kadugli (Kadugli)	Kadugli	ɟ
+xtc	Kadugli (Kadugli)	Kadugli	ɓ
+xtc	Kadugli (Kadugli)	Kadugli	ɗ
+xtc	Kadugli (Kadugli)	Kadugli	<ʄ>	questionable
+xtc	Kadugli (Kadugli)	Kadugli	f
+xtc	Kadugli (Kadugli)	Kadugli	s
+xtc	Kadugli (Kadugli)	Kadugli	m
+xtc	Kadugli (Kadugli)	Kadugli	n
+xtc	Kadugli (Kadugli)	Kadugli	ɲ
+xtc	Kadugli (Kadugli)	Kadugli	ŋ
+xtc	Kadugli (Kadugli)	Kadugli	l
+xtc	Kadugli (Kadugli)	Kadugli	r
+xtc	Kadugli (Kadugli)	Kadugli	w
+xtc	Kadugli (Kadugli)	Kadugli	j
+xtc	Kadugli (Kadugli)	Kadugli	pː
+xtc	Kadugli (Kadugli)	Kadugli	t̪ː
+xtc	Kadugli (Kadugli)	Kadugli	ʈː
+xtc	Kadugli (Kadugli)	Kadugli	kː
+xtc	Kadugli (Kadugli)	Kadugli	ʔː
+xtc	Kadugli (Kadugli)	Kadugli	bː
+xtc	Kadugli (Kadugli)	Kadugli	ɟː
+xtc	Kadugli (Kadugli)	Kadugli	ɓː
+xtc	Kadugli (Kadugli)	Kadugli	ɗː
+xtc	Kadugli (Kadugli)	Kadugli	fː
+xtc	Kadugli (Kadugli)	Kadugli	sː
+xtc	Kadugli (Kadugli)	Kadugli	mː
+xtc	Kadugli (Kadugli)	Kadugli	nː
+xtc	Kadugli (Kadugli)	Kadugli	ɲː
+xtc	Kadugli (Kadugli)	Kadugli	ŋː
+xtc	Kadugli (Kadugli)	Kadugli	lː
+xtc	Kadugli (Kadugli)	Kadugli	rː
+xtc	Kadugli (Kadugli)	Kadugli	wː
+xtc	Kadugli (Kadugli)	Kadugli	jː
+xtc	Kadugli (Kadugli)	Kadugli	ɪ
+xtc	Kadugli (Kadugli)	Kadugli	ɪː
+xtc	Kadugli (Kadugli)	Kadugli	ɛ
+xtc	Kadugli (Kadugli)	Kadugli	ɛː
+xtc	Kadugli (Kadugli)	Kadugli	a
+xtc	Kadugli (Kadugli)	Kadugli	aː
+xtc	Kadugli (Kadugli)	Kadugli	ʊː
+xtc	Kadugli (Kadugli)	Kadugli	ʊ
+xtc	Kadugli (Kadugli)	Kadugli	ɔː
+xtc	Kadugli (Kadugli)	Kadugli	ɔ
+xtc	Kadugli (Kadugli)	Kadugli	i
+xtc	Kadugli (Kadugli)	Kadugli	iː
+xtc	Kadugli (Kadugli)	Kadugli	e
+xtc	Kadugli (Kadugli)	Kadugli	eː
+xtc	Kadugli (Kadugli)	Kadugli	ə
+xtc	Kadugli (Kadugli)	Kadugli	əː
+xtc	Kadugli (Kadugli)	Kadugli	u
+xtc	Kadugli (Kadugli)	Kadugli	uː
+xtc	Kadugli (Kadugli)	Kadugli	o
+xtc	Kadugli (Kadugli)	Kadugli	oː
+xtc	Kadugli (Kadugli)	Kadugli	˦
+xtc	Kadugli (Kadugli)	Kadugli	˨
+xtc	Kadugli (Kadugli)	Kadugli	˧
+
 xtc	Kadugli (Miri)	Miri	t̪				kadugli_krongo.pdf
-xtc	Kadugli (Miri)	Miri	ʈ				
-xtc	Kadugli (Miri)	Miri	c				
-xtc	Kadugli (Miri)	Miri	k				
-xtc	Kadugli (Miri)	Miri	ʔ				
-xtc	Kadugli (Miri)	Miri	b				
-xtc	Kadugli (Miri)	Miri	ɟ				
-xtc	Kadugli (Miri)	Miri	ɓ				
-xtc	Kadugli (Miri)	Miri	ɗ				
-xtc	Kadugli (Miri)	Miri	<ʄ>	questionable			
-xtc	Kadugli (Miri)	Miri	f				
-xtc	Kadugli (Miri)	Miri	s				
-xtc	Kadugli (Miri)	Miri	z				
-xtc	Kadugli (Miri)	Miri	m				
-xtc	Kadugli (Miri)	Miri	n				
-xtc	Kadugli (Miri)	Miri	ɲ				
-xtc	Kadugli (Miri)	Miri	ŋ				
-xtc	Kadugli (Miri)	Miri	l				
-xtc	Kadugli (Miri)	Miri	r				
-xtc	Kadugli (Miri)	Miri	w				
-xtc	Kadugli (Miri)	Miri	j				
-xtc	Kadugli (Miri)	Miri	t̪ː				
-xtc	Kadugli (Miri)	Miri	ʈː				
-xtc	Kadugli (Miri)	Miri	cː				
-xtc	Kadugli (Miri)	Miri	kː				
-xtc	Kadugli (Miri)	Miri	ʔː				
-xtc	Kadugli (Miri)	Miri	bː				
-xtc	Kadugli (Miri)	Miri	ɟː				
-xtc	Kadugli (Miri)	Miri	ɓː				
-xtc	Kadugli (Miri)	Miri	ɗː				
-xtc	Kadugli (Miri)	Miri	fː				
-xtc	Kadugli (Miri)	Miri	sː				
-xtc	Kadugli (Miri)	Miri	zː				
-xtc	Kadugli (Miri)	Miri	mː				
-xtc	Kadugli (Miri)	Miri	nː				
-xtc	Kadugli (Miri)	Miri	ɲː				
-xtc	Kadugli (Miri)	Miri	ŋː				
-xtc	Kadugli (Miri)	Miri	lː				
-xtc	Kadugli (Miri)	Miri	rː				
-xtc	Kadugli (Miri)	Miri	wː				
-xtc	Kadugli (Miri)	Miri	jː				
-xtc	Kadugli (Miri)	Miri	ɪ				
-xtc	Kadugli (Miri)	Miri	ɪː				
-xtc	Kadugli (Miri)	Miri	ɛ				
-xtc	Kadugli (Miri)	Miri	ɛː				
-xtc	Kadugli (Miri)	Miri	a				
-xtc	Kadugli (Miri)	Miri	aː				
-xtc	Kadugli (Miri)	Miri	ʊː				
-xtc	Kadugli (Miri)	Miri	ʊ				
-xtc	Kadugli (Miri)	Miri	ɔː				
-xtc	Kadugli (Miri)	Miri	ɔ				
-xtc	Kadugli (Miri)	Miri	i				
-xtc	Kadugli (Miri)	Miri	iː				
-xtc	Kadugli (Miri)	Miri	e				
-xtc	Kadugli (Miri)	Miri	eː				
-xtc	Kadugli (Miri)	Miri	ə				
-xtc	Kadugli (Miri)	Miri	əː				
-xtc	Kadugli (Miri)	Miri	u				
-xtc	Kadugli (Miri)	Miri	uː				
-xtc	Kadugli (Miri)	Miri	o				
-xtc	Kadugli (Miri)	Miri	oː				
-xtc	Kadugli (Miri)	Miri	˦				
-xtc	Kadugli (Miri)	Miri	˨				
-							
+xtc	Kadugli (Miri)	Miri	ʈ
+xtc	Kadugli (Miri)	Miri	c
+xtc	Kadugli (Miri)	Miri	k
+xtc	Kadugli (Miri)	Miri	ʔ
+xtc	Kadugli (Miri)	Miri	b
+xtc	Kadugli (Miri)	Miri	ɟ
+xtc	Kadugli (Miri)	Miri	ɓ
+xtc	Kadugli (Miri)	Miri	ɗ
+xtc	Kadugli (Miri)	Miri	<ʄ>	questionable
+xtc	Kadugli (Miri)	Miri	f
+xtc	Kadugli (Miri)	Miri	s
+xtc	Kadugli (Miri)	Miri	z
+xtc	Kadugli (Miri)	Miri	m
+xtc	Kadugli (Miri)	Miri	n
+xtc	Kadugli (Miri)	Miri	ɲ
+xtc	Kadugli (Miri)	Miri	ŋ
+xtc	Kadugli (Miri)	Miri	l
+xtc	Kadugli (Miri)	Miri	r
+xtc	Kadugli (Miri)	Miri	w
+xtc	Kadugli (Miri)	Miri	j
+xtc	Kadugli (Miri)	Miri	t̪ː
+xtc	Kadugli (Miri)	Miri	ʈː
+xtc	Kadugli (Miri)	Miri	cː
+xtc	Kadugli (Miri)	Miri	kː
+xtc	Kadugli (Miri)	Miri	ʔː
+xtc	Kadugli (Miri)	Miri	bː
+xtc	Kadugli (Miri)	Miri	ɟː
+xtc	Kadugli (Miri)	Miri	ɓː
+xtc	Kadugli (Miri)	Miri	ɗː
+xtc	Kadugli (Miri)	Miri	fː
+xtc	Kadugli (Miri)	Miri	sː
+xtc	Kadugli (Miri)	Miri	zː
+xtc	Kadugli (Miri)	Miri	mː
+xtc	Kadugli (Miri)	Miri	nː
+xtc	Kadugli (Miri)	Miri	ɲː
+xtc	Kadugli (Miri)	Miri	ŋː
+xtc	Kadugli (Miri)	Miri	lː
+xtc	Kadugli (Miri)	Miri	rː
+xtc	Kadugli (Miri)	Miri	wː
+xtc	Kadugli (Miri)	Miri	jː
+xtc	Kadugli (Miri)	Miri	ɪ
+xtc	Kadugli (Miri)	Miri	ɪː
+xtc	Kadugli (Miri)	Miri	ɛ
+xtc	Kadugli (Miri)	Miri	ɛː
+xtc	Kadugli (Miri)	Miri	a
+xtc	Kadugli (Miri)	Miri	aː
+xtc	Kadugli (Miri)	Miri	ʊː
+xtc	Kadugli (Miri)	Miri	ʊ
+xtc	Kadugli (Miri)	Miri	ɔː
+xtc	Kadugli (Miri)	Miri	ɔ
+xtc	Kadugli (Miri)	Miri	i
+xtc	Kadugli (Miri)	Miri	iː
+xtc	Kadugli (Miri)	Miri	e
+xtc	Kadugli (Miri)	Miri	eː
+xtc	Kadugli (Miri)	Miri	ə
+xtc	Kadugli (Miri)	Miri	əː
+xtc	Kadugli (Miri)	Miri	u
+xtc	Kadugli (Miri)	Miri	uː
+xtc	Kadugli (Miri)	Miri	o
+xtc	Kadugli (Miri)	Miri	oː
+xtc	Kadugli (Miri)	Miri	˦
+xtc	Kadugli (Miri)	Miri	˨
+
 xtc	Kadugli (Katcha)	Katcha	p				kadugli_krongo.pdf
-xtc	Kadugli (Katcha)	Katcha	t̪		[t̪]		
-xtc	Kadugli (Katcha)	Katcha	t̪		[d̪]		
-xtc	Kadugli (Katcha)	Katcha	ʈ				
-xtc	Kadugli (Katcha)	Katcha	c				
-xtc	Kadugli (Katcha)	Katcha	k		[k]		
-xtc	Kadugli (Katcha)	Katcha	k		[ɡ]		
-xtc	Kadugli (Katcha)	Katcha	ʔ				
-xtc	Kadugli (Katcha)	Katcha	b				
-xtc	Kadugli (Katcha)	Katcha	ɟ				
-xtc	Kadugli (Katcha)	Katcha	ɓ				
-xtc	Kadugli (Katcha)	Katcha	ɗ				
-xtc	Kadugli (Katcha)	Katcha	<ʄ>	questionable			
-xtc	Kadugli (Katcha)	Katcha	f				
-xtc	Kadugli (Katcha)	Katcha	s				
-xtc	Kadugli (Katcha)	Katcha	m				
-xtc	Kadugli (Katcha)	Katcha	n				
-xtc	Kadugli (Katcha)	Katcha	ɲ				
-xtc	Kadugli (Katcha)	Katcha	ŋ				
-xtc	Kadugli (Katcha)	Katcha	l				
-xtc	Kadugli (Katcha)	Katcha	r				
-xtc	Kadugli (Katcha)	Katcha	w				
-xtc	Kadugli (Katcha)	Katcha	j				
-xtc	Kadugli (Katcha)	Katcha	pː				
-xtc	Kadugli (Katcha)	Katcha	t̪ː		[t̪ː]		
-xtc	Kadugli (Katcha)	Katcha	t̪ː		[d̪ː]		
-xtc	Kadugli (Katcha)	Katcha	ʈː				
-xtc	Kadugli (Katcha)	Katcha	cː				
-xtc	Kadugli (Katcha)	Katcha	kː		[kː]		
-xtc	Kadugli (Katcha)	Katcha	kː		[ɡː]		
-xtc	Kadugli (Katcha)	Katcha	ʔː				
-xtc	Kadugli (Katcha)	Katcha	ɓː				
-xtc	Kadugli (Katcha)	Katcha	ɗː				
-xtc	Kadugli (Katcha)	Katcha	fː				
-xtc	Kadugli (Katcha)	Katcha	sː				
-xtc	Kadugli (Katcha)	Katcha	mː				
-xtc	Kadugli (Katcha)	Katcha	nː				
-xtc	Kadugli (Katcha)	Katcha	ɲː				
-xtc	Kadugli (Katcha)	Katcha	ŋː				
-xtc	Kadugli (Katcha)	Katcha	lː				
-xtc	Kadugli (Katcha)	Katcha	rː				
-xtc	Kadugli (Katcha)	Katcha	wː				
-xtc	Kadugli (Katcha)	Katcha	jː				
-xtc	Kadugli (Katcha)	Katcha	ɪ				
-xtc	Kadugli (Katcha)	Katcha	ɪː				
-xtc	Kadugli (Katcha)	Katcha	ɛ				
-xtc	Kadugli (Katcha)	Katcha	ɛː				
-xtc	Kadugli (Katcha)	Katcha	a				
-xtc	Kadugli (Katcha)	Katcha	aː				
-xtc	Kadugli (Katcha)	Katcha	ʊː				
-xtc	Kadugli (Katcha)	Katcha	ʊ				
-xtc	Kadugli (Katcha)	Katcha	ɔː				
-xtc	Kadugli (Katcha)	Katcha	ɔ				
-xtc	Kadugli (Katcha)	Katcha	i				
-xtc	Kadugli (Katcha)	Katcha	iː				
-xtc	Kadugli (Katcha)	Katcha	e				
-xtc	Kadugli (Katcha)	Katcha	eː				
-xtc	Kadugli (Katcha)	Katcha	ə				
-xtc	Kadugli (Katcha)	Katcha	əː				
-xtc	Kadugli (Katcha)	Katcha	u				
-xtc	Kadugli (Katcha)	Katcha	uː				
-xtc	Kadugli (Katcha)	Katcha	o				
-xtc	Kadugli (Katcha)	Katcha	oː				
-xtc	Kadugli (Katcha)	Katcha	˦				
-xtc	Kadugli (Katcha)	Katcha	˨				
-							
+xtc	Kadugli (Katcha)	Katcha	t̪		[t̪]
+xtc	Kadugli (Katcha)	Katcha	t̪		[d̪]
+xtc	Kadugli (Katcha)	Katcha	ʈ
+xtc	Kadugli (Katcha)	Katcha	c
+xtc	Kadugli (Katcha)	Katcha	k		[k]
+xtc	Kadugli (Katcha)	Katcha	k		[ɡ]
+xtc	Kadugli (Katcha)	Katcha	ʔ
+xtc	Kadugli (Katcha)	Katcha	b
+xtc	Kadugli (Katcha)	Katcha	ɟ
+xtc	Kadugli (Katcha)	Katcha	ɓ
+xtc	Kadugli (Katcha)	Katcha	ɗ
+xtc	Kadugli (Katcha)	Katcha	<ʄ>	questionable
+xtc	Kadugli (Katcha)	Katcha	f
+xtc	Kadugli (Katcha)	Katcha	s
+xtc	Kadugli (Katcha)	Katcha	m
+xtc	Kadugli (Katcha)	Katcha	n
+xtc	Kadugli (Katcha)	Katcha	ɲ
+xtc	Kadugli (Katcha)	Katcha	ŋ
+xtc	Kadugli (Katcha)	Katcha	l
+xtc	Kadugli (Katcha)	Katcha	r
+xtc	Kadugli (Katcha)	Katcha	w
+xtc	Kadugli (Katcha)	Katcha	j
+xtc	Kadugli (Katcha)	Katcha	pː
+xtc	Kadugli (Katcha)	Katcha	t̪ː		[t̪ː]
+xtc	Kadugli (Katcha)	Katcha	t̪ː		[d̪ː]
+xtc	Kadugli (Katcha)	Katcha	ʈː
+xtc	Kadugli (Katcha)	Katcha	cː
+xtc	Kadugli (Katcha)	Katcha	kː		[kː]
+xtc	Kadugli (Katcha)	Katcha	kː		[ɡː]
+xtc	Kadugli (Katcha)	Katcha	ʔː
+xtc	Kadugli (Katcha)	Katcha	ɓː
+xtc	Kadugli (Katcha)	Katcha	ɗː
+xtc	Kadugli (Katcha)	Katcha	fː
+xtc	Kadugli (Katcha)	Katcha	sː
+xtc	Kadugli (Katcha)	Katcha	mː
+xtc	Kadugli (Katcha)	Katcha	nː
+xtc	Kadugli (Katcha)	Katcha	ɲː
+xtc	Kadugli (Katcha)	Katcha	ŋː
+xtc	Kadugli (Katcha)	Katcha	lː
+xtc	Kadugli (Katcha)	Katcha	rː
+xtc	Kadugli (Katcha)	Katcha	wː
+xtc	Kadugli (Katcha)	Katcha	jː
+xtc	Kadugli (Katcha)	Katcha	ɪ
+xtc	Kadugli (Katcha)	Katcha	ɪː
+xtc	Kadugli (Katcha)	Katcha	ɛ
+xtc	Kadugli (Katcha)	Katcha	ɛː
+xtc	Kadugli (Katcha)	Katcha	a
+xtc	Kadugli (Katcha)	Katcha	aː
+xtc	Kadugli (Katcha)	Katcha	ʊː
+xtc	Kadugli (Katcha)	Katcha	ʊ
+xtc	Kadugli (Katcha)	Katcha	ɔː
+xtc	Kadugli (Katcha)	Katcha	ɔ
+xtc	Kadugli (Katcha)	Katcha	i
+xtc	Kadugli (Katcha)	Katcha	iː
+xtc	Kadugli (Katcha)	Katcha	e
+xtc	Kadugli (Katcha)	Katcha	eː
+xtc	Kadugli (Katcha)	Katcha	ə
+xtc	Kadugli (Katcha)	Katcha	əː
+xtc	Kadugli (Katcha)	Katcha	u
+xtc	Kadugli (Katcha)	Katcha	uː
+xtc	Kadugli (Katcha)	Katcha	o
+xtc	Kadugli (Katcha)	Katcha	oː
+xtc	Kadugli (Katcha)	Katcha	˦
+xtc	Kadugli (Katcha)	Katcha	˨
+
 mgc	Morokodo		ɓ				mgc.pdf
-mgc	Morokodo		ɗ				
-mgc	Morokodo		ʄ				
-mgc	Morokodo		p				
-mgc	Morokodo		c				
-mgc	Morokodo		t				
-mgc	Morokodo		k				
-mgc	Morokodo		b				
-mgc	Morokodo		d				
-mgc	Morokodo		ɟ				
-mgc	Morokodo		ɡ				
-mgc	Morokodo		ɡb				
-mgc	Morokodo		kp				
-mgc	Morokodo		mb				
-mgc	Morokodo		ɱv				
-mgc	Morokodo		nd				
-mgc	Morokodo		ɲɟ				
-mgc	Morokodo		nz				
-mgc	Morokodo		ŋɡ				
-mgc	Morokodo		ŋmɡb				
-mgc	Morokodo		ndr				
-mgc	Morokodo		dr				
-mgc	Morokodo		tr				
-mgc	Morokodo		ɡbr				
-mgc	Morokodo		kpr				
-mgc	Morokodo		m				
-mgc	Morokodo		n				
-mgc	Morokodo		ɲ				
-mgc	Morokodo		ŋ				
-mgc	Morokodo		f				
-mgc	Morokodo		s				
-mgc	Morokodo		h				
-mgc	Morokodo		v				
-mgc	Morokodo		z				
-mgc	Morokodo		l				
-mgc	Morokodo		r				
-mgc	Morokodo		ɾ				
-mgc	Morokodo		w				
-mgc	Morokodo		j				
-mgc	Morokodo		ʔ				
-mgc	Morokodo		hʷ				
-mgc	Morokodo		tʷ				
-mgc	Morokodo		i				
-mgc	Morokodo		e				
-mgc	Morokodo		ə				
-mgc	Morokodo		ɵ				
-mgc	Morokodo		u				
-mgc	Morokodo		ɪ				
-mgc	Morokodo		ɛ				
-mgc	Morokodo		ɑ				
-mgc	Morokodo		ʊ				
-mgc	Morokodo		ɔ				
-mgc	Morokodo		˦				
-mgc	Morokodo		˨				
-							
+mgc	Morokodo		ɗ
+mgc	Morokodo		ʄ
+mgc	Morokodo		p
+mgc	Morokodo		c
+mgc	Morokodo		t
+mgc	Morokodo		k
+mgc	Morokodo		b
+mgc	Morokodo		d
+mgc	Morokodo		ɟ
+mgc	Morokodo		ɡ
+mgc	Morokodo		ɡb
+mgc	Morokodo		kp
+mgc	Morokodo		mb
+mgc	Morokodo		ɱv
+mgc	Morokodo		nd
+mgc	Morokodo		ɲɟ
+mgc	Morokodo		nz
+mgc	Morokodo		ŋɡ
+mgc	Morokodo		ŋmɡb
+mgc	Morokodo		ndr
+mgc	Morokodo		dr
+mgc	Morokodo		tr
+mgc	Morokodo		ɡbr
+mgc	Morokodo		kpr
+mgc	Morokodo		m
+mgc	Morokodo		n
+mgc	Morokodo		ɲ
+mgc	Morokodo		ŋ
+mgc	Morokodo		f
+mgc	Morokodo		s
+mgc	Morokodo		h
+mgc	Morokodo		v
+mgc	Morokodo		z
+mgc	Morokodo		l
+mgc	Morokodo		r
+mgc	Morokodo		ɾ
+mgc	Morokodo		w
+mgc	Morokodo		j
+mgc	Morokodo		ʔ
+mgc	Morokodo		hʷ
+mgc	Morokodo		tʷ
+mgc	Morokodo		i
+mgc	Morokodo		e
+mgc	Morokodo		ə
+mgc	Morokodo		ɵ
+mgc	Morokodo		u
+mgc	Morokodo		ɪ
+mgc	Morokodo		ɛ
+mgc	Morokodo		ɑ
+mgc	Morokodo		ʊ
+mgc	Morokodo		ɔ
+mgc	Morokodo		˦
+mgc	Morokodo		˨
+
 luc	Aringa		ɪ				luc.pdf
-luc	Aringa		i				
-luc	Aringa		ɛ				
-luc	Aringa		e				
-luc	Aringa		a				
-luc	Aringa		ʊ				
-luc	Aringa		u				
-luc	Aringa		ɔ				
-luc	Aringa		o				
-luc	Aringa		p				
-luc	Aringa		b				
-luc	Aringa		t̪				
-luc	Aringa		d̪				
-luc	Aringa		tɾ				
-luc	Aringa		dɾ				
-luc	Aringa		k				
-luc	Aringa		ɡ				
-luc	Aringa		kp				
-luc	Aringa		ɡb				
-luc	Aringa		ʔ				
-luc	Aringa		f				
-luc	Aringa		v				
-luc	Aringa		s				
-luc	Aringa		z				
-luc	Aringa		ts				
-luc	Aringa		dz				
-luc	Aringa		m				
-luc	Aringa		n				
-luc	Aringa		ɲ				
-luc	Aringa		ŋ				
-luc	Aringa		ŋm				
-luc	Aringa		mb				
-luc	Aringa		ɱv				
-luc	Aringa		nd				
-luc	Aringa		ndɾ				
-luc	Aringa		ndz				
-luc	Aringa		ŋɡ				
-luc	Aringa		ŋmɡb				
-luc	Aringa		ɾ				
-luc	Aringa		l				
-luc	Aringa		ɓ				
-luc	Aringa		ɗ				
-luc	Aringa		ˀw				
-luc	Aringa		ˀj				
-luc	Aringa		˦				
-luc	Aringa		˨				
-luc	Aringa		˧				
-luc	Aringa		˨˦				
-luc	Aringa		˦˨				
-							
+luc	Aringa		i
+luc	Aringa		ɛ
+luc	Aringa		e
+luc	Aringa		a
+luc	Aringa		ʊ
+luc	Aringa		u
+luc	Aringa		ɔ
+luc	Aringa		o
+luc	Aringa		p
+luc	Aringa		b
+luc	Aringa		t̪
+luc	Aringa		d̪
+luc	Aringa		tɾ
+luc	Aringa		dɾ
+luc	Aringa		k
+luc	Aringa		ɡ
+luc	Aringa		kp
+luc	Aringa		ɡb
+luc	Aringa		ʔ
+luc	Aringa		f
+luc	Aringa		v
+luc	Aringa		s
+luc	Aringa		z
+luc	Aringa		ts
+luc	Aringa		dz
+luc	Aringa		m
+luc	Aringa		n
+luc	Aringa		ɲ
+luc	Aringa		ŋ
+luc	Aringa		ŋm
+luc	Aringa		mb
+luc	Aringa		ɱv
+luc	Aringa		nd
+luc	Aringa		ndɾ
+luc	Aringa		ndz
+luc	Aringa		ŋɡ
+luc	Aringa		ŋmɡb
+luc	Aringa		ɾ
+luc	Aringa		l
+luc	Aringa		ɓ
+luc	Aringa		ɗ
+luc	Aringa		ˀw
+luc	Aringa		ˀj
+luc	Aringa		˦
+luc	Aringa		˨
+luc	Aringa		˧
+luc	Aringa		˨˦
+luc	Aringa		˦˨
+
 keg	These		p		[p]		keg.pdf
-keg	These		p		[b]		
-keg	These		p		[f]	free variation, initial position	
-keg	These		p		[h]	free variation, initial position	
-keg	These		m				
-keg	These		ɓ				
-keg	These		t		[t]		
-keg	These		t		[d]		
-keg	These		t		[t̪]		
-keg	These		t		[d̪]		
-keg	These		ɗ				
-keg	These		n				
-keg	These		r				
-keg	These		s				
-keg	These		l				
-keg	These		ʈ		[ʈ]		
-keg	These		ʈ		[ɽ]		
-keg	These		ʈ		[ɖ]		
-keg	These		ɖ				
-keg	These		ɟ				
-keg	These		ɲ				
-keg	These		j				
-keg	These		k		[k]		
-keg	These		k		[ɡ]		
-keg	These		ŋ				
-keg	These		kʷ				
-keg	These		ŋʷ				
-keg	These		w				
-keg	These		tː				
-keg	These		nː				
-keg	These		mː				
-keg	These		lː				
-keg	These		sː				
-keg	These		ɪ				
-keg	These		ɛ				
-keg	These		a				
-keg	These		ɔ				
-keg	These		ʊ				
-keg	These		i				
-keg	These		e				
-keg	These		ə				
-keg	These		o				
-keg	These		u				
-keg	These		ɪː				
-keg	These		ɛː				
-keg	These		aː				
-keg	These		ɔː				
-keg	These		ʊː				
-keg	These		iː				
-keg	These		uː				
-keg	These		əː				
-keg	These		˦				
-keg	These		˨				
-keg	These		˧				
-keg	These		˨˦				
-keg	These		˦˨				
-							
+keg	These		p		[b]
+keg	These		p		[f]	free variation, initial position
+keg	These		p		[h]	free variation, initial position
+keg	These		m
+keg	These		ɓ
+keg	These		t		[t]
+keg	These		t		[d]
+keg	These		t		[t̪]
+keg	These		t		[d̪]
+keg	These		ɗ
+keg	These		n
+keg	These		r
+keg	These		s
+keg	These		l
+keg	These		ʈ		[ʈ]
+keg	These		ʈ		[ɽ]
+keg	These		ʈ		[ɖ]
+keg	These		ɖ
+keg	These		ɟ
+keg	These		ɲ
+keg	These		j
+keg	These		k		[k]
+keg	These		k		[ɡ]
+keg	These		ŋ
+keg	These		kʷ
+keg	These		ŋʷ
+keg	These		w
+keg	These		tː
+keg	These		nː
+keg	These		mː
+keg	These		lː
+keg	These		sː
+keg	These		ɪ
+keg	These		ɛ
+keg	These		a
+keg	These		ɔ
+keg	These		ʊ
+keg	These		i
+keg	These		e
+keg	These		ə
+keg	These		o
+keg	These		u
+keg	These		ɪː
+keg	These		ɛː
+keg	These		aː
+keg	These		ɔː
+keg	These		ʊː
+keg	These		iː
+keg	These		uː
+keg	These		əː
+keg	These		˦
+keg	These		˨
+keg	These		˧
+keg	These		˨˦
+keg	These		˦˨
+
 lmd	Lumun		t		[t]		talodi.pdf
-lmd	Lumun		t		[d]		
-lmd	Lumun		t		[tː]		
-lmd	Lumun		c		[c]		
-lmd	Lumun		c		[ɟ]		
-lmd	Lumun		c		[cː]		
-lmd	Lumun		k		[k]		
-lmd	Lumun		k		[ɡ]		
-lmd	Lumun		k		[kː]		
-lmd	Lumun		kʷ		[kʷ]		
-lmd	Lumun		kʷ		[ɡʷ]		
-lmd	Lumun		kʷ		[kʷː]		
-lmd	Lumun		m		[m]		
-lmd	Lumun		m		[mː]		
-lmd	Lumun		n		[n]		
-lmd	Lumun		n		[nː]		
-lmd	Lumun		ɲ		[ɲ]		
-lmd	Lumun		ɲ		[ɲː]		
-lmd	Lumun		ŋ		[ŋ]		
-lmd	Lumun		ŋ		[ŋː]		
-lmd	Lumun		ŋʷ		[ŋʷ]		
-lmd	Lumun		ŋʷ		[ŋʷː]		
-lmd	Lumun		l		[l]		
-lmd	Lumun		l		[lː]		
-lmd	Lumun		r		[r]		
-lmd	Lumun		r		[rː]		
-lmd	Lumun		ɾ		[ɾ]		
-lmd	Lumun		ɾ		[ɾː]		
-lmd	Lumun		ɽ				
-lmd	Lumun		w				
-lmd	Lumun		j				
-lmd	Lumun		i				
-lmd	Lumun		ə				
-lmd	Lumun		u				
-lmd	Lumun		ɪ				
-lmd	Lumun		ɛ				
-lmd	Lumun		a				
-lmd	Lumun		ʊ				
-lmd	Lumun		ɔ				
-lmd	Lumun		˦				
-lmd	Lumun		˨				
-lmd	Lumun		t̪		[t̪]		
-lmd	Lumun		t̪		[t̪ː]		
-lmd	Lumun		p		[p]		
-lmd	Lumun		p		[b]		
-lmd	Lumun		p		[pː]		
-lmd	Lumun		iː				
-lmd	Lumun		əː				
-lmd	Lumun		uː				
-lmd	Lumun		ɪː				
-lmd	Lumun		aː				
-lmd	Lumun		ɛː				
-lmd	Lumun		ʊː				
-lmd	Lumun		ɔː				
-							
+lmd	Lumun		t		[d]
+lmd	Lumun		t		[tː]
+lmd	Lumun		c		[c]
+lmd	Lumun		c		[ɟ]
+lmd	Lumun		c		[cː]
+lmd	Lumun		k		[k]
+lmd	Lumun		k		[ɡ]
+lmd	Lumun		k		[kː]
+lmd	Lumun		kʷ		[kʷ]
+lmd	Lumun		kʷ		[ɡʷ]
+lmd	Lumun		kʷ		[kʷː]
+lmd	Lumun		m		[m]
+lmd	Lumun		m		[mː]
+lmd	Lumun		n		[n]
+lmd	Lumun		n		[nː]
+lmd	Lumun		ɲ		[ɲ]
+lmd	Lumun		ɲ		[ɲː]
+lmd	Lumun		ŋ		[ŋ]
+lmd	Lumun		ŋ		[ŋː]
+lmd	Lumun		ŋʷ		[ŋʷ]
+lmd	Lumun		ŋʷ		[ŋʷː]
+lmd	Lumun		l		[l]
+lmd	Lumun		l		[lː]
+lmd	Lumun		r		[r]
+lmd	Lumun		r		[rː]
+lmd	Lumun		ɾ		[ɾ]
+lmd	Lumun		ɾ		[ɾː]
+lmd	Lumun		ɽ
+lmd	Lumun		w
+lmd	Lumun		j
+lmd	Lumun		i
+lmd	Lumun		ə
+lmd	Lumun		u
+lmd	Lumun		ɪ
+lmd	Lumun		ɛ
+lmd	Lumun		a
+lmd	Lumun		ʊ
+lmd	Lumun		ɔ
+lmd	Lumun		˦
+lmd	Lumun		˨
+lmd	Lumun		t̪		[t̪]
+lmd	Lumun		t̪		[t̪ː]
+lmd	Lumun		p		[p]
+lmd	Lumun		p		[b]
+lmd	Lumun		p		[pː]
+lmd	Lumun		iː
+lmd	Lumun		əː
+lmd	Lumun		uː
+lmd	Lumun		ɪː
+lmd	Lumun		aː
+lmd	Lumun		ɛː
+lmd	Lumun		ʊː
+lmd	Lumun		ɔː
+
 acz	Asharon		p		[p]		talodi.pdf
-acz	Asharon		p		[b]		
-acz	Asharon		t̪		[t̪]		
-acz	Asharon		t̪		[d̪ʉ		
-acz	Asharon		t		[t]		
-acz	Asharon		t		[ɽ]		
-acz	Asharon		c		[c]		
-acz	Asharon		c		[ɟ]		
-acz	Asharon		k		[k]		
-acz	Asharon		k		[ɡ]		
-acz	Asharon		kʷ		[kʷ]		
-acz	Asharon		kʷ		[ɡʷ]		
-acz	Asharon		ts				
-acz	Asharon		s		[s]		
-acz	Asharon		s		[z]		
-acz	Asharon		m				
-acz	Asharon		n				
-acz	Asharon		ɲ				
-acz	Asharon		ŋ				
-acz	Asharon		ŋʷ				
-acz	Asharon		l				
-acz	Asharon		r				
-acz	Asharon		w				
-acz	Asharon		j				
-acz	Asharon		i				
-acz	Asharon		e				
-acz	Asharon		ə				
-acz	Asharon		u				
-acz	Asharon		o				
-acz	Asharon		ɪ				
-acz	Asharon		ɛ				
-acz	Asharon		a				
-acz	Asharon		ʊ				
-acz	Asharon		ɔ				
-acz	Asharon		iː				
-acz	Asharon		eː				
-acz	Asharon		əː				
-acz	Asharon		uː				
-acz	Asharon		oː				
-acz	Asharon		ɪː				
-acz	Asharon		ɛː				
-acz	Asharon		aː				
-acz	Asharon		ʊː				
-acz	Asharon		ɔː				
-acz	Asharon		ɲː				
-							
+acz	Asharon		p		[b]
+acz	Asharon		t̪		[t̪]
+acz	Asharon		t̪		[d̪ʉ
+acz	Asharon		t		[t]
+acz	Asharon		t		[ɽ]
+acz	Asharon		c		[c]
+acz	Asharon		c		[ɟ]
+acz	Asharon		k		[k]
+acz	Asharon		k		[ɡ]
+acz	Asharon		kʷ		[kʷ]
+acz	Asharon		kʷ		[ɡʷ]
+acz	Asharon		ts
+acz	Asharon		s		[s]
+acz	Asharon		s		[z]
+acz	Asharon		m
+acz	Asharon		n
+acz	Asharon		ɲ
+acz	Asharon		ŋ
+acz	Asharon		ŋʷ
+acz	Asharon		l
+acz	Asharon		r
+acz	Asharon		w
+acz	Asharon		j
+acz	Asharon		i
+acz	Asharon		e
+acz	Asharon		ə
+acz	Asharon		u
+acz	Asharon		o
+acz	Asharon		ɪ
+acz	Asharon		ɛ
+acz	Asharon		a
+acz	Asharon		ʊ
+acz	Asharon		ɔ
+acz	Asharon		iː
+acz	Asharon		eː
+acz	Asharon		əː
+acz	Asharon		uː
+acz	Asharon		oː
+acz	Asharon		ɪː
+acz	Asharon		ɛː
+acz	Asharon		aː
+acz	Asharon		ʊː
+acz	Asharon		ɔː
+acz	Asharon		ɲː
+
 taz	Tocco		p		[p]		talodi.pdf
-taz	Tocco		p		[b]		
-taz	Tocco		p		[pː]		
-taz	Tocco		t̪		[t̪]		
-taz	Tocco		t̪		[d̪]		
-taz	Tocco		t̪		[t̪ː]		
-taz	Tocco		t		[t]		
-taz	Tocco		t		[d]		
-taz	Tocco		t		[rː]		
-taz	Tocco		c		[c]		
-taz	Tocco		c		[ɟ]		
-taz	Tocco		c		[cː]		
-taz	Tocco		k		[k]		
-taz	Tocco		k		[ɡ]		
-taz	Tocco		k		kː]		
-taz	Tocco		m		[m]		
-taz	Tocco		m		[mː]		
-taz	Tocco		n		[n]		
-taz	Tocco		n		[nː]		
-taz	Tocco		ɲ		[ɲ]		
-taz	Tocco		ɲ		[ɲː]		
-taz	Tocco		ŋ		[ŋ]		
-taz	Tocco		ŋ		[ŋː]		
-taz	Tocco		ŋʷ		[ŋʷ]		
-taz	Tocco		ŋʷ		[ŋʷː]		
-taz	Tocco		l		[l]		
-taz	Tocco		l		[lː]		
-taz	Tocco		r		[r]		
-taz	Tocco		r		[rː]		
-taz	Tocco		ɾ		[ɾ]		
-taz	Tocco		ɾ		[ɾː]		
-taz	Tocco		w				
-taz	Tocco		i				
-taz	Tocco		e				
-taz	Tocco		ə				
-taz	Tocco		u				
-taz	Tocco		o				
-taz	Tocco		ɪ				
-taz	Tocco		ɛ				
-taz	Tocco		a				
-taz	Tocco		ʊ				
-taz	Tocco		ɔ				
-taz	Tocco		˦				
-taz	Tocco		˨				
-taz	Tocco		<j>	in question			
-							
+taz	Tocco		p		[b]
+taz	Tocco		p		[pː]
+taz	Tocco		t̪		[t̪]
+taz	Tocco		t̪		[d̪]
+taz	Tocco		t̪		[t̪ː]
+taz	Tocco		t		[t]
+taz	Tocco		t		[d]
+taz	Tocco		t		[rː]
+taz	Tocco		c		[c]
+taz	Tocco		c		[ɟ]
+taz	Tocco		c		[cː]
+taz	Tocco		k		[k]
+taz	Tocco		k		[ɡ]
+taz	Tocco		k		kː]
+taz	Tocco		m		[m]
+taz	Tocco		m		[mː]
+taz	Tocco		n		[n]
+taz	Tocco		n		[nː]
+taz	Tocco		ɲ		[ɲ]
+taz	Tocco		ɲ		[ɲː]
+taz	Tocco		ŋ		[ŋ]
+taz	Tocco		ŋ		[ŋː]
+taz	Tocco		ŋʷ		[ŋʷ]
+taz	Tocco		ŋʷ		[ŋʷː]
+taz	Tocco		l		[l]
+taz	Tocco		l		[lː]
+taz	Tocco		r		[r]
+taz	Tocco		r		[rː]
+taz	Tocco		ɾ		[ɾ]
+taz	Tocco		ɾ		[ɾː]
+taz	Tocco		w
+taz	Tocco		i
+taz	Tocco		e
+taz	Tocco		ə
+taz	Tocco		u
+taz	Tocco		o
+taz	Tocco		ɪ
+taz	Tocco		ɛ
+taz	Tocco		a
+taz	Tocco		ʊ
+taz	Tocco		ɔ
+taz	Tocco		˦
+taz	Tocco		˨
+taz	Tocco		<j>	in question
+
 dec	Thakik		p				talodi.pdf
-dec	Thakik		t̪				
-dec	Thakik		t				
-dec	Thakik		k				
-dec	Thakik		ɸ				
-dec	Thakik		s				
-dec	Thakik		x				
-dec	Thakik		m				
-dec	Thakik		n				
-dec	Thakik		ŋ				
-dec	Thakik		l				
-dec	Thakik		r				
-dec	Thakik		ɾ				
-dec	Thakik		ɽ				
-dec	Thakik		w				
-dec	Thakik		j				
-dec	Thakik		i				
-dec	Thakik		e				
-dec	Thakik		ə				
-dec	Thakik		u				
-dec	Thakik		o				
-dec	Thakik		ɪ				
-dec	Thakik		ɛ				
-dec	Thakik		a				
-dec	Thakik		ʊ				
-dec	Thakik		ɔ				
-							
+dec	Thakik		t̪
+dec	Thakik		t
+dec	Thakik		k
+dec	Thakik		ɸ
+dec	Thakik		s
+dec	Thakik		x
+dec	Thakik		m
+dec	Thakik		n
+dec	Thakik		ŋ
+dec	Thakik		l
+dec	Thakik		r
+dec	Thakik		ɾ
+dec	Thakik		ɽ
+dec	Thakik		w
+dec	Thakik		j
+dec	Thakik		i
+dec	Thakik		e
+dec	Thakik		ə
+dec	Thakik		u
+dec	Thakik		o
+dec	Thakik		ɪ
+dec	Thakik		ɛ
+dec	Thakik		a
+dec	Thakik		ʊ
+dec	Thakik		ɔ
+
 did	Didinga		ɓ				did.pdf
-did	Didinga		m				
-did	Didinga		w				
-did	Didinga		b		[b]		
-did	Didinga		b		[p̚]		
-did	Didinga		p				
-did	Didinga		v				
-did	Didinga		mː				
-did	Didinga		β				
-did	Didinga		d̪				
-did	Didinga		t̪				
-did	Didinga		t̺	DRM: Resource clearly says that the two anterior coronals are a laminal dental (which is t̪ and is correct in PHOIBLE) and an apical dental (which is the one that needs to be changed).			
-did	Didinga		ð		[ð]		
-did	Didinga		ð		[θ]		
-did	Didinga		ðː				
-did	Didinga		ɗ				
-did	Didinga		d		[d]		
-did	Didinga		d		[t̚]		
-did	Didinga		ʈ				
-did	Didinga		n				
-did	Didinga		nː				
-did	Didinga		l				
-did	Didinga		lː				
-did	Didinga		ɾ				
-did	Didinga		r				
-did	Didinga		ʄ				
-did	Didinga		d̠ʒ		[d̠ʒ]		
-did	Didinga		d̠ʒ		[t̠ʃ̚]		
-did	Didinga		t̠ʃ				
-did	Didinga		ʒ				
-did	Didinga		ɲ				
-did	Didinga		ɲː				
-did	Didinga		j				
-did	Didinga		ʝ				
-did	Didinga		ɠ				
-did	Didinga		ɡ		[ɡ]		
-did	Didinga		ɡ		[k̚]		
-did	Didinga		k				
-did	Didinga		ɣ		[ɣ]		
-did	Didinga		ɣ		[x]		
-did	Didinga		ŋ				
-did	Didinga		ŋː				
-did	Didinga		e				
-did	Didinga		eː				
-did	Didinga		i				
-did	Didinga		iː				
-did	Didinga		o				
-did	Didinga		oː				
-did	Didinga		u				
-did	Didinga		uː				
-did	Didinga		ɛ				
-did	Didinga		ɛː				
-did	Didinga		ɪ				
-did	Didinga		ɪː				
-did	Didinga		ɔ				
-did	Didinga		ɔː				
-did	Didinga		ʊ				
-did	Didinga		ʊː				
-did	Didinga		a				
-did	Didinga		aː				
-did	Didinga		˨˦				
-did	Didinga		˦˨				
-did	Didinga		˦				
-did	Didinga		˨				
-							
+did	Didinga		m
+did	Didinga		w
+did	Didinga		b		[b]
+did	Didinga		b		[p̚]
+did	Didinga		p
+did	Didinga		v
+did	Didinga		mː
+did	Didinga		β
+did	Didinga		d̪
+did	Didinga		t̪
+did	Didinga		t̺	DRM: Resource clearly says that the two anterior coronals are a laminal dental (which is t̪ and is correct in PHOIBLE) and an apical dental (which is the one that needs to be changed).
+did	Didinga		ð		[ð]
+did	Didinga		ð		[θ]
+did	Didinga		ðː
+did	Didinga		ɗ
+did	Didinga		d		[d]
+did	Didinga		d		[t̚]
+did	Didinga		ʈ
+did	Didinga		n
+did	Didinga		nː
+did	Didinga		l
+did	Didinga		lː
+did	Didinga		ɾ
+did	Didinga		r
+did	Didinga		ʄ
+did	Didinga		d̠ʒ		[d̠ʒ]
+did	Didinga		d̠ʒ		[t̠ʃ̚]
+did	Didinga		t̠ʃ
+did	Didinga		ʒ
+did	Didinga		ɲ
+did	Didinga		ɲː
+did	Didinga		j
+did	Didinga		ʝ
+did	Didinga		ɠ
+did	Didinga		ɡ		[ɡ]
+did	Didinga		ɡ		[k̚]
+did	Didinga		k
+did	Didinga		ɣ		[ɣ]
+did	Didinga		ɣ		[x]
+did	Didinga		ŋ
+did	Didinga		ŋː
+did	Didinga		e
+did	Didinga		eː
+did	Didinga		i
+did	Didinga		iː
+did	Didinga		o
+did	Didinga		oː
+did	Didinga		u
+did	Didinga		uː
+did	Didinga		ɛ
+did	Didinga		ɛː
+did	Didinga		ɪ
+did	Didinga		ɪː
+did	Didinga		ɔ
+did	Didinga		ɔː
+did	Didinga		ʊ
+did	Didinga		ʊː
+did	Didinga		a
+did	Didinga		aː
+did	Didinga		˨˦
+did	Didinga		˦˨
+did	Didinga		˦
+did	Didinga		˨
+
 lwo	Luwo		i				lwoian.pdf
-lwo	Luwo		eː				
-lwo	Luwo		ə				
-lwo	Luwo		oː				
-lwo	Luwo		u				
-lwo	Luwo		ɪ				
-lwo	Luwo		ɛ				
-lwo	Luwo		ɑ				
-lwo	Luwo		ɔ				
-lwo	Luwo		ʊ				
-lwo	Luwo		˦				
-lwo	Luwo		˨				
-lwo	Luwo		˧				
-lwo	Luwo		b				
-lwo	Luwo		c				
-lwo	Luwo		d̪				
-lwo	Luwo		d				
-lwo	Luwo		ɟ				
-lwo	Luwo		ɡ				
-lwo	Luwo		k				
-lwo	Luwo		l				
-lwo	Luwo		m				
-lwo	Luwo		n				
-lwo	Luwo		n̪				
-lwo	Luwo		ɲ				
-lwo	Luwo		ŋ				
-lwo	Luwo		p				
-lwo	Luwo		ɾ				
-lwo	Luwo		t̪				
-lwo	Luwo		t				
-lwo	Luwo		j				
-lwo	Luwo		w				
-							
+lwo	Luwo		eː
+lwo	Luwo		ə
+lwo	Luwo		oː
+lwo	Luwo		u
+lwo	Luwo		ɪ
+lwo	Luwo		ɛ
+lwo	Luwo		ɑ
+lwo	Luwo		ɔ
+lwo	Luwo		ʊ
+lwo	Luwo		˦
+lwo	Luwo		˨
+lwo	Luwo		˧
+lwo	Luwo		b
+lwo	Luwo		c
+lwo	Luwo		d̪
+lwo	Luwo		d
+lwo	Luwo		ɟ
+lwo	Luwo		ɡ
+lwo	Luwo		k
+lwo	Luwo		l
+lwo	Luwo		m
+lwo	Luwo		n
+lwo	Luwo		n̪
+lwo	Luwo		ɲ
+lwo	Luwo		ŋ
+lwo	Luwo		p
+lwo	Luwo		ɾ
+lwo	Luwo		t̪
+lwo	Luwo		t
+lwo	Luwo		j
+lwo	Luwo		w
+
 ach	Acholi		e				lwoian.pdf
-ach	Acholi		ɑ				
-ach	Acholi		o				
-ach	Acholi		u				
-ach	Acholi		ɪ				
-ach	Acholi		ɛ				
-ach	Acholi		b				
-ach	Acholi		c				
-ach	Acholi		d̪				
-ach	Acholi		d				
-ach	Acholi		ɡ				
-ach	Acholi		ɟ				
-ach	Acholi		k				
-ach	Acholi		l				
-ach	Acholi		m				
-ach	Acholi		n				
-ach	Acholi		ɲ				
-ach	Acholi		ŋ				
-ach	Acholi		p				
-ach	Acholi		ɾ				
-ach	Acholi		t				
-ach	Acholi		w				
-ach	Acholi		j				
-ach	Acholi		˦				
-ach	Acholi		˨				
-ach	Acholi		˧				
-ach	Acholi		ɛ				
-ach	Acholi		ɔ				
-ach	Acholi		ʊ				
-ach	Acholi		ə				
-							
+ach	Acholi		ɑ
+ach	Acholi		o
+ach	Acholi		u
+ach	Acholi		ɪ
+ach	Acholi		ɛ
+ach	Acholi		b
+ach	Acholi		c
+ach	Acholi		d̪
+ach	Acholi		d
+ach	Acholi		ɡ
+ach	Acholi		ɟ
+ach	Acholi		k
+ach	Acholi		l
+ach	Acholi		m
+ach	Acholi		n
+ach	Acholi		ɲ
+ach	Acholi		ŋ
+ach	Acholi		p
+ach	Acholi		ɾ
+ach	Acholi		t
+ach	Acholi		w
+ach	Acholi		j
+ach	Acholi		˦
+ach	Acholi		˨
+ach	Acholi		˧
+ach	Acholi		ɛ
+ach	Acholi		ɔ
+ach	Acholi		ʊ
+ach	Acholi		ə
+
 bxb	Belanda Boor		i				lwoian.pdf
-bxb	Belanda Boor		ɪ				
-bxb	Belanda Boor		ɛ				
-bxb	Belanda Boor		e				
-bxb	Belanda Boor		ɑ				
-bxb	Belanda Boor		ə				
-bxb	Belanda Boor		o				
-bxb	Belanda Boor		ɔ				
-bxb	Belanda Boor		u				
-bxb	Belanda Boor		ʊ				
-bxb	Belanda Boor		b				
-bxb	Belanda Boor		c				
-bxb	Belanda Boor		d̪				
-bxb	Belanda Boor		ɗ				
-bxb	Belanda Boor		d				
-bxb	Belanda Boor		ɡ				
-bxb	Belanda Boor		f				
-bxb	Belanda Boor		ɡb				
-bxb	Belanda Boor		ɟ				
-bxb	Belanda Boor		k				
-bxb	Belanda Boor		kp				
-bxb	Belanda Boor		l				
-bxb	Belanda Boor		m				
-bxb	Belanda Boor		mb				
-bxb	Belanda Boor		n				
-bxb	Belanda Boor		nd				
-bxb	Belanda Boor		n̪				
-bxb	Belanda Boor		ɲɟ				
-bxb	Belanda Boor		ɲ				
-bxb	Belanda Boor		ŋ				
-bxb	Belanda Boor		ŋmɡb				
-bxb	Belanda Boor		ɾ				
-bxb	Belanda Boor		t				
-bxb	Belanda Boor		w				
-bxb	Belanda Boor		j				
-bxb	Belanda Boor		˦				
-bxb	Belanda Boor		˨				
-bxb	Belanda Boor		˧				
-							
+bxb	Belanda Boor		ɪ
+bxb	Belanda Boor		ɛ
+bxb	Belanda Boor		e
+bxb	Belanda Boor		ɑ
+bxb	Belanda Boor		ə
+bxb	Belanda Boor		o
+bxb	Belanda Boor		ɔ
+bxb	Belanda Boor		u
+bxb	Belanda Boor		ʊ
+bxb	Belanda Boor		b
+bxb	Belanda Boor		c
+bxb	Belanda Boor		d̪
+bxb	Belanda Boor		ɗ
+bxb	Belanda Boor		d
+bxb	Belanda Boor		ɡ
+bxb	Belanda Boor		f
+bxb	Belanda Boor		ɡb
+bxb	Belanda Boor		ɟ
+bxb	Belanda Boor		k
+bxb	Belanda Boor		kp
+bxb	Belanda Boor		l
+bxb	Belanda Boor		m
+bxb	Belanda Boor		mb
+bxb	Belanda Boor		n
+bxb	Belanda Boor		nd
+bxb	Belanda Boor		n̪
+bxb	Belanda Boor		ɲɟ
+bxb	Belanda Boor		ɲ
+bxb	Belanda Boor		ŋ
+bxb	Belanda Boor		ŋmɡb
+bxb	Belanda Boor		ɾ
+bxb	Belanda Boor		t
+bxb	Belanda Boor		w
+bxb	Belanda Boor		j
+bxb	Belanda Boor		˦
+bxb	Belanda Boor		˨
+bxb	Belanda Boor		˧
+
 bvi	Belanda Viri		ɓ				viri.pdf
-bvi	Belanda Viri		m				
-bvi	Belanda Viri		f				
-bvi	Belanda Viri		v				
-bvi	Belanda Viri		ɱv				
-bvi	Belanda Viri		t				
-bvi	Belanda Viri		d				
-bvi	Belanda Viri		ɗ				
-bvi	Belanda Viri		s				
-bvi	Belanda Viri		z				
-bvi	Belanda Viri		n				
-bvi	Belanda Viri		nd				
-bvi	Belanda Viri		nz				
-bvi	Belanda Viri		l				
-bvi	Belanda Viri		r		[r]		
-bvi	Belanda Viri		r		[ɾ]		
-bvi	Belanda Viri		d̠ʒ	sounds listed in phonetic inventory, not phoneme inventory, but no comment on what phoneme they are associated with			
-bvi	Belanda Viri		c	sounds listed in phonetic inventory, not phoneme inventory, but no comment on what phoneme they are associated with			
-bvi	Belanda Viri		ɟ	sounds listed in phonetic inventory, not phoneme inventory, but no comment on what phoneme they are associated with			
-bvi	Belanda Viri		ɲɟ				
-bvi	Belanda Viri		j				
-bvi	Belanda Viri		k				
-bvi	Belanda Viri		ɡ				
-bvi	Belanda Viri		ŋ				
-bvi	Belanda Viri		ŋɡ				
-bvi	Belanda Viri		kp				
-bvi	Belanda Viri		ɡb				
-bvi	Belanda Viri		ŋmɡb				
-bvi	Belanda Viri		w				
-bvi	Belanda Viri		i				
-bvi	Belanda Viri		ɪ				
-bvi	Belanda Viri		e				
-bvi	Belanda Viri		ɛ				
-bvi	Belanda Viri		ɘ				
-bvi	Belanda Viri		ɑ				
-bvi	Belanda Viri		u				
-bvi	Belanda Viri		ʊ				
-bvi	Belanda Viri		o				
-bvi	Belanda Viri		ɔ				
-bvi	Belanda Viri		˨˦				
-bvi	Belanda Viri		˦˨				
-bvi	Belanda Viri		˦				
-bvi	Belanda Viri		˨				
-bvi	Belanda Viri		˧				
-							
+bvi	Belanda Viri		m
+bvi	Belanda Viri		f
+bvi	Belanda Viri		v
+bvi	Belanda Viri		ɱv
+bvi	Belanda Viri		t
+bvi	Belanda Viri		d
+bvi	Belanda Viri		ɗ
+bvi	Belanda Viri		s
+bvi	Belanda Viri		z
+bvi	Belanda Viri		n
+bvi	Belanda Viri		nd
+bvi	Belanda Viri		nz
+bvi	Belanda Viri		l
+bvi	Belanda Viri		r		[r]
+bvi	Belanda Viri		r		[ɾ]
+bvi	Belanda Viri		d̠ʒ	sounds listed in phonetic inventory, not phoneme inventory, but no comment on what phoneme they are associated with
+bvi	Belanda Viri		c	sounds listed in phonetic inventory, not phoneme inventory, but no comment on what phoneme they are associated with
+bvi	Belanda Viri		ɟ	sounds listed in phonetic inventory, not phoneme inventory, but no comment on what phoneme they are associated with
+bvi	Belanda Viri		ɲɟ
+bvi	Belanda Viri		j
+bvi	Belanda Viri		k
+bvi	Belanda Viri		ɡ
+bvi	Belanda Viri		ŋ
+bvi	Belanda Viri		ŋɡ
+bvi	Belanda Viri		kp
+bvi	Belanda Viri		ɡb
+bvi	Belanda Viri		ŋmɡb
+bvi	Belanda Viri		w
+bvi	Belanda Viri		i
+bvi	Belanda Viri		ɪ
+bvi	Belanda Viri		e
+bvi	Belanda Viri		ɛ
+bvi	Belanda Viri		ɘ
+bvi	Belanda Viri		ɑ
+bvi	Belanda Viri		u
+bvi	Belanda Viri		ʊ
+bvi	Belanda Viri		o
+bvi	Belanda Viri		ɔ
+bvi	Belanda Viri		˨˦
+bvi	Belanda Viri		˦˨
+bvi	Belanda Viri		˦
+bvi	Belanda Viri		˨
+bvi	Belanda Viri		˧
+
 ndz	Ndogo		p				viri.pdf
-ndz	Ndogo		t				
-ndz	Ndogo		c				
-ndz	Ndogo		k				
-ndz	Ndogo		kp				
-ndz	Ndogo		b				
-ndz	Ndogo		d				
-ndz	Ndogo		ɟ				
-ndz	Ndogo		ɡ				
-ndz	Ndogo		ɡb				
-ndz	Ndogo		ɓ				
-ndz	Ndogo		ɗ				
-ndz	Ndogo		m				
-ndz	Ndogo		n				
-ndz	Ndogo		mb				
-ndz	Ndogo		nd				
-ndz	Ndogo		ɲɟ				
-ndz	Ndogo		nɡ				
-ndz	Ndogo		ŋmɡb				
-ndz	Ndogo		f				
-ndz	Ndogo		s				
-ndz	Ndogo		v				
-ndz	Ndogo		z				
-ndz	Ndogo		ⱱ				
-ndz	Ndogo		l				
-ndz	Ndogo		r				
-ndz	Ndogo		ɾ				
-ndz	Ndogo		w				
-ndz	Ndogo		j				
-ndz	Ndogo		ɪ				
-ndz	Ndogo		ɛ				
-ndz	Ndogo		a				
-ndz	Ndogo		ɔ				
-ndz	Ndogo		ʊ				
-ndz	Ndogo		˦˨				
-ndz	Ndogo		˦				
-ndz	Ndogo		˨				
-ndz	Ndogo		˧				
-							
+ndz	Ndogo		t
+ndz	Ndogo		c
+ndz	Ndogo		k
+ndz	Ndogo		kp
+ndz	Ndogo		b
+ndz	Ndogo		d
+ndz	Ndogo		ɟ
+ndz	Ndogo		ɡ
+ndz	Ndogo		ɡb
+ndz	Ndogo		ɓ
+ndz	Ndogo		ɗ
+ndz	Ndogo		m
+ndz	Ndogo		n
+ndz	Ndogo		mb
+ndz	Ndogo		nd
+ndz	Ndogo		ɲɟ
+ndz	Ndogo		nɡ
+ndz	Ndogo		ŋmɡb
+ndz	Ndogo		f
+ndz	Ndogo		s
+ndz	Ndogo		v
+ndz	Ndogo		z
+ndz	Ndogo		ⱱ
+ndz	Ndogo		l
+ndz	Ndogo		r
+ndz	Ndogo		ɾ
+ndz	Ndogo		w
+ndz	Ndogo		j
+ndz	Ndogo		ɪ
+ndz	Ndogo		ɛ
+ndz	Ndogo		a
+ndz	Ndogo		ɔ
+ndz	Ndogo		ʊ
+ndz	Ndogo		˦˨
+ndz	Ndogo		˦
+ndz	Ndogo		˨
+ndz	Ndogo		˧
+
 bde	Bade	Western	p				bde.pdf
-bde	Bade	Western	b				
-bde	Bade	Western	ɓ				
-bde	Bade	Western	f				
-bde	Bade	Western	v				
-bde	Bade	Western	m				
-bde	Bade	Western	t				
-bde	Bade	Western	d				
-bde	Bade	Western	ɗ				
-bde	Bade	Western	s				
-bde	Bade	Western	z				
-bde	Bade	Western	n				
-bde	Bade	Western	r				
-bde	Bade	Western	t̠ʃ				
-bde	Bade	Western	d̠ʒ				
-bde	Bade	Western	ʄ	updated from ʔʲ -- DRM			
-bde	Bade	Western	ɗʲ				
-bde	Bade	Western	ʃ				
-bde	Bade	Western	ɲ				
-bde	Bade	Western	j				
-bde	Bade	Western	ɮ				
-bde	Bade	Western	ɬ				
-bde	Bade	Western	l				
-bde	Bade	Western	k				
-bde	Bade	Western	ɡ				
-bde	Bade	Western	ŋ				
-bde	Bade	Western	kʷ				
-bde	Bade	Western	ɡʷ				
-bde	Bade	Western	w				
-bde	Bade	Western	ħ				
-bde	Bade	Western	ʕ				
-bde	Bade	Western	ħʷ				
-bde	Bade	Western	ʕʷ				
-bde	Bade	Western	i				
-bde	Bade	Western	eː				
-bde	Bade	Western	ɨ				
-bde	Bade	Western	a				
-bde	Bade	Western	iː				
-bde	Bade	Western	aː				
-bde	Bade	Western	u				
-bde	Bade	Western	uː				
-bde	Bade	Western	oː				
-bde	Bade	Western	˨˦				
-bde	Bade	Western	˦˨				
-bde	Bade	Western	˦				
-bde	Bade	Western	˨				
-							
+bde	Bade	Western	b
+bde	Bade	Western	ɓ
+bde	Bade	Western	f
+bde	Bade	Western	v
+bde	Bade	Western	m
+bde	Bade	Western	t
+bde	Bade	Western	d
+bde	Bade	Western	ɗ
+bde	Bade	Western	s
+bde	Bade	Western	z
+bde	Bade	Western	n
+bde	Bade	Western	r
+bde	Bade	Western	t̠ʃ
+bde	Bade	Western	d̠ʒ
+bde	Bade	Western	ʄ	updated from ʔʲ -- DRM
+bde	Bade	Western	ɗʲ
+bde	Bade	Western	ʃ
+bde	Bade	Western	ɲ
+bde	Bade	Western	j
+bde	Bade	Western	ɮ
+bde	Bade	Western	ɬ
+bde	Bade	Western	l
+bde	Bade	Western	k
+bde	Bade	Western	ɡ
+bde	Bade	Western	ŋ
+bde	Bade	Western	kʷ
+bde	Bade	Western	ɡʷ
+bde	Bade	Western	w
+bde	Bade	Western	ħ
+bde	Bade	Western	ʕ
+bde	Bade	Western	ħʷ
+bde	Bade	Western	ʕʷ
+bde	Bade	Western	i
+bde	Bade	Western	eː
+bde	Bade	Western	ɨ
+bde	Bade	Western	a
+bde	Bade	Western	iː
+bde	Bade	Western	aː
+bde	Bade	Western	u
+bde	Bade	Western	uː
+bde	Bade	Western	oː
+bde	Bade	Western	˨˦
+bde	Bade	Western	˦˨
+bde	Bade	Western	˦
+bde	Bade	Western	˨
+
 fpe	Pichi		p				fpe.pdf
-fpe	Pichi		b				
-fpe	Pichi		t				
-fpe	Pichi		d				
-fpe	Pichi		k				
-fpe	Pichi		ɡ				
-fpe	Pichi		t̠ʃ				
-fpe	Pichi		d̠ʒ				
-fpe	Pichi		f				
-fpe	Pichi		v				
-fpe	Pichi		s				
-fpe	Pichi		ʃ				
-fpe	Pichi		ʁ				
-fpe	Pichi		h				
-fpe	Pichi		m				
-fpe	Pichi		n				
-fpe	Pichi		ɲ				
-fpe	Pichi		ŋ				
-fpe	Pichi		l				
-fpe	Pichi		j				
-fpe	Pichi		w				
-fpe	Pichi		i				
-fpe	Pichi		u				
-fpe	Pichi		e				
-fpe	Pichi		o				
-fpe	Pichi		ɛ				
-fpe	Pichi		ɔ				
-fpe	Pichi		a				
-fpe	Pichi		˦				
-fpe	Pichi		˨				
-							
+fpe	Pichi		b
+fpe	Pichi		t
+fpe	Pichi		d
+fpe	Pichi		k
+fpe	Pichi		ɡ
+fpe	Pichi		t̠ʃ
+fpe	Pichi		d̠ʒ
+fpe	Pichi		f
+fpe	Pichi		v
+fpe	Pichi		s
+fpe	Pichi		ʃ
+fpe	Pichi		ʁ
+fpe	Pichi		h
+fpe	Pichi		m
+fpe	Pichi		n
+fpe	Pichi		ɲ
+fpe	Pichi		ŋ
+fpe	Pichi		l
+fpe	Pichi		j
+fpe	Pichi		w
+fpe	Pichi		i
+fpe	Pichi		u
+fpe	Pichi		e
+fpe	Pichi		o
+fpe	Pichi		ɛ
+fpe	Pichi		ɔ
+fpe	Pichi		a
+fpe	Pichi		˦
+fpe	Pichi		˨
+
 jit	Jita		p				jit.pdf
-jit	Jita		β				
-jit	Jita		t				
-jit	Jita		d				
-jit	Jita		k				
-jit	Jita		ɡ				
-jit	Jita		f				
-jit	Jita		s				
-jit	Jita		t̠ʃ				
-jit	Jita		d̠ʒ				
-jit	Jita		m				
-jit	Jita		n				
-jit	Jita		mb				
-jit	Jita		nd				
-jit	Jita		ɲɟ				
-jit	Jita		ŋɡ				
-jit	Jita		l		[l]		
-jit	Jita		l		[ɾ]		
-jit	Jita		l		[ɺ]		
-jit	Jita		i				
-jit	Jita		iː				
-jit	Jita		e				
-jit	Jita		eː				
-jit	Jita		u				
-jit	Jita		uː				
-jit	Jita		o				
-jit	Jita		oː				
-jit	Jita		a				
-jit	Jita		aː				
-jit	Jita		˦				
-jit	Jita		˨				
-							
+jit	Jita		β
+jit	Jita		t
+jit	Jita		d
+jit	Jita		k
+jit	Jita		ɡ
+jit	Jita		f
+jit	Jita		s
+jit	Jita		t̠ʃ
+jit	Jita		d̠ʒ
+jit	Jita		m
+jit	Jita		n
+jit	Jita		mb
+jit	Jita		nd
+jit	Jita		ɲɟ
+jit	Jita		ŋɡ
+jit	Jita		l		[l]
+jit	Jita		l		[ɾ]
+jit	Jita		l		[ɺ]
+jit	Jita		i
+jit	Jita		iː
+jit	Jita		e
+jit	Jita		eː
+jit	Jita		u
+jit	Jita		uː
+jit	Jita		o
+jit	Jita		oː
+jit	Jita		a
+jit	Jita		aː
+jit	Jita		˦
+jit	Jita		˨
+
 dim	Dime		p		[p]		dim.pdf
-dim	Dime		p		[pʰ]		
-dim	Dime		p		[ɸ]		
-dim	Dime		b		[b]		
-dim	Dime		b		[β]		
-dim	Dime		pʼ				
-dim	Dime		f				
-dim	Dime		m				
-dim	Dime		w				
-dim	Dime		t		[t]		
-dim	Dime		t		[tʰ]		
-dim	Dime		d				
-dim	Dime		tʼ				
-dim	Dime		ɗ				
-dim	Dime		s				
-dim	Dime		z				
-dim	Dime		ʃ				
-dim	Dime		ts				
-dim	Dime		n		[n]		
-dim	Dime		n		[ɲ]		
-dim	Dime		l				
-dim	Dime		ɾ				
-dim	Dime		ʃ				
-dim	Dime		ʒ				
-dim	Dime		t̠ʃ				
-dim	Dime		d̠ʒ				
-dim	Dime		t̠ʃʼ				
-dim	Dime		j				
-dim	Dime		k		[k]		
-dim	Dime		k		[kʰ]		
-dim	Dime		ɡ				
-dim	Dime		kʼ				
-dim	Dime		x				
-dim	Dime		ɣ				
-dim	Dime		ŋ				
-dim	Dime		χ				
-dim	Dime		ʁ				
-dim	Dime		ʔ				
-dim	Dime		h				
-dim	Dime		pː				
-dim	Dime		bː				
-dim	Dime		pʼː				
-dim	Dime		fː				
-dim	Dime		mː				
-dim	Dime		wː				
-dim	Dime		tː				
-dim	Dime		dː				
-dim	Dime		tʼː				
-dim	Dime		sː				
-dim	Dime		zː				
-dim	Dime		ʃː				
-dim	Dime		nː				
-dim	Dime		lː				
-dim	Dime		ʃː				
-dim	Dime		ʒː				
-dim	Dime		t̠ʃː				
-dim	Dime		t̠ʃʼː				
-dim	Dime		jː				
-dim	Dime		kː				
-dim	Dime		ɡː				
-dim	Dime		kʼː				
-dim	Dime		i				
-dim	Dime		e				
-dim	Dime		ɛ				
-dim	Dime		ɨ				
-dim	Dime		ə				
-dim	Dime		a				
-dim	Dime		u				
-dim	Dime		o				
-dim	Dime		ɔ				
-dim	Dime		iː				
-dim	Dime		eː				
-dim	Dime		uː				
-dim	Dime		oː				
-dim	Dime		aː				
-dim	Dime		ai				
-dim	Dime		oi				
-dim	Dime		ei				
-dim	Dime		ui				
-dim	Dime		˦				
-dim	Dime		˨				
-							
+dim	Dime		p		[pʰ]
+dim	Dime		p		[ɸ]
+dim	Dime		b		[b]
+dim	Dime		b		[β]
+dim	Dime		pʼ
+dim	Dime		f
+dim	Dime		m
+dim	Dime		w
+dim	Dime		t		[t]
+dim	Dime		t		[tʰ]
+dim	Dime		d
+dim	Dime		tʼ
+dim	Dime		ɗ
+dim	Dime		s
+dim	Dime		z
+dim	Dime		ʃ
+dim	Dime		ts
+dim	Dime		n		[n]
+dim	Dime		n		[ɲ]
+dim	Dime		l
+dim	Dime		ɾ
+dim	Dime		ʃ
+dim	Dime		ʒ
+dim	Dime		t̠ʃ
+dim	Dime		d̠ʒ
+dim	Dime		t̠ʃʼ
+dim	Dime		j
+dim	Dime		k		[k]
+dim	Dime		k		[kʰ]
+dim	Dime		ɡ
+dim	Dime		kʼ
+dim	Dime		x
+dim	Dime		ɣ
+dim	Dime		ŋ
+dim	Dime		χ
+dim	Dime		ʁ
+dim	Dime		ʔ
+dim	Dime		h
+dim	Dime		pː
+dim	Dime		bː
+dim	Dime		pʼː
+dim	Dime		fː
+dim	Dime		mː
+dim	Dime		wː
+dim	Dime		tː
+dim	Dime		dː
+dim	Dime		tʼː
+dim	Dime		sː
+dim	Dime		zː
+dim	Dime		ʃː
+dim	Dime		nː
+dim	Dime		lː
+dim	Dime		ʃː
+dim	Dime		ʒː
+dim	Dime		t̠ʃː
+dim	Dime		t̠ʃʼː
+dim	Dime		jː
+dim	Dime		kː
+dim	Dime		ɡː
+dim	Dime		kʼː
+dim	Dime		i
+dim	Dime		e
+dim	Dime		ɛ
+dim	Dime		ɨ
+dim	Dime		ə
+dim	Dime		a
+dim	Dime		u
+dim	Dime		o
+dim	Dime		ɔ
+dim	Dime		iː
+dim	Dime		eː
+dim	Dime		uː
+dim	Dime		oː
+dim	Dime		aː
+dim	Dime		ai
+dim	Dime		oi
+dim	Dime		ei
+dim	Dime		ui
+dim	Dime		˦
+dim	Dime		˨
+
 lto	Lutsootso		p		[p]		lto.pdf
-lto	Lutsootso		p		[b]		
-lto	Lutsootso		m				
-lto	Lutsootso		β				
-lto	Lutsootso		f				
-lto	Lutsootso		t		[t]		
-lto	Lutsootso		t		[d]		
-lto	Lutsootso		n				
-lto	Lutsootso		l				
-lto	Lutsootso		r				
-lto	Lutsootso		ɺ				
-lto	Lutsootso		s		[s]		
-lto	Lutsootso		s		[z]		
-lto	Lutsootso		ts				
-lto	Lutsootso		ʃ				
-lto	Lutsootso		t̠ʃ		[t̠ʃ]		
-lto	Lutsootso		t̠ʃ		[d̠ʒ]		
-lto	Lutsootso		ɲ				
-lto	Lutsootso		ç				
-lto	Lutsootso		k		[k]		
-lto	Lutsootso		k		[ɡ]		
-lto	Lutsootso		ŋ				
-lto	Lutsootso		x				
-lto	Lutsootso		h				
-lto	Lutsootso		i				
-lto	Lutsootso		iː				
-lto	Lutsootso		e				
-lto	Lutsootso		eː				
-lto	Lutsootso		a				
-lto	Lutsootso		aː				
-lto	Lutsootso		u				
-lto	Lutsootso		uː				
-lto	Lutsootso		o				
-lto	Lutsootso		oː				
-lto	Lutsootso		˦				
-lto	Lutsootso		˨				
-							
+lto	Lutsootso		p		[b]
+lto	Lutsootso		m
+lto	Lutsootso		β
+lto	Lutsootso		f
+lto	Lutsootso		t		[t]
+lto	Lutsootso		t		[d]
+lto	Lutsootso		n
+lto	Lutsootso		l
+lto	Lutsootso		r
+lto	Lutsootso		ɺ
+lto	Lutsootso		s		[s]
+lto	Lutsootso		s		[z]
+lto	Lutsootso		ts
+lto	Lutsootso		ʃ
+lto	Lutsootso		t̠ʃ		[t̠ʃ]
+lto	Lutsootso		t̠ʃ		[d̠ʒ]
+lto	Lutsootso		ɲ
+lto	Lutsootso		ç
+lto	Lutsootso		k		[k]
+lto	Lutsootso		k		[ɡ]
+lto	Lutsootso		ŋ
+lto	Lutsootso		x
+lto	Lutsootso		h
+lto	Lutsootso		i
+lto	Lutsootso		iː
+lto	Lutsootso		e
+lto	Lutsootso		eː
+lto	Lutsootso		a
+lto	Lutsootso		aː
+lto	Lutsootso		u
+lto	Lutsootso		uː
+lto	Lutsootso		o
+lto	Lutsootso		oː
+lto	Lutsootso		˦
+lto	Lutsootso		˨
+
 djm	Jamsay, Dogon		˦				djm.pdf
-djm	Jamsay, Dogon		˨				
-djm	Jamsay, Dogon		p				
-djm	Jamsay, Dogon		b				
-djm	Jamsay, Dogon		t̠ʃ				
-djm	Jamsay, Dogon		k				
-djm	Jamsay, Dogon		b				
-djm	Jamsay, Dogon		d				
-djm	Jamsay, Dogon		d̠ʒ				
-djm	Jamsay, Dogon		ɡ		[ɡ]		
-djm	Jamsay, Dogon		ɡ		[ɣ]		
-djm	Jamsay, Dogon		m				
-djm	Jamsay, Dogon		n				
-djm	Jamsay, Dogon		ɲ				
-djm	Jamsay, Dogon		ŋ				
-djm	Jamsay, Dogon		<f>	loanwords			
-djm	Jamsay, Dogon		s				
-djm	Jamsay, Dogon		<ʃ>	marɡinal			
-djm	Jamsay, Dogon		l				
-djm	Jamsay, Dogon		w				
-djm	Jamsay, Dogon		r				
-djm	Jamsay, Dogon		j				
-djm	Jamsay, Dogon		w̃				
-djm	Jamsay, Dogon		r̃				
-djm	Jamsay, Dogon		j̃				
-djm	Jamsay, Dogon		<h>	loanwords			
-djm	Jamsay, Dogon		<ʔ>	marɡinal			
-djm	Jamsay, Dogon		bː				
-djm	Jamsay, Dogon		t̠ʃː				
-djm	Jamsay, Dogon		dː				
-djm	Jamsay, Dogon		ɡː				
-djm	Jamsay, Dogon		d̠ʒː				
-djm	Jamsay, Dogon		kː				
-djm	Jamsay, Dogon		lː				
-djm	Jamsay, Dogon		mː				
-djm	Jamsay, Dogon		nː				
-djm	Jamsay, Dogon		ŋː				
-djm	Jamsay, Dogon		pː				
-djm	Jamsay, Dogon		rː				
-djm	Jamsay, Dogon		tː				
-djm	Jamsay, Dogon		jː				
-djm	Jamsay, Dogon		u				
-djm	Jamsay, Dogon		o				
-djm	Jamsay, Dogon		ɔ				
-djm	Jamsay, Dogon		a				
-djm	Jamsay, Dogon		ɛ				
-djm	Jamsay, Dogon		e				
-djm	Jamsay, Dogon		i				
-djm	Jamsay, Dogon		uː				
-djm	Jamsay, Dogon		oː				
-djm	Jamsay, Dogon		ɔː				
-djm	Jamsay, Dogon		aː				
-djm	Jamsay, Dogon		ɛː				
-djm	Jamsay, Dogon		eː				
-djm	Jamsay, Dogon		iː				
-djm	Jamsay, Dogon		ũː				
-djm	Jamsay, Dogon		<õː>	loanwords			
-djm	Jamsay, Dogon		ɔ̃ː				
-djm	Jamsay, Dogon		ãː				
-djm	Jamsay, Dogon		ɛ̃ː				
-djm	Jamsay, Dogon		ẽː				
-djm	Jamsay, Dogon		ĩː				
-							
+djm	Jamsay, Dogon		˨
+djm	Jamsay, Dogon		p
+djm	Jamsay, Dogon		b
+djm	Jamsay, Dogon		t̠ʃ
+djm	Jamsay, Dogon		k
+djm	Jamsay, Dogon		b
+djm	Jamsay, Dogon		d
+djm	Jamsay, Dogon		d̠ʒ
+djm	Jamsay, Dogon		ɡ		[ɡ]
+djm	Jamsay, Dogon		ɡ		[ɣ]
+djm	Jamsay, Dogon		m
+djm	Jamsay, Dogon		n
+djm	Jamsay, Dogon		ɲ
+djm	Jamsay, Dogon		ŋ
+djm	Jamsay, Dogon		<f>	loanwords
+djm	Jamsay, Dogon		s
+djm	Jamsay, Dogon		<ʃ>	marɡinal
+djm	Jamsay, Dogon		l
+djm	Jamsay, Dogon		w
+djm	Jamsay, Dogon		r
+djm	Jamsay, Dogon		j
+djm	Jamsay, Dogon		w̃
+djm	Jamsay, Dogon		r̃
+djm	Jamsay, Dogon		j̃
+djm	Jamsay, Dogon		<h>	loanwords
+djm	Jamsay, Dogon		<ʔ>	marɡinal
+djm	Jamsay, Dogon		bː
+djm	Jamsay, Dogon		t̠ʃː
+djm	Jamsay, Dogon		dː
+djm	Jamsay, Dogon		ɡː
+djm	Jamsay, Dogon		d̠ʒː
+djm	Jamsay, Dogon		kː
+djm	Jamsay, Dogon		lː
+djm	Jamsay, Dogon		mː
+djm	Jamsay, Dogon		nː
+djm	Jamsay, Dogon		ŋː
+djm	Jamsay, Dogon		pː
+djm	Jamsay, Dogon		rː
+djm	Jamsay, Dogon		tː
+djm	Jamsay, Dogon		jː
+djm	Jamsay, Dogon		u
+djm	Jamsay, Dogon		o
+djm	Jamsay, Dogon		ɔ
+djm	Jamsay, Dogon		a
+djm	Jamsay, Dogon		ɛ
+djm	Jamsay, Dogon		e
+djm	Jamsay, Dogon		i
+djm	Jamsay, Dogon		uː
+djm	Jamsay, Dogon		oː
+djm	Jamsay, Dogon		ɔː
+djm	Jamsay, Dogon		aː
+djm	Jamsay, Dogon		ɛː
+djm	Jamsay, Dogon		eː
+djm	Jamsay, Dogon		iː
+djm	Jamsay, Dogon		ũː
+djm	Jamsay, Dogon		<õː>	loanwords
+djm	Jamsay, Dogon		ɔ̃ː
+djm	Jamsay, Dogon		ãː
+djm	Jamsay, Dogon		ɛ̃ː
+djm	Jamsay, Dogon		ẽː
+djm	Jamsay, Dogon		ĩː
+
 kam	Kikamba		β		[β]		kam.pdf
-kam	Kikamba		β		[b]		
-kam	Kikamba		m				
-kam	Kikamba		ð				
-kam	Kikamba		ɲ				
-kam	Kikamba		j				
-kam	Kikamba		t		[t]		
-kam	Kikamba		t		[d]		
-kam	Kikamba		s		[s]		
-kam	Kikamba		s		[z]		
-kam	Kikamba		l		[l]		
-kam	Kikamba		l		[d]		
-kam	Kikamba		n				
-kam	Kikamba		k		[k]		
-kam	Kikamba		k		[ɡ]		
-kam	Kikamba		k		[t̠ʃ]		
-kam	Kikamba		k		[d̠ʒ]		
-kam	Kikamba		ŋ				
-kam	Kikamba		w				
-kam	Kikamba		ɥ				
-kam	Kikamba		i				
-kam	Kikamba		e				
-kam	Kikamba		ɛ				
-kam	Kikamba		a				
-kam	Kikamba		u				
-kam	Kikamba		o				
-kam	Kikamba		ɔ				
-kam	Kikamba		iː				
-kam	Kikamba		eː				
-kam	Kikamba		ɛː				
-kam	Kikamba		aː				
-kam	Kikamba		uː				
-kam	Kikamba		oː				
-kam	Kikamba		ɔː				
-kam	Kikamba		˥				
-kam	Kikamba		˩				
-kam	Kikamba		˦				
-kam	Kikamba		˨				
-							
+kam	Kikamba		β		[b]
+kam	Kikamba		m
+kam	Kikamba		ð
+kam	Kikamba		ɲ
+kam	Kikamba		j
+kam	Kikamba		t		[t]
+kam	Kikamba		t		[d]
+kam	Kikamba		s		[s]
+kam	Kikamba		s		[z]
+kam	Kikamba		l		[l]
+kam	Kikamba		l		[d]
+kam	Kikamba		n
+kam	Kikamba		k		[k]
+kam	Kikamba		k		[ɡ]
+kam	Kikamba		k		[t̠ʃ]
+kam	Kikamba		k		[d̠ʒ]
+kam	Kikamba		ŋ
+kam	Kikamba		w
+kam	Kikamba		ɥ
+kam	Kikamba		i
+kam	Kikamba		e
+kam	Kikamba		ɛ
+kam	Kikamba		a
+kam	Kikamba		u
+kam	Kikamba		o
+kam	Kikamba		ɔ
+kam	Kikamba		iː
+kam	Kikamba		eː
+kam	Kikamba		ɛː
+kam	Kikamba		aː
+kam	Kikamba		uː
+kam	Kikamba		oː
+kam	Kikamba		ɔː
+kam	Kikamba		˥
+kam	Kikamba		˩
+kam	Kikamba		˦
+kam	Kikamba		˨
+
 ksf	Bafia		i				ksf.pdf
-ksf	Bafia		e				
-ksf	Bafia		ɛ				
-ksf	Bafia		ɨ				
-ksf	Bafia		ə				
-ksf	Bafia		ɜ				
-ksf	Bafia		a				
-ksf	Bafia		u				
-ksf	Bafia		o				
-ksf	Bafia		ɔ				
-ksf	Bafia		iː				
-ksf	Bafia		eː				
-ksf	Bafia		ɛː				
-ksf	Bafia		ɨː				
-ksf	Bafia		əː				
-ksf	Bafia		ɜː				
-ksf	Bafia		aː				
-ksf	Bafia		uː				
-ksf	Bafia		oː				
-ksf	Bafia		ɔː				
-ksf	Bafia		p				
-ksf	Bafia		b				
-ksf	Bafia		ɓ				
-ksf	Bafia		f				
-ksf	Bafia		v				
-ksf	Bafia		m				
-ksf	Bafia		w				
-ksf	Bafia		t				
-ksf	Bafia		d				
-ksf	Bafia		ɗ				
-ksf	Bafia		s				
-ksf	Bafia		z				
-ksf	Bafia		l				
-ksf	Bafia		n				
-ksf	Bafia		t̠ʃ				
-ksf	Bafia		d̠ʒ				
-ksf	Bafia		r				
-ksf	Bafia		ɲ				
-ksf	Bafia		j				
-ksf	Bafia		k				
-ksf	Bafia		ɡ				
-ksf	Bafia		ɣ				
-ksf	Bafia		ŋ				
-ksf	Bafia		kp				
-ksf	Bafia		ɡb				
-ksf	Bafia		ʔ				
-ksf	Bafia		h				
-ksf	Bafia		˨˦				
-ksf	Bafia		˦˨				
-ksf	Bafia		˦				
-ksf	Bafia		˨				
-							
+ksf	Bafia		e
+ksf	Bafia		ɛ
+ksf	Bafia		ɨ
+ksf	Bafia		ə
+ksf	Bafia		ɜ
+ksf	Bafia		a
+ksf	Bafia		u
+ksf	Bafia		o
+ksf	Bafia		ɔ
+ksf	Bafia		iː
+ksf	Bafia		eː
+ksf	Bafia		ɛː
+ksf	Bafia		ɨː
+ksf	Bafia		əː
+ksf	Bafia		ɜː
+ksf	Bafia		aː
+ksf	Bafia		uː
+ksf	Bafia		oː
+ksf	Bafia		ɔː
+ksf	Bafia		p
+ksf	Bafia		b
+ksf	Bafia		ɓ
+ksf	Bafia		f
+ksf	Bafia		v
+ksf	Bafia		m
+ksf	Bafia		w
+ksf	Bafia		t
+ksf	Bafia		d
+ksf	Bafia		ɗ
+ksf	Bafia		s
+ksf	Bafia		z
+ksf	Bafia		l
+ksf	Bafia		n
+ksf	Bafia		t̠ʃ
+ksf	Bafia		d̠ʒ
+ksf	Bafia		r
+ksf	Bafia		ɲ
+ksf	Bafia		j
+ksf	Bafia		k
+ksf	Bafia		ɡ
+ksf	Bafia		ɣ
+ksf	Bafia		ŋ
+ksf	Bafia		kp
+ksf	Bafia		ɡb
+ksf	Bafia		ʔ
+ksf	Bafia		h
+ksf	Bafia		˨˦
+ksf	Bafia		˦˨
+ksf	Bafia		˦
+ksf	Bafia		˨
+
 laj	Lango		b				laj.pdf
-laj	Lango		t̠ʃ				
-laj	Lango		d				
-laj	Lango		ɡ				
-laj	Lango		d̠ʒ				
-laj	Lango		k				
-laj	Lango		l				
-laj	Lango		m				
-laj	Lango		n				
-laj	Lango		ŋ				
-laj	Lango		ɲ				
-laj	Lango		p				
-laj	Lango		r				
-laj	Lango		s				
-laj	Lango		t̪		[t̪]		
-laj	Lango		t̪		[t]		
-laj	Lango		w				
-laj	Lango		j				
-laj	Lango		z				
-laj	Lango		ɔ				
-laj	Lango		ɔː				
-laj	Lango		o				
-laj	Lango		oː				
-laj	Lango		ɛ				
-laj	Lango		ɛː				
-laj	Lango		e				
-laj	Lango		eː				
-laj	Lango		ɪ				
-laj	Lango		ɪː				
-laj	Lango		i				
-laj	Lango		iː				
-laj	Lango		æ				
-laj	Lango		æː				
-laj	Lango		a				
-laj	Lango		aː				
-laj	Lango		ʊ				
-laj	Lango		ʊː				
-laj	Lango		u				
-laj	Lango		uː				
-laj	Lango		˦				
-laj	Lango		˨				
-							
+laj	Lango		t̠ʃ
+laj	Lango		d
+laj	Lango		ɡ
+laj	Lango		d̠ʒ
+laj	Lango		k
+laj	Lango		l
+laj	Lango		m
+laj	Lango		n
+laj	Lango		ŋ
+laj	Lango		ɲ
+laj	Lango		p
+laj	Lango		r
+laj	Lango		s
+laj	Lango		t̪		[t̪]
+laj	Lango		t̪		[t]
+laj	Lango		w
+laj	Lango		j
+laj	Lango		z
+laj	Lango		ɔ
+laj	Lango		ɔː
+laj	Lango		o
+laj	Lango		oː
+laj	Lango		ɛ
+laj	Lango		ɛː
+laj	Lango		e
+laj	Lango		eː
+laj	Lango		ɪ
+laj	Lango		ɪː
+laj	Lango		i
+laj	Lango		iː
+laj	Lango		æ
+laj	Lango		æː
+laj	Lango		a
+laj	Lango		aː
+laj	Lango		ʊ
+laj	Lango		ʊː
+laj	Lango		u
+laj	Lango		uː
+laj	Lango		˦
+laj	Lango		˨
+
 lks	Olukisa		i				lks.pdf;lks_donohew.pdf
-lks	Olukisa		iː				
-lks	Olukisa		e				
-lks	Olukisa		eː				
-lks	Olukisa		a				
-lks	Olukisa		aː				
-lks	Olukisa		o				
-lks	Olukisa		oː				
-lks	Olukisa		u				
-lks	Olukisa		uː				
-lks	Olukisa		w				
-lks	Olukisa		j				
-lks	Olukisa		p				
-lks	Olukisa		mb				
-lks	Olukisa		m				
-lks	Olukisa		β				
-lks	Olukisa		f				
-lks	Olukisa		t				
-lks	Olukisa		nd				
-lks	Olukisa		n				
-lks	Olukisa		ts				
-lks	Olukisa		nz				
-lks	Olukisa		s				
-lks	Olukisa		r				
-lks	Olukisa		l				
-lks	Olukisa		t̠ʃ				
-lks	Olukisa		n̠d̠ʒ				
-lks	Olukisa		ʃ				
-lks	Olukisa		ɲ				
-lks	Olukisa		k				
-lks	Olukisa		ŋɡ				
-lks	Olukisa		ŋ				
-lks	Olukisa		x				
-lks	Olukisa		h				
-lks	Olukisa		˦				
-lks	Olukisa		˨				
-lks	Olukisa		˨˦				
-lks	Olukisa		˦˨				
-							
+lks	Olukisa		iː
+lks	Olukisa		e
+lks	Olukisa		eː
+lks	Olukisa		a
+lks	Olukisa		aː
+lks	Olukisa		o
+lks	Olukisa		oː
+lks	Olukisa		u
+lks	Olukisa		uː
+lks	Olukisa		w
+lks	Olukisa		j
+lks	Olukisa		p
+lks	Olukisa		mb
+lks	Olukisa		m
+lks	Olukisa		β
+lks	Olukisa		f
+lks	Olukisa		t
+lks	Olukisa		nd
+lks	Olukisa		n
+lks	Olukisa		ts
+lks	Olukisa		nz
+lks	Olukisa		s
+lks	Olukisa		r
+lks	Olukisa		l
+lks	Olukisa		t̠ʃ
+lks	Olukisa		n̠d̠ʒ
+lks	Olukisa		ʃ
+lks	Olukisa		ɲ
+lks	Olukisa		k
+lks	Olukisa		ŋɡ
+lks	Olukisa		ŋ
+lks	Olukisa		x
+lks	Olukisa		h
+lks	Olukisa		˦
+lks	Olukisa		˨
+lks	Olukisa		˨˦
+lks	Olukisa		˦˨
+
 nuj	Nyole		p				nuj.pdf
-nuj	Nyole		t				
-nuj	Nyole		t̠ʃ				
-nuj	Nyole		k				
-nuj	Nyole		j				
-nuj	Nyole		i				
-nuj	Nyole		ɸ				
-nuj	Nyole		s				
-nuj	Nyole		x				
-nuj	Nyole		e				
-nuj	Nyole		a				
-nuj	Nyole		o				
-nuj	Nyole		u				
-nuj	Nyole		b				
-nuj	Nyole		d				
-nuj	Nyole		d̠ʒ				
-nuj	Nyole		ɡ				
-nuj	Nyole		β				
-nuj	Nyole		l				
-nuj	Nyole		r				
-nuj	Nyole		w				
-nuj	Nyole		m				
-nuj	Nyole		n				
-nuj	Nyole		ɲ				
-nuj	Nyole		ŋ				
-nuj	Nyole		mb				
-nuj	Nyole		nd				
-nuj	Nyole		n̠d̠ʒ				
-nuj	Nyole		ŋɡ				
-nuj	Nyole		˦				
-nuj	Nyole		˨				
-nuj	Nyole		iː				
-nuj	Nyole		eː				
-nuj	Nyole		aː				
-nuj	Nyole		oː				
-nuj	Nyole		uː				
-							
+nuj	Nyole		t
+nuj	Nyole		t̠ʃ
+nuj	Nyole		k
+nuj	Nyole		j
+nuj	Nyole		i
+nuj	Nyole		ɸ
+nuj	Nyole		s
+nuj	Nyole		x
+nuj	Nyole		e
+nuj	Nyole		a
+nuj	Nyole		o
+nuj	Nyole		u
+nuj	Nyole		b
+nuj	Nyole		d
+nuj	Nyole		d̠ʒ
+nuj	Nyole		ɡ
+nuj	Nyole		β
+nuj	Nyole		l
+nuj	Nyole		r
+nuj	Nyole		w
+nuj	Nyole		m
+nuj	Nyole		n
+nuj	Nyole		ɲ
+nuj	Nyole		ŋ
+nuj	Nyole		mb
+nuj	Nyole		nd
+nuj	Nyole		n̠d̠ʒ
+nuj	Nyole		ŋɡ
+nuj	Nyole		˦
+nuj	Nyole		˨
+nuj	Nyole		iː
+nuj	Nyole		eː
+nuj	Nyole		aː
+nuj	Nyole		oː
+nuj	Nyole		uː
+
 wmw	Kimwani		i				wmw.pdf
-wmw	Kimwani		e				
-wmw	Kimwani		a				
-wmw	Kimwani		u				
-wmw	Kimwani		o				
-wmw	Kimwani		p				
-wmw	Kimwani		b				
-wmw	Kimwani		m				
-wmw	Kimwani		f				
-wmw	Kimwani		v				
-wmw	Kimwani		w				
-wmw	Kimwani		t				
-wmw	Kimwani		d				
-wmw	Kimwani		n				
-wmw	Kimwani		s				
-wmw	Kimwani		z				
-wmw	Kimwani		l				
-wmw	Kimwani		r				
-wmw	Kimwani		ɲ				
-wmw	Kimwani		ʃ				
-wmw	Kimwani		t̠ʃ				
-wmw	Kimwani		d̠ʒ				
-wmw	Kimwani		j				
-wmw	Kimwani		k				
-wmw	Kimwani		ɡ				
-wmw	Kimwani		ŋɡ				
-							
+wmw	Kimwani		e
+wmw	Kimwani		a
+wmw	Kimwani		u
+wmw	Kimwani		o
+wmw	Kimwani		p
+wmw	Kimwani		b
+wmw	Kimwani		m
+wmw	Kimwani		f
+wmw	Kimwani		v
+wmw	Kimwani		w
+wmw	Kimwani		t
+wmw	Kimwani		d
+wmw	Kimwani		n
+wmw	Kimwani		s
+wmw	Kimwani		z
+wmw	Kimwani		l
+wmw	Kimwani		r
+wmw	Kimwani		ɲ
+wmw	Kimwani		ʃ
+wmw	Kimwani		t̠ʃ
+wmw	Kimwani		d̠ʒ
+wmw	Kimwani		j
+wmw	Kimwani		k
+wmw	Kimwani		ɡ
+wmw	Kimwani		ŋɡ
+
 xkv	Shekgalagari		pʰ				xkv.pdf
-xkv	Shekgalagari		p				
-xkv	Shekgalagari		b				
-xkv	Shekgalagari		m				
-xkv	Shekgalagari		kʘ				
-xkv	Shekgalagari		tʰ				
-xkv	Shekgalagari		t				
-xkv	Shekgalagari		d				
-xkv	Shekgalagari		n				
-xkv	Shekgalagari		kǀ				
-xkv	Shekgalagari		r		[ɾ]		
-xkv	Shekgalagari		r		[r]		
-xkv	Shekgalagari		s				
-xkv	Shekgalagari		z				
-xkv	Shekgalagari		l				
-xkv	Shekgalagari		tsʰ				
-xkv	Shekgalagari		ts				
-xkv	Shekgalagari		ʃ				
-xkv	Shekgalagari		ʒ				
-xkv	Shekgalagari		t̠ʃʰ				
-xkv	Shekgalagari		t̠ʃ				
-xkv	Shekgalagari		d̠ʒ				
-xkv	Shekgalagari		cʰ				
-xkv	Shekgalagari		c				
-xkv	Shekgalagari		ɟ				
-xkv	Shekgalagari		ɲ				
-xkv	Shekgalagari		j				
-xkv	Shekgalagari		kʰ				
-xkv	Shekgalagari		k				
-xkv	Shekgalagari		ɡ				
-xkv	Shekgalagari		ŋ				
-xkv	Shekgalagari		w				
-xkv	Shekgalagari		qʰ				
-xkv	Shekgalagari		q				
-xkv	Shekgalagari		χ				
-xkv	Shekgalagari		h				
-xkv	Shekgalagari		ʃʷ				
-xkv	Shekgalagari		ʒʷ				
-xkv	Shekgalagari		tsʷ				
-xkv	Shekgalagari		tsʷʰ				
-xkv	Shekgalagari		t̠ʃʷ				
-xkv	Shekgalagari		t̠ʃʷʰ				
-xkv	Shekgalagari		cʷ				
-xkv	Shekgalagari		cʷʰ				
-xkv	Shekgalagari		˦				
-xkv	Shekgalagari		˨				
-xkv	Shekgalagari		ʊ				
-xkv	Shekgalagari		ɔ				
-xkv	Shekgalagari		a				
-xkv	Shekgalagari		i				
-xkv	Shekgalagari		ɛ				
-xkv	Shekgalagari		e				
-xkv	Shekgalagari		ɪ				
-xkv	Shekgalagari		u				
-							
+xkv	Shekgalagari		p
+xkv	Shekgalagari		b
+xkv	Shekgalagari		m
+xkv	Shekgalagari		kʘ
+xkv	Shekgalagari		tʰ
+xkv	Shekgalagari		t
+xkv	Shekgalagari		d
+xkv	Shekgalagari		n
+xkv	Shekgalagari		kǀ
+xkv	Shekgalagari		r		[ɾ]
+xkv	Shekgalagari		r		[r]
+xkv	Shekgalagari		s
+xkv	Shekgalagari		z
+xkv	Shekgalagari		l
+xkv	Shekgalagari		tsʰ
+xkv	Shekgalagari		ts
+xkv	Shekgalagari		ʃ
+xkv	Shekgalagari		ʒ
+xkv	Shekgalagari		t̠ʃʰ
+xkv	Shekgalagari		t̠ʃ
+xkv	Shekgalagari		d̠ʒ
+xkv	Shekgalagari		cʰ
+xkv	Shekgalagari		c
+xkv	Shekgalagari		ɟ
+xkv	Shekgalagari		ɲ
+xkv	Shekgalagari		j
+xkv	Shekgalagari		kʰ
+xkv	Shekgalagari		k
+xkv	Shekgalagari		ɡ
+xkv	Shekgalagari		ŋ
+xkv	Shekgalagari		w
+xkv	Shekgalagari		qʰ
+xkv	Shekgalagari		q
+xkv	Shekgalagari		χ
+xkv	Shekgalagari		h
+xkv	Shekgalagari		ʃʷ
+xkv	Shekgalagari		ʒʷ
+xkv	Shekgalagari		tsʷ
+xkv	Shekgalagari		tsʷʰ
+xkv	Shekgalagari		t̠ʃʷ
+xkv	Shekgalagari		t̠ʃʷʰ
+xkv	Shekgalagari		cʷ
+xkv	Shekgalagari		cʷʰ
+xkv	Shekgalagari		˦
+xkv	Shekgalagari		˨
+xkv	Shekgalagari		ʊ
+xkv	Shekgalagari		ɔ
+xkv	Shekgalagari		a
+xkv	Shekgalagari		i
+xkv	Shekgalagari		ɛ
+xkv	Shekgalagari		e
+xkv	Shekgalagari		ɪ
+xkv	Shekgalagari		u
+
 boz	Tigemaxo Bozo		pʰ				boz.pdf
-boz	Tigemaxo Bozo		b				
-boz	Tigemaxo Bozo		m				
-boz	Tigemaxo Bozo		w				
-boz	Tigemaxo Bozo		f				
-boz	Tigemaxo Bozo		tʰ				
-boz	Tigemaxo Bozo		d				
-boz	Tigemaxo Bozo		s				
-boz	Tigemaxo Bozo		ɾ				
-boz	Tigemaxo Bozo		l				
-boz	Tigemaxo Bozo		n				
-boz	Tigemaxo Bozo		ɟ				
-boz	Tigemaxo Bozo		ɲ				
-boz	Tigemaxo Bozo		j				
-boz	Tigemaxo Bozo		kʰ				
-boz	Tigemaxo Bozo		ɡ				
-boz	Tigemaxo Bozo		x				
-boz	Tigemaxo Bozo		ŋ				
-boz	Tigemaxo Bozo		h				
-boz	Tigemaxo Bozo		i				
-boz	Tigemaxo Bozo		ĩ				
-boz	Tigemaxo Bozo		e				
-boz	Tigemaxo Bozo		ẽ				
-boz	Tigemaxo Bozo		ɛ				
-boz	Tigemaxo Bozo		ɛ̃				
-boz	Tigemaxo Bozo		a				
-boz	Tigemaxo Bozo		ã				
-boz	Tigemaxo Bozo		u				
-boz	Tigemaxo Bozo		ũ				
-boz	Tigemaxo Bozo		o				
-boz	Tigemaxo Bozo		õ				
-boz	Tigemaxo Bozo		ɔ				
-boz	Tigemaxo Bozo		ɔ̃				
-boz	Tigemaxo Bozo		˦				
-boz	Tigemaxo Bozo		˨				
-boz	Tigemaxo Bozo		˧				
-							
+boz	Tigemaxo Bozo		b
+boz	Tigemaxo Bozo		m
+boz	Tigemaxo Bozo		w
+boz	Tigemaxo Bozo		f
+boz	Tigemaxo Bozo		tʰ
+boz	Tigemaxo Bozo		d
+boz	Tigemaxo Bozo		s
+boz	Tigemaxo Bozo		ɾ
+boz	Tigemaxo Bozo		l
+boz	Tigemaxo Bozo		n
+boz	Tigemaxo Bozo		ɟ
+boz	Tigemaxo Bozo		ɲ
+boz	Tigemaxo Bozo		j
+boz	Tigemaxo Bozo		kʰ
+boz	Tigemaxo Bozo		ɡ
+boz	Tigemaxo Bozo		x
+boz	Tigemaxo Bozo		ŋ
+boz	Tigemaxo Bozo		h
+boz	Tigemaxo Bozo		i
+boz	Tigemaxo Bozo		ĩ
+boz	Tigemaxo Bozo		e
+boz	Tigemaxo Bozo		ẽ
+boz	Tigemaxo Bozo		ɛ
+boz	Tigemaxo Bozo		ɛ̃
+boz	Tigemaxo Bozo		a
+boz	Tigemaxo Bozo		ã
+boz	Tigemaxo Bozo		u
+boz	Tigemaxo Bozo		ũ
+boz	Tigemaxo Bozo		o
+boz	Tigemaxo Bozo		õ
+boz	Tigemaxo Bozo		ɔ
+boz	Tigemaxo Bozo		ɔ̃
+boz	Tigemaxo Bozo		˦
+boz	Tigemaxo Bozo		˨
+boz	Tigemaxo Bozo		˧
+
 alw	Alaaba		iː				alw.pdf
-alw	Alaaba		ɪ				
-alw	Alaaba		ɛ				
-alw	Alaaba		ɛː				
-alw	Alaaba		a				
-alw	Alaaba		aː				
-alw	Alaaba		uː				
-alw	Alaaba		ʊ				
-alw	Alaaba		ɔ				
-alw	Alaaba		ɔː				
-alw	Alaaba		<p>	rare			
-alw	Alaaba		b				
-alw	Alaaba		pʼ				
-alw	Alaaba		m				
-alw	Alaaba		ɰ				
-alw	Alaaba		f				
-alw	Alaaba		t				
-alw	Alaaba		d				
-alw	Alaaba		tʼ				
-alw	Alaaba		s				
-alw	Alaaba		z				
-alw	Alaaba		n				
-alw	Alaaba		r		[ɾ]		
-alw	Alaaba		r		[r]		
-alw	Alaaba		l				
-alw	Alaaba		t̠ʃ				
-alw	Alaaba		d̠ʒ				
-alw	Alaaba		t̠ʃʼ				
-alw	Alaaba		ʃ				
-alw	Alaaba		ʒ				
-alw	Alaaba		ɲ				
-alw	Alaaba		j				
-alw	Alaaba		k				
-alw	Alaaba		ɡ				
-alw	Alaaba		kʼ				
-alw	Alaaba		ʔ				
-alw	Alaaba		h				
-alw	Alaaba		pː				
-alw	Alaaba		pʼː				
-alw	Alaaba		bː				
-alw	Alaaba		tː				
-alw	Alaaba		tʼː				
-alw	Alaaba		dː				
-alw	Alaaba		t̠ʃː				
-alw	Alaaba		t̠ʃʼː				
-alw	Alaaba		d̠ʒː				
-alw	Alaaba		kː				
-alw	Alaaba		kʼː				
-alw	Alaaba		ɡː				
-alw	Alaaba		ʔː				
-alw	Alaaba		fː				
-alw	Alaaba		sː				
-alw	Alaaba		ʃː				
-alw	Alaaba		hː				
-alw	Alaaba		zː				
-alw	Alaaba		ʒː				
-alw	Alaaba		mː				
-alw	Alaaba		nː				
-alw	Alaaba		ɲː				
-alw	Alaaba		rː				
-alw	Alaaba		lː				
-alw	Alaaba		wː				
-alw	Alaaba		jː				
-							
+alw	Alaaba		ɪ
+alw	Alaaba		ɛ
+alw	Alaaba		ɛː
+alw	Alaaba		a
+alw	Alaaba		aː
+alw	Alaaba		uː
+alw	Alaaba		ʊ
+alw	Alaaba		ɔ
+alw	Alaaba		ɔː
+alw	Alaaba		<p>	rare
+alw	Alaaba		b
+alw	Alaaba		pʼ
+alw	Alaaba		m
+alw	Alaaba		ɰ
+alw	Alaaba		f
+alw	Alaaba		t
+alw	Alaaba		d
+alw	Alaaba		tʼ
+alw	Alaaba		s
+alw	Alaaba		z
+alw	Alaaba		n
+alw	Alaaba		r		[ɾ]
+alw	Alaaba		r		[r]
+alw	Alaaba		l
+alw	Alaaba		t̠ʃ
+alw	Alaaba		d̠ʒ
+alw	Alaaba		t̠ʃʼ
+alw	Alaaba		ʃ
+alw	Alaaba		ʒ
+alw	Alaaba		ɲ
+alw	Alaaba		j
+alw	Alaaba		k
+alw	Alaaba		ɡ
+alw	Alaaba		kʼ
+alw	Alaaba		ʔ
+alw	Alaaba		h
+alw	Alaaba		pː
+alw	Alaaba		pʼː
+alw	Alaaba		bː
+alw	Alaaba		tː
+alw	Alaaba		tʼː
+alw	Alaaba		dː
+alw	Alaaba		t̠ʃː
+alw	Alaaba		t̠ʃʼː
+alw	Alaaba		d̠ʒː
+alw	Alaaba		kː
+alw	Alaaba		kʼː
+alw	Alaaba		ɡː
+alw	Alaaba		ʔː
+alw	Alaaba		fː
+alw	Alaaba		sː
+alw	Alaaba		ʃː
+alw	Alaaba		hː
+alw	Alaaba		zː
+alw	Alaaba		ʒː
+alw	Alaaba		mː
+alw	Alaaba		nː
+alw	Alaaba		ɲː
+alw	Alaaba		rː
+alw	Alaaba		lː
+alw	Alaaba		wː
+alw	Alaaba		jː
+
 deg	Degema		m				deg.pdf
-deg	Degema		p		[p]		
-deg	Degema		p		[p̚]		
-deg	Degema		b				
-deg	Degema		ɓ				
-deg	Degema		f				
-deg	Degema		β		[β]		
-deg	Degema		β		[β̥]		
-deg	Degema		n				
-deg	Degema		t				
-deg	Degema		d				
-deg	Degema		ɗ				
-deg	Degema		r		[r]		
-deg	Degema		r		[r̥]		
-deg	Degema		s				
-deg	Degema		l				
-deg	Degema		ɲ				
-deg	Degema		d̠ʒ				
-deg	Degema		j				
-deg	Degema		ŋ				
-deg	Degema		k				
-deg	Degema		ɡ				
-deg	Degema		ŋʷ				
-deg	Degema		kp				
-deg	Degema		ɡb				
-deg	Degema		h				
-deg	Degema		w				
-deg	Degema		i		[ĩ]		
-deg	Degema		ɪ		[ɪ̃]		
-deg	Degema		e		[ẽ]		
-deg	Degema		ɛ		[ɛ̃]		
-deg	Degema		ə		[ə̃]		
-deg	Degema		a		[ã]		
-deg	Degema		u		[ũ]		
-deg	Degema		ʊ		[ʊ̃]		
-deg	Degema		o		[õ]		
-deg	Degema		ɔ		[ɔ̃]		
-deg	Degema		i		[i]		
-deg	Degema		ɪ		[ɪ]		
-deg	Degema		e		[e]		
-deg	Degema		ɛ		[ɛ]		
-deg	Degema		ə		[ə]		
-deg	Degema		a		[a]		
-deg	Degema		u		[u]		
-deg	Degema		ʊ		[ʊ]		
-deg	Degema		o		[o]		
-deg	Degema		ɔ		[ɔ]		
-deg	Degema		˦		[˦]		
-deg	Degema		˦		[↓˦]		
-deg	Degema		˨				
-							
+deg	Degema		p		[p]
+deg	Degema		p		[p̚]
+deg	Degema		b
+deg	Degema		ɓ
+deg	Degema		f
+deg	Degema		β		[β]
+deg	Degema		β		[β̥]
+deg	Degema		n
+deg	Degema		t
+deg	Degema		d
+deg	Degema		ɗ
+deg	Degema		r		[r]
+deg	Degema		r		[r̥]
+deg	Degema		s
+deg	Degema		l
+deg	Degema		ɲ
+deg	Degema		d̠ʒ
+deg	Degema		j
+deg	Degema		ŋ
+deg	Degema		k
+deg	Degema		ɡ
+deg	Degema		ŋʷ
+deg	Degema		kp
+deg	Degema		ɡb
+deg	Degema		h
+deg	Degema		w
+deg	Degema		i		[ĩ]
+deg	Degema		ɪ		[ɪ̃]
+deg	Degema		e		[ẽ]
+deg	Degema		ɛ		[ɛ̃]
+deg	Degema		ə		[ə̃]
+deg	Degema		a		[ã]
+deg	Degema		u		[ũ]
+deg	Degema		ʊ		[ʊ̃]
+deg	Degema		o		[õ]
+deg	Degema		ɔ		[ɔ̃]
+deg	Degema		i		[i]
+deg	Degema		ɪ		[ɪ]
+deg	Degema		e		[e]
+deg	Degema		ɛ		[ɛ]
+deg	Degema		ə		[ə]
+deg	Degema		a		[a]
+deg	Degema		u		[u]
+deg	Degema		ʊ		[ʊ]
+deg	Degema		o		[o]
+deg	Degema		ɔ		[ɔ]
+deg	Degema		˦		[˦]
+deg	Degema		˦		[↓˦]
+deg	Degema		˨
+
 bsc	Basari		kp		[kp]		bsc.pdf
-bsc	Basari		kp		[kpʷ]		
-bsc	Basari		ɡb		[ɡb]		
-bsc	Basari		ɡb		[ɡbʷ]		
-bsc	Basari		pʰ		[pʰ]		
-bsc	Basari		pʰ		[pʷʰ]		
-bsc	Basari		b		[b]		
-bsc	Basari		b		[bʷ]		
-bsc	Basari		b		[b̚]		
-bsc	Basari		b		[b̥]	b̥ is lenis	
-bsc	Basari		ŋm				
-bsc	Basari		m		[m]		
-bsc	Basari		m		[mʷ]		
-bsc	Basari		m		[m̥]	m̥ is lenis	
-bsc	Basari		m		[m̩]		
-bsc	Basari		f		[f]		
-bsc	Basari		f		[fʷ]		
-bsc	Basari		w				
-bsc	Basari		tʰ		[tʰ]		
-bsc	Basari		tʰ		[tʷʰ]		
-bsc	Basari		d		[d]		
-bsc	Basari		d		[ɾ]		
-bsc	Basari		d		[dʷ]		
-bsc	Basari		n		[n]		
-bsc	Basari		n		[nʷ]		
-bsc	Basari		n		[n̥]	n̥ is lenis	
-bsc	Basari		s		[s]		
-bsc	Basari		s		[sʷ]		
-bsc	Basari		l		[l]		
-bsc	Basari		l		[l̥]	l̥ is lenis	
-bsc	Basari		l		[ɾ]		
-bsc	Basari		l		[ɫ]		
-bsc	Basari		t̠ʃʰ		[t̠ʃʰ]		
-bsc	Basari		t̠ʃʰ		[t̠ʃʷʰ]		
-bsc	Basari		d̠ʒ		[d̠ʒ]		
-bsc	Basari		d̠ʒ		[d̠ʒʷ]		
-bsc	Basari		ɲ		[ɲ]		
-bsc	Basari		ɲ		[ɲʷ]		
-bsc	Basari		ɲ		[ɲ̥]	ɲ̥ is lenis	
-bsc	Basari		ɲ		[ɲ̩]		
-bsc	Basari		j				
-bsc	Basari		kʰ		[kʰ]		
-bsc	Basari		kʰ		[kʷʰ]		
-bsc	Basari		kʰ		[k̠]		
-bsc	Basari		ɡ		[ɡ]		
-bsc	Basari		ɡ		[ɡʷ]		
-bsc	Basari		ɡ		[ɡ̠]		
-bsc	Basari		ŋ		[ŋ]		
-bsc	Basari		ŋ		[ŋʷ]		
-bsc	Basari		ŋ		[ŋ̥]	ŋ̥ is lenis	
-bsc	Basari		ŋ		[ŋ̩]		
-bsc	Basari		h				
-bsc	Basari		i		[i]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		i		[ĩ]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		i		[ɨ]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		i		[z‿i]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		i		[ɪ]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		i		[i̞]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		i		[iː]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		e		[e]		
-bsc	Basari		e		[ẽ]		
-bsc	Basari		e		[eː]		
-bsc	Basari		a		[a]		
-bsc	Basari		a		[ã]		
-bsc	Basari		a		[aː]		
-bsc	Basari		a		[ɛ]		
-bsc	Basari		a		[ʌ]		
-bsc	Basari		a		[æ]		
-bsc	Basari		u		[u]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		u		[ũ]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		u		[uː]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		u		[v‿u]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		u		[ɨ]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		u		[ʊ]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation	
-bsc	Basari		o		[o]		
-bsc	Basari		o		[õ]		
-bsc	Basari		o		[oː]		
-bsc	Basari		ɔ		[ɔ]		
-bsc	Basari		ɔ		[ɔ̃]		
-bsc	Basari		ɔ		[ɔː]		
-bsc	Basari		ɔ		[ɒ]		
-bsc	Basari		˦				
-bsc	Basari		˨				
-bsc	Basari		˧				
-							
+bsc	Basari		kp		[kpʷ]
+bsc	Basari		ɡb		[ɡb]
+bsc	Basari		ɡb		[ɡbʷ]
+bsc	Basari		pʰ		[pʰ]
+bsc	Basari		pʰ		[pʷʰ]
+bsc	Basari		b		[b]
+bsc	Basari		b		[bʷ]
+bsc	Basari		b		[b̚]
+bsc	Basari		b		[b̥]	b̥ is lenis
+bsc	Basari		ŋm
+bsc	Basari		m		[m]
+bsc	Basari		m		[mʷ]
+bsc	Basari		m		[m̥]	m̥ is lenis
+bsc	Basari		m		[m̩]
+bsc	Basari		f		[f]
+bsc	Basari		f		[fʷ]
+bsc	Basari		w
+bsc	Basari		tʰ		[tʰ]
+bsc	Basari		tʰ		[tʷʰ]
+bsc	Basari		d		[d]
+bsc	Basari		d		[ɾ]
+bsc	Basari		d		[dʷ]
+bsc	Basari		n		[n]
+bsc	Basari		n		[nʷ]
+bsc	Basari		n		[n̥]	n̥ is lenis
+bsc	Basari		s		[s]
+bsc	Basari		s		[sʷ]
+bsc	Basari		l		[l]
+bsc	Basari		l		[l̥]	l̥ is lenis
+bsc	Basari		l		[ɾ]
+bsc	Basari		l		[ɫ]
+bsc	Basari		t̠ʃʰ		[t̠ʃʰ]
+bsc	Basari		t̠ʃʰ		[t̠ʃʷʰ]
+bsc	Basari		d̠ʒ		[d̠ʒ]
+bsc	Basari		d̠ʒ		[d̠ʒʷ]
+bsc	Basari		ɲ		[ɲ]
+bsc	Basari		ɲ		[ɲʷ]
+bsc	Basari		ɲ		[ɲ̥]	ɲ̥ is lenis
+bsc	Basari		ɲ		[ɲ̩]
+bsc	Basari		j
+bsc	Basari		kʰ		[kʰ]
+bsc	Basari		kʰ		[kʷʰ]
+bsc	Basari		kʰ		[k̠]
+bsc	Basari		ɡ		[ɡ]
+bsc	Basari		ɡ		[ɡʷ]
+bsc	Basari		ɡ		[ɡ̠]
+bsc	Basari		ŋ		[ŋ]
+bsc	Basari		ŋ		[ŋʷ]
+bsc	Basari		ŋ		[ŋ̥]	ŋ̥ is lenis
+bsc	Basari		ŋ		[ŋ̩]
+bsc	Basari		h
+bsc	Basari		i		[i]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		i		[ĩ]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		i		[ɨ]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		i		[z‿i]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		i		[ɪ]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		i		[i̞]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		i		[iː]	z‿i is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		e		[e]
+bsc	Basari		e		[ẽ]
+bsc	Basari		e		[eː]
+bsc	Basari		a		[a]
+bsc	Basari		a		[ã]
+bsc	Basari		a		[aː]
+bsc	Basari		a		[ɛ]
+bsc	Basari		a		[ʌ]
+bsc	Basari		a		[æ]
+bsc	Basari		u		[u]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		u		[ũ]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		u		[uː]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		u		[v‿u]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		u		[ɨ]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		u		[ʊ]	v‿u is a fricative vowel, no standard convention.  Adopted Bruce Connell's notation
+bsc	Basari		o		[o]
+bsc	Basari		o		[õ]
+bsc	Basari		o		[oː]
+bsc	Basari		ɔ		[ɔ]
+bsc	Basari		ɔ		[ɔ̃]
+bsc	Basari		ɔ		[ɔː]
+bsc	Basari		ɔ		[ɒ]
+bsc	Basari		˦
+bsc	Basari		˨
+bsc	Basari		˧
+
 pre	Principense		a		[a]		pre.pdf
-pre	Principense		a		[ã]		
-pre	Principense		ɓ				
-pre	Principense		ɗ				
-pre	Principense		ɛ		[ɛ]		
-pre	Principense		ɛ		[ɛ̃]		
-pre	Principense		e		[e]		
-pre	Principense		e		[ẽ]		
-pre	Principense		f				
-pre	Principense		ɡ				
-pre	Principense		ɡb				
-pre	Principense		i		[i]		
-pre	Principense		i		[ĩ]		
-pre	Principense		ʒ				
-pre	Principense		k				
-pre	Principense		kp				
-pre	Principense		l				
-pre	Principense		ʎ				
-pre	Principense		m				
-pre	Principense		n		[n]		
-pre	Principense		n		[ŋ]		
-pre	Principense		ɲ		[ɲ]		
-pre	Principense		ɲ		[j̃]		
-pre	Principense		ɔ		[ɔ]		
-pre	Principense		ɔ		[ɔ̃]		
-pre	Principense		o		[o]		
-pre	Principense		o		[õ]		
-pre	Principense		p				
-pre	Principense		r				
-pre	Principense		s		[s]		
-pre	Principense		s		[ʃ]		
-pre	Principense		t				
-pre	Principense		t̠ʃ				
-pre	Principense		u		[u]		
-pre	Principense		u		[ũ]		
-pre	Principense		v				
-pre	Principense		w				
-pre	Principense		j				
-pre	Principense		z		[z]		
-pre	Principense		z		[ʒ]		
-pre	Principense		˦				
-pre	Principense		˨				
-							
+pre	Principense		a		[ã]
+pre	Principense		ɓ
+pre	Principense		ɗ
+pre	Principense		ɛ		[ɛ]
+pre	Principense		ɛ		[ɛ̃]
+pre	Principense		e		[e]
+pre	Principense		e		[ẽ]
+pre	Principense		f
+pre	Principense		ɡ
+pre	Principense		ɡb
+pre	Principense		i		[i]
+pre	Principense		i		[ĩ]
+pre	Principense		ʒ
+pre	Principense		k
+pre	Principense		kp
+pre	Principense		l
+pre	Principense		ʎ
+pre	Principense		m
+pre	Principense		n		[n]
+pre	Principense		n		[ŋ]
+pre	Principense		ɲ		[ɲ]
+pre	Principense		ɲ		[j̃]
+pre	Principense		ɔ		[ɔ]
+pre	Principense		ɔ		[ɔ̃]
+pre	Principense		o		[o]
+pre	Principense		o		[õ]
+pre	Principense		p
+pre	Principense		r
+pre	Principense		s		[s]
+pre	Principense		s		[ʃ]
+pre	Principense		t
+pre	Principense		t̠ʃ
+pre	Principense		u		[u]
+pre	Principense		u		[ũ]
+pre	Principense		v
+pre	Principense		w
+pre	Principense		j
+pre	Principense		z		[z]
+pre	Principense		z		[ʒ]
+pre	Principense		˦
+pre	Principense		˨
+
 nko	Nkonya		<k>		[k]	loanwords only	nko.pdf
-nko	Nkonya		<k>		[ɡ]	loanwords only	
-nko	Nkonya		ɟ		[ɟ]		
-nko	Nkonya		ɟ		[c]		
-nko	Nkonya		t				
-nko	Nkonya		ɖ		[ɖ]		
-nko	Nkonya		ɖ		[d]		
-nko	Nkonya		ɖ		[r]		
-nko	Nkonya		p				
-nko	Nkonya		b				
-nko	Nkonya		<kp>		[kp]	loanwords only	
-nko	Nkonya		<kp>		[ɡb]	loanwords only	
-nko	Nkonya		ɦ				
-nko	Nkonya		ʝ				
-nko	Nkonya		s				
-nko	Nkonya		w				
-nko	Nkonya		f				
-nko	Nkonya		ts				
-nko	Nkonya		ŋ				
-nko	Nkonya		j				
-nko	Nkonya		ɲ				
-nko	Nkonya		n				
-nko	Nkonya		m				
-nko	Nkonya		nʷ				
-nko	Nkonya		l		[l]		
-nko	Nkonya		l		[r]		
-nko	Nkonya		ɑ				
-nko	Nkonya		e				
-nko	Nkonya		ɛ				
-nko	Nkonya		i				
-nko	Nkonya		o				
-nko	Nkonya		ɔ				
-nko	Nkonya		u				
-nko	Nkonya		ẽ				
-nko	Nkonya		ɑ̃				
-nko	Nkonya		ɛ̃				
-nko	Nkonya		ĩ				
-nko	Nkonya		õ				
-nko	Nkonya		ɔ̃				
-nko	Nkonya		ũ				
-							
+nko	Nkonya		<k>		[ɡ]	loanwords only
+nko	Nkonya		ɟ		[ɟ]
+nko	Nkonya		ɟ		[c]
+nko	Nkonya		t
+nko	Nkonya		ɖ		[ɖ]
+nko	Nkonya		ɖ		[d]
+nko	Nkonya		ɖ		[r]
+nko	Nkonya		p
+nko	Nkonya		b
+nko	Nkonya		<kp>		[kp]	loanwords only
+nko	Nkonya		<kp>		[ɡb]	loanwords only
+nko	Nkonya		ɦ
+nko	Nkonya		ʝ
+nko	Nkonya		s
+nko	Nkonya		w
+nko	Nkonya		f
+nko	Nkonya		ts
+nko	Nkonya		ŋ
+nko	Nkonya		j
+nko	Nkonya		ɲ
+nko	Nkonya		n
+nko	Nkonya		m
+nko	Nkonya		nʷ
+nko	Nkonya		l		[l]
+nko	Nkonya		l		[r]
+nko	Nkonya		ɑ
+nko	Nkonya		e
+nko	Nkonya		ɛ
+nko	Nkonya		i
+nko	Nkonya		o
+nko	Nkonya		ɔ
+nko	Nkonya		u
+nko	Nkonya		ẽ
+nko	Nkonya		ɑ̃
+nko	Nkonya		ɛ̃
+nko	Nkonya		ĩ
+nko	Nkonya		õ
+nko	Nkonya		ɔ̃
+nko	Nkonya		ũ
+
 gru	Soddo		i				gunan_gurage.pdf
-gru	Soddo		e				
-gru	Soddo		a				
-gru	Soddo		ʌ				
-gru	Soddo		o				
-gru	Soddo		u				
-gru	Soddo		œ				
-gru	Soddo		b				
-gru	Soddo		bʷ				
-gru	Soddo		d				
-gru	Soddo		ɣ				
-gru	Soddo		z				
-gru	Soddo		ʒ				
-gru	Soddo		ɡ				
-gru	Soddo		ɡʷ				
-gru	Soddo		ɡʲ				
-gru	Soddo		f				
-gru	Soddo		fʷ				
-gru	Soddo		t				
-gru	Soddo		t̠ʃ				
-gru	Soddo		s				
-gru	Soddo		ʃ				
-gru	Soddo		k				
-gru	Soddo		kʷ				
-gru	Soddo		kʲ				
-gru	Soddo		tʼ				
-gru	Soddo		t̠ʃʼ				
-gru	Soddo		q				
-gru	Soddo		qʷ				
-gru	Soddo		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-gru	Soddo		m				
-gru	Soddo		mʷ				
-gru	Soddo		n				
-gru	Soddo		w				
-gru	Soddo		r				
-gru	Soddo		<l>	rare			
-gru	Soddo		j				
-gru	Soddo		h				
-gru	Soddo		hʷ				
-gru	Soddo		hʲ				
-gru	Soddo		ɲ				
-							
+gru	Soddo		e
+gru	Soddo		a
+gru	Soddo		ʌ
+gru	Soddo		o
+gru	Soddo		u
+gru	Soddo		œ
+gru	Soddo		b
+gru	Soddo		bʷ
+gru	Soddo		d
+gru	Soddo		ɣ
+gru	Soddo		z
+gru	Soddo		ʒ
+gru	Soddo		ɡ
+gru	Soddo		ɡʷ
+gru	Soddo		ɡʲ
+gru	Soddo		f
+gru	Soddo		fʷ
+gru	Soddo		t
+gru	Soddo		t̠ʃ
+gru	Soddo		s
+gru	Soddo		ʃ
+gru	Soddo		k
+gru	Soddo		kʷ
+gru	Soddo		kʲ
+gru	Soddo		tʼ
+gru	Soddo		t̠ʃʼ
+gru	Soddo		kʼ
+gru	Soddo		kʷʼ
+gru	Soddo		kʲʼ
+gru	Soddo		m
+gru	Soddo		mʷ
+gru	Soddo		n
+gru	Soddo		w
+gru	Soddo		r
+gru	Soddo		<l>	rare
+gru	Soddo		j
+gru	Soddo		h
+gru	Soddo		hʷ
+gru	Soddo		hʲ
+gru	Soddo		ɲ
+
 gru	Goggot		i				gunan_gurage.pdf
-gru	Goggot		e				
-gru	Goggot		a				
-gru	Goggot		ʌ				
-gru	Goggot		o				
-gru	Goggot		u				
-gru	Goggot		œ				
-gru	Goggot		b				
-gru	Goggot		bʷ				
-gru	Goggot		d				
-gru	Goggot		ɣ				
-gru	Goggot		z				
-gru	Goggot		ʒ				
-gru	Goggot		ɡ				
-gru	Goggot		ɡʷ				
-gru	Goggot		ɡʲ				
-gru	Goggot		f				
-gru	Goggot		fʷ				
-gru	Goggot		t				
-gru	Goggot		t̠ʃ				
-gru	Goggot		s				
-gru	Goggot		ʃ				
-gru	Goggot		k				
-gru	Goggot		kʷ				
-gru	Goggot		kʲ				
-gru	Goggot		tʼ				
-gru	Goggot		t̠ʃʼ				
-gru	Goggot		q				
-gru	Goggot		qʷ				
-gru	Goggot		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-gru	Goggot		m				
-gru	Goggot		mʷ				
-gru	Goggot		n				
-gru	Goggot		w				
-gru	Goggot		r				
-gru	Goggot		l				
-gru	Goggot		j				
-gru	Goggot		h				
-gru	Goggot		hʷ				
-gru	Goggot		hʲ				
-gru	Goggot		ɲ				
-							
+gru	Goggot		e
+gru	Goggot		a
+gru	Goggot		ʌ
+gru	Goggot		o
+gru	Goggot		u
+gru	Goggot		œ
+gru	Goggot		b
+gru	Goggot		bʷ
+gru	Goggot		d
+gru	Goggot		ɣ
+gru	Goggot		z
+gru	Goggot		ʒ
+gru	Goggot		ɡ
+gru	Goggot		ɡʷ
+gru	Goggot		ɡʲ
+gru	Goggot		f
+gru	Goggot		fʷ
+gru	Goggot		t
+gru	Goggot		t̠ʃ
+gru	Goggot		s
+gru	Goggot		ʃ
+gru	Goggot		k
+gru	Goggot		kʷ
+gru	Goggot		kʲ
+gru	Goggot		tʼ
+gru	Goggot		t̠ʃʼ
+gru	Goggot		kʼ
+gru	Goggot		kʷʼ
+gru	Goggot		kʲʼ
+gru	Goggot		m
+gru	Goggot		mʷ
+gru	Goggot		n
+gru	Goggot		w
+gru	Goggot		r
+gru	Goggot		l
+gru	Goggot		j
+gru	Goggot		h
+gru	Goggot		hʷ
+gru	Goggot		hʲ
+gru	Goggot		ɲ
+
 mvz	Masqan		i				gunan_gurage.pdf
-mvz	Masqan		e				
-mvz	Masqan		a				
-mvz	Masqan		ʌ				
-mvz	Masqan		o				
-mvz	Masqan		u				
-mvz	Masqan		œ				
-mvz	Masqan		b				
-mvz	Masqan		bʷ				
-mvz	Masqan		d				
-mvz	Masqan		ɣ				
-mvz	Masqan		z				
-mvz	Masqan		ʒ				
-mvz	Masqan		ɡ				
-mvz	Masqan		ɡʷ				
-mvz	Masqan		ɡʲ				
-mvz	Masqan		f				
-mvz	Masqan		fʷ				
-mvz	Masqan		t				
-mvz	Masqan		t̠ʃ				
-mvz	Masqan		s				
-mvz	Masqan		ʃ				
-mvz	Masqan		k				
-mvz	Masqan		kʷ				
-mvz	Masqan		kʲ				
-mvz	Masqan		tʼ				
-mvz	Masqan		t̠ʃʼ				
-mvz	Masqan		q				
-mvz	Masqan		qʷ				
-mvz	Masqan		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-mvz	Masqan		m				
-mvz	Masqan		mʷ				
-mvz	Masqan		n				
-mvz	Masqan		w				
-mvz	Masqan		r				
-mvz	Masqan		l				
-mvz	Masqan		j				
-mvz	Masqan		h				
-mvz	Masqan		hʷ				
-mvz	Masqan		hʲ				
-mvz	Masqan		ɲ				
-							
+mvz	Masqan		e
+mvz	Masqan		a
+mvz	Masqan		ʌ
+mvz	Masqan		o
+mvz	Masqan		u
+mvz	Masqan		œ
+mvz	Masqan		b
+mvz	Masqan		bʷ
+mvz	Masqan		d
+mvz	Masqan		ɣ
+mvz	Masqan		z
+mvz	Masqan		ʒ
+mvz	Masqan		ɡ
+mvz	Masqan		ɡʷ
+mvz	Masqan		ɡʲ
+mvz	Masqan		f
+mvz	Masqan		fʷ
+mvz	Masqan		t
+mvz	Masqan		t̠ʃ
+mvz	Masqan		s
+mvz	Masqan		ʃ
+mvz	Masqan		k
+mvz	Masqan		kʷ
+mvz	Masqan		kʲ
+mvz	Masqan		tʼ
+mvz	Masqan		t̠ʃʼ
+mvz	Masqan		kʼ
+mvz	Masqan		kʷʼ
+mvz	Masqan		kʲʼ
+mvz	Masqan		m
+mvz	Masqan		mʷ
+mvz	Masqan		n
+mvz	Masqan		w
+mvz	Masqan		r
+mvz	Masqan		l
+mvz	Masqan		j
+mvz	Masqan		h
+mvz	Masqan		hʷ
+mvz	Masqan		hʲ
+mvz	Masqan		ɲ
+
 sgw	Muher		i				gunan_gurage.pdf
-sgw	Muher		e				
-sgw	Muher		a				
-sgw	Muher		ʌ				
-sgw	Muher		u				
-sgw	Muher		o				
-sgw	Muher		ɔ				
-sgw	Muher		œ				
-sgw	Muher		b				
-sgw	Muher		bʷ				
-sgw	Muher		d				
-sgw	Muher		ɣ				
-sgw	Muher		z				
-sgw	Muher		ʒ				
-sgw	Muher		ɡ				
-sgw	Muher		ɡʷ				
-sgw	Muher		ɡʲ				
-sgw	Muher		f				
-sgw	Muher		fʷ				
-sgw	Muher		t				
-sgw	Muher		t̠ʃ				
-sgw	Muher		s				
-sgw	Muher		ʃ				
-sgw	Muher		k				
-sgw	Muher		kʷ				
-sgw	Muher		kʲ				
-sgw	Muher		tʼ				
-sgw	Muher		t̠ʃʼ				
-sgw	Muher		q				
-sgw	Muher		qʷ				
-sgw	Muher		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-sgw	Muher		m				
-sgw	Muher		mʷ				
-sgw	Muher		n				
-sgw	Muher		w				
-sgw	Muher		r				
-sgw	Muher		l				
-sgw	Muher		j				
-sgw	Muher		h		[h]		
-sgw	Muher		h		[x]		
-sgw	Muher		hʷ		[hʷ]		
-sgw	Muher		hʷ		[xʷ]		
-sgw	Muher		hʲ		[hʲ]		
-sgw	Muher		hʲ		[xʲ]		
-sgw	Muher		ɲ				
-							
+sgw	Muher		e
+sgw	Muher		a
+sgw	Muher		ʌ
+sgw	Muher		u
+sgw	Muher		o
+sgw	Muher		ɔ
+sgw	Muher		œ
+sgw	Muher		b
+sgw	Muher		bʷ
+sgw	Muher		d
+sgw	Muher		ɣ
+sgw	Muher		z
+sgw	Muher		ʒ
+sgw	Muher		ɡ
+sgw	Muher		ɡʷ
+sgw	Muher		ɡʲ
+sgw	Muher		f
+sgw	Muher		fʷ
+sgw	Muher		t
+sgw	Muher		t̠ʃ
+sgw	Muher		s
+sgw	Muher		ʃ
+sgw	Muher		k
+sgw	Muher		kʷ
+sgw	Muher		kʲ
+sgw	Muher		tʼ
+sgw	Muher		t̠ʃʼ
+sgw	Muher		kʼ
+sgw	Muher		kʷʼ
+sgw	Muher		kʲʼ
+sgw	Muher		m
+sgw	Muher		mʷ
+sgw	Muher		n
+sgw	Muher		w
+sgw	Muher		r
+sgw	Muher		l
+sgw	Muher		j
+sgw	Muher		h		[h]
+sgw	Muher		h		[x]
+sgw	Muher		hʷ		[hʷ]
+sgw	Muher		hʷ		[xʷ]
+sgw	Muher		hʲ		[hʲ]
+sgw	Muher		hʲ		[xʲ]
+sgw	Muher		ɲ
+
 sgw	Ezha		i				gunan_gurage.pdf
-sgw	Ezha		e				
-sgw	Ezha		a				
-sgw	Ezha		ʌ				
-sgw	Ezha		u				
-sgw	Ezha		o				
-sgw	Ezha		b				
-sgw	Ezha		bʷ				
-sgw	Ezha		d				
-sgw	Ezha		ɣ				
-sgw	Ezha		z				
-sgw	Ezha		ʒ				
-sgw	Ezha		ɡ				
-sgw	Ezha		ɡʷ				
-sgw	Ezha		ɡʲ				
-sgw	Ezha		f				
-sgw	Ezha		fʷ				
-sgw	Ezha		t				
-sgw	Ezha		t̠ʃ				
-sgw	Ezha		s				
-sgw	Ezha		ʃ				
-sgw	Ezha		k				
-sgw	Ezha		kʷ				
-sgw	Ezha		kʲ				
-sgw	Ezha		tʼ				
-sgw	Ezha		t̠ʃʼ				
-sgw	Ezha		q				
-sgw	Ezha		qʷ				
-sgw	Ezha		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-sgw	Ezha		m				
-sgw	Ezha		mʷ				
-sgw	Ezha		n				
-sgw	Ezha		w				
-sgw	Ezha		r				
-sgw	Ezha		l				
-sgw	Ezha		j				
-sgw	Ezha		h				
-sgw	Ezha		hʷ				
-sgw	Ezha		hʲ				
-							
+sgw	Ezha		e
+sgw	Ezha		a
+sgw	Ezha		ʌ
+sgw	Ezha		u
+sgw	Ezha		o
+sgw	Ezha		b
+sgw	Ezha		bʷ
+sgw	Ezha		d
+sgw	Ezha		ɣ
+sgw	Ezha		z
+sgw	Ezha		ʒ
+sgw	Ezha		ɡ
+sgw	Ezha		ɡʷ
+sgw	Ezha		ɡʲ
+sgw	Ezha		f
+sgw	Ezha		fʷ
+sgw	Ezha		t
+sgw	Ezha		t̠ʃ
+sgw	Ezha		s
+sgw	Ezha		ʃ
+sgw	Ezha		k
+sgw	Ezha		kʷ
+sgw	Ezha		kʲ
+sgw	Ezha		tʼ
+sgw	Ezha		t̠ʃʼ
+sgw	Ezha		kʼ
+sgw	Ezha		kʷʼ
+sgw	Ezha		kʲʼ
+sgw	Ezha		m
+sgw	Ezha		mʷ
+sgw	Ezha		n
+sgw	Ezha		w
+sgw	Ezha		r
+sgw	Ezha		l
+sgw	Ezha		j
+sgw	Ezha		h
+sgw	Ezha		hʷ
+sgw	Ezha		hʲ
+
 sgw	Chaha		i				gunan_gurage.pdf
-sgw	Chaha		e				
-sgw	Chaha		a				
-sgw	Chaha		ʌ				
-sgw	Chaha		u				
-sgw	Chaha		o				
-sgw	Chaha		ɔ				
-sgw	Chaha		œ				
-sgw	Chaha		b				
-sgw	Chaha		bʷ				
-sgw	Chaha		d				
-sgw	Chaha		ɣ				
-sgw	Chaha		z				
-sgw	Chaha		ʒ				
-sgw	Chaha		ɡ				
-sgw	Chaha		ɡʷ				
-sgw	Chaha		ɡʲ				
-sgw	Chaha		f				
-sgw	Chaha		fʷ				
-sgw	Chaha		t				
-sgw	Chaha		t̠ʃ				
-sgw	Chaha		s				
-sgw	Chaha		ʃ				
-sgw	Chaha		k				
-sgw	Chaha		kʷ				
-sgw	Chaha		kʲ				
-sgw	Chaha		tʼ				
-sgw	Chaha		t̠ʃʼ				
-sgw	Chaha		q				
-sgw	Chaha		qʷ				
-sgw	Chaha		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-sgw	Chaha		m				
-sgw	Chaha		mʷ				
-sgw	Chaha		n				
-sgw	Chaha		w				
-sgw	Chaha		r				
-sgw	Chaha		l				
-sgw	Chaha		j				
-sgw	Chaha		h				
-sgw	Chaha		hʷ				
-sgw	Chaha		hʲ				
-sgw	Chaha		β				
-sgw	Chaha		p				
-sgw	Chaha		pʷ				
-							
+sgw	Chaha		e
+sgw	Chaha		a
+sgw	Chaha		ʌ
+sgw	Chaha		u
+sgw	Chaha		o
+sgw	Chaha		ɔ
+sgw	Chaha		œ
+sgw	Chaha		b
+sgw	Chaha		bʷ
+sgw	Chaha		d
+sgw	Chaha		ɣ
+sgw	Chaha		z
+sgw	Chaha		ʒ
+sgw	Chaha		ɡ
+sgw	Chaha		ɡʷ
+sgw	Chaha		ɡʲ
+sgw	Chaha		f
+sgw	Chaha		fʷ
+sgw	Chaha		t
+sgw	Chaha		t̠ʃ
+sgw	Chaha		s
+sgw	Chaha		ʃ
+sgw	Chaha		k
+sgw	Chaha		kʷ
+sgw	Chaha		kʲ
+sgw	Chaha		tʼ
+sgw	Chaha		t̠ʃʼ
+sgw	Chaha		kʼ
+sgw	Chaha		kʷʼ
+sgw	Chaha		kʲʼ
+sgw	Chaha		m
+sgw	Chaha		mʷ
+sgw	Chaha		n
+sgw	Chaha		w
+sgw	Chaha		r
+sgw	Chaha		l
+sgw	Chaha		j
+sgw	Chaha		h
+sgw	Chaha		hʷ
+sgw	Chaha		hʲ
+sgw	Chaha		β
+sgw	Chaha		p
+sgw	Chaha		pʷ
+
 sgw	Gumer		i				gunan_gurage.pdf
-sgw	Gumer		e				
-sgw	Gumer		a				
-sgw	Gumer		ʌ				
-sgw	Gumer		u				
-sgw	Gumer		o				
-sgw	Gumer		œ				
-sgw	Gumer		b				
-sgw	Gumer		bʷ				
-sgw	Gumer		d				
-sgw	Gumer		ɣ				
-sgw	Gumer		z				
-sgw	Gumer		ʒ				
-sgw	Gumer		ɡ				
-sgw	Gumer		ɡʷ				
-sgw	Gumer		ɡʲ				
-sgw	Gumer		f				
-sgw	Gumer		fʷ				
-sgw	Gumer		t				
-sgw	Gumer		t̠ʃ				
-sgw	Gumer		s				
-sgw	Gumer		ʃ				
-sgw	Gumer		k				
-sgw	Gumer		kʷ				
-sgw	Gumer		kʲ				
-sgw	Gumer		tʼ				
-sgw	Gumer		t̠ʃʼ				
-sgw	Gumer		q				
-sgw	Gumer		qʷ				
-sgw	Gumer		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-sgw	Gumer		m				
-sgw	Gumer		mʷ				
-sgw	Gumer		n				
-sgw	Gumer		w				
-sgw	Gumer		r				
-sgw	Gumer		l				
-sgw	Gumer		j				
-sgw	Gumer		h		[h]		
-sgw	Gumer		h		[x]		
-sgw	Gumer		hʷ		[hʷ]		
-sgw	Gumer		hʷ		[xʷ]		
-sgw	Gumer		hʲ		[hʲ]		
-sgw	Gumer		hʲ		[xʲ]		
-sgw	Gumer		p				
-sgw	Gumer		pʷ				
-							
+sgw	Gumer		e
+sgw	Gumer		a
+sgw	Gumer		ʌ
+sgw	Gumer		u
+sgw	Gumer		o
+sgw	Gumer		œ
+sgw	Gumer		b
+sgw	Gumer		bʷ
+sgw	Gumer		d
+sgw	Gumer		ɣ
+sgw	Gumer		z
+sgw	Gumer		ʒ
+sgw	Gumer		ɡ
+sgw	Gumer		ɡʷ
+sgw	Gumer		ɡʲ
+sgw	Gumer		f
+sgw	Gumer		fʷ
+sgw	Gumer		t
+sgw	Gumer		t̠ʃ
+sgw	Gumer		s
+sgw	Gumer		ʃ
+sgw	Gumer		k
+sgw	Gumer		kʷ
+sgw	Gumer		kʲ
+sgw	Gumer		tʼ
+sgw	Gumer		t̠ʃʼ
+sgw	Gumer		kʼ
+sgw	Gumer		kʷʼ
+sgw	Gumer		kʲʼ
+sgw	Gumer		m
+sgw	Gumer		mʷ
+sgw	Gumer		n
+sgw	Gumer		w
+sgw	Gumer		r
+sgw	Gumer		l
+sgw	Gumer		j
+sgw	Gumer		h		[h]
+sgw	Gumer		h		[x]
+sgw	Gumer		hʷ		[hʷ]
+sgw	Gumer		hʷ		[xʷ]
+sgw	Gumer		hʲ		[hʲ]
+sgw	Gumer		hʲ		[xʲ]
+sgw	Gumer		p
+sgw	Gumer		pʷ
+
 sgw	Gura		i				gunan_gurage.pdf
-sgw	Gura		e				
-sgw	Gura		a				
-sgw	Gura		ʌ				
-sgw	Gura		u				
-sgw	Gura		o				
-sgw	Gura		b				
-sgw	Gura		bʷ				
-sgw	Gura		d				
-sgw	Gura		ɣ				
-sgw	Gura		z				
-sgw	Gura		ʒ				
-sgw	Gura		ɡ				
-sgw	Gura		ɡʷ				
-sgw	Gura		ɡʲ				
-sgw	Gura		f				
-sgw	Gura		fʷ				
-sgw	Gura		t				
-sgw	Gura		t̠ʃ				
-sgw	Gura		s				
-sgw	Gura		ʃ				
-sgw	Gura		k				
-sgw	Gura		kʷ				
-sgw	Gura		kʲ				
-sgw	Gura		tʼ				
-sgw	Gura		t̠ʃʼ				
-sgw	Gura		q				
-sgw	Gura		qʷ				
-sgw	Gura		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-sgw	Gura		m				
-sgw	Gura		mʷ				
-sgw	Gura		n				
-sgw	Gura		w				
-sgw	Gura		r				
-sgw	Gura		l				
-sgw	Gura		j				
-sgw	Gura		h				
-sgw	Gura		hʷ				
-sgw	Gura		hʲ				
-sgw	Gura		p				
-sgw	Gura		pʷ				
-sgw	Gura		β				
-							
+sgw	Gura		e
+sgw	Gura		a
+sgw	Gura		ʌ
+sgw	Gura		u
+sgw	Gura		o
+sgw	Gura		b
+sgw	Gura		bʷ
+sgw	Gura		d
+sgw	Gura		ɣ
+sgw	Gura		z
+sgw	Gura		ʒ
+sgw	Gura		ɡ
+sgw	Gura		ɡʷ
+sgw	Gura		ɡʲ
+sgw	Gura		f
+sgw	Gura		fʷ
+sgw	Gura		t
+sgw	Gura		t̠ʃ
+sgw	Gura		s
+sgw	Gura		ʃ
+sgw	Gura		k
+sgw	Gura		kʷ
+sgw	Gura		kʲ
+sgw	Gura		tʼ
+sgw	Gura		t̠ʃʼ
+sgw	Gura		kʼ
+sgw	Gura		kʷʼ
+sgw	Gura		kʲʼ
+sgw	Gura		m
+sgw	Gura		mʷ
+sgw	Gura		n
+sgw	Gura		w
+sgw	Gura		r
+sgw	Gura		l
+sgw	Gura		j
+sgw	Gura		h
+sgw	Gura		hʷ
+sgw	Gura		hʲ
+sgw	Gura		p
+sgw	Gura		pʷ
+sgw	Gura		β
+
 sgw	Gyeto		i				gunan_gurage.pdf
-sgw	Gyeto		e				
-sgw	Gyeto		a				
-sgw	Gyeto		ʌ				
-sgw	Gyeto		u				
-sgw	Gyeto		o				
-sgw	Gyeto		b				
-sgw	Gyeto		bʷ				
-sgw	Gyeto		d				
-sgw	Gyeto		ɣ				
-sgw	Gyeto		z				
-sgw	Gyeto		ʒ				
-sgw	Gyeto		ɡ				
-sgw	Gyeto		ɡʷ				
-sgw	Gyeto		ɡʲ				
-sgw	Gyeto		f				
-sgw	Gyeto		fʷ				
-sgw	Gyeto		t				
-sgw	Gyeto		t̠ʃ				
-sgw	Gyeto		s				
-sgw	Gyeto		ʃ				
-sgw	Gyeto		k				
-sgw	Gyeto		kʷ				
-sgw	Gyeto		kʲ				
-sgw	Gyeto		tʼ				
-sgw	Gyeto		t̠ʃʼ				
-sgw	Gyeto		q				
-sgw	Gyeto		qʷ				
-sgw	Gyeto		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-sgw	Gyeto		m				
-sgw	Gyeto		mʷ				
-sgw	Gyeto		n				
-sgw	Gyeto		w				
-sgw	Gyeto		r				
-sgw	Gyeto		l				
-sgw	Gyeto		j				
-sgw	Gyeto		h				
-sgw	Gyeto		hʷ				
-sgw	Gyeto		hʲ				
-sgw	Gyeto		p				
-sgw	Gyeto		pʷ				
-sgw	Gyeto		β				
-sgw	Gyeto		w̃				
-sgw	Gyeto		β̃				
-sgw	Gyeto		r̃				
-							
+sgw	Gyeto		e
+sgw	Gyeto		a
+sgw	Gyeto		ʌ
+sgw	Gyeto		u
+sgw	Gyeto		o
+sgw	Gyeto		b
+sgw	Gyeto		bʷ
+sgw	Gyeto		d
+sgw	Gyeto		ɣ
+sgw	Gyeto		z
+sgw	Gyeto		ʒ
+sgw	Gyeto		ɡ
+sgw	Gyeto		ɡʷ
+sgw	Gyeto		ɡʲ
+sgw	Gyeto		f
+sgw	Gyeto		fʷ
+sgw	Gyeto		t
+sgw	Gyeto		t̠ʃ
+sgw	Gyeto		s
+sgw	Gyeto		ʃ
+sgw	Gyeto		k
+sgw	Gyeto		kʷ
+sgw	Gyeto		kʲ
+sgw	Gyeto		tʼ
+sgw	Gyeto		t̠ʃʼ
+sgw	Gyeto		kʼ
+sgw	Gyeto		kʷʼ
+sgw	Gyeto		kʲʼ
+sgw	Gyeto		m
+sgw	Gyeto		mʷ
+sgw	Gyeto		n
+sgw	Gyeto		w
+sgw	Gyeto		r
+sgw	Gyeto		l
+sgw	Gyeto		j
+sgw	Gyeto		h
+sgw	Gyeto		hʷ
+sgw	Gyeto		hʲ
+sgw	Gyeto		p
+sgw	Gyeto		pʷ
+sgw	Gyeto		β
+sgw	Gyeto		w̃
+sgw	Gyeto		β̃
+sgw	Gyeto		r̃
+
 ior	Ennemor		i				gunan_gurage.pdf
-ior	Ennemor		e				
-ior	Ennemor		a				
-ior	Ennemor		ʌ				
-ior	Ennemor		u				
-ior	Ennemor		o				
-ior	Ennemor		œ				
-ior	Ennemor		b				
-ior	Ennemor		bʷ				
-ior	Ennemor		d				
-ior	Ennemor		ɣ				
-ior	Ennemor		z				
-ior	Ennemor		ʒ				
-ior	Ennemor		ɡ				
-ior	Ennemor		ɡʷ				
-ior	Ennemor		ɡʲ				
-ior	Ennemor		f				
-ior	Ennemor		fʷ				
-ior	Ennemor		t				
-ior	Ennemor		t̠ʃ				
-ior	Ennemor		s				
-ior	Ennemor		ʃ				
-ior	Ennemor		k				
-ior	Ennemor		kʷ				
-ior	Ennemor		kʲ				
-ior	Ennemor		tʼ				
-ior	Ennemor		t̠ʃʼ				
-ior	Ennemor		q				
-ior	Ennemor		qʷ				
-ior	Ennemor		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-ior	Ennemor		m				
-ior	Ennemor		mʷ				
-ior	Ennemor		n				
-ior	Ennemor		w				
-ior	Ennemor		r				
-ior	Ennemor		l				
-ior	Ennemor		j				
-ior	Ennemor		h				
-ior	Ennemor		hʷ				
-ior	Ennemor		hʲ				
-ior	Ennemor		β				
-ior	Ennemor		ɲ				
-ior	Ennemor		w̃				
-ior	Ennemor		β̃				
-ior	Ennemor		r̃				
-ior	Ennemor		ʔ	ok			
-ior	Ennemor		ʔʷ	ok			
-							
+ior	Ennemor		e
+ior	Ennemor		a
+ior	Ennemor		ʌ
+ior	Ennemor		u
+ior	Ennemor		o
+ior	Ennemor		œ
+ior	Ennemor		b
+ior	Ennemor		bʷ
+ior	Ennemor		d
+ior	Ennemor		ɣ
+ior	Ennemor		z
+ior	Ennemor		ʒ
+ior	Ennemor		ɡ
+ior	Ennemor		ɡʷ
+ior	Ennemor		ɡʲ
+ior	Ennemor		f
+ior	Ennemor		fʷ
+ior	Ennemor		t
+ior	Ennemor		t̠ʃ
+ior	Ennemor		s
+ior	Ennemor		ʃ
+ior	Ennemor		k
+ior	Ennemor		kʷ
+ior	Ennemor		kʲ
+ior	Ennemor		tʼ
+ior	Ennemor		t̠ʃʼ
+ior	Ennemor		kʼ
+ior	Ennemor		kʷʼ
+ior	Ennemor		kʲʼ
+ior	Ennemor		m
+ior	Ennemor		mʷ
+ior	Ennemor		n
+ior	Ennemor		w
+ior	Ennemor		r
+ior	Ennemor		l
+ior	Ennemor		j
+ior	Ennemor		h
+ior	Ennemor		hʷ
+ior	Ennemor		hʲ
+ior	Ennemor		β
+ior	Ennemor		ɲ
+ior	Ennemor		w̃
+ior	Ennemor		β̃
+ior	Ennemor		r̃
+ior	Ennemor		ʔ	ok
+ior	Ennemor		ʔʷ	ok
+
 ior	Endegen		i				gunan_gurage.pdf
-ior	Endegen		e				
-ior	Endegen		a				
-ior	Endegen		ʌ				
-ior	Endegen		u				
-ior	Endegen		o				
-ior	Endegen		b				
-ior	Endegen		bʷ				
-ior	Endegen		d				
-ior	Endegen		ɣ				
-ior	Endegen		z				
-ior	Endegen		ʒ				
-ior	Endegen		ɡ				
-ior	Endegen		ɡʷ				
-ior	Endegen		ɡʲ				
-ior	Endegen		f				
-ior	Endegen		fʷ				
-ior	Endegen		t				
-ior	Endegen		t̠ʃ				
-ior	Endegen		s				
-ior	Endegen		ʃ				
-ior	Endegen		k				
-ior	Endegen		kʷ				
-ior	Endegen		kʲ				
-ior	Endegen		tʼ				
-ior	Endegen		t̠ʃʼ				
-ior	Endegen		q				
-ior	Endegen		qʷ				
-ior	Endegen		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-ior	Endegen		m				
-ior	Endegen		mʷ				
-ior	Endegen		n				
-ior	Endegen		w				
-ior	Endegen		r				
-ior	Endegen		l				
-ior	Endegen		j				
-ior	Endegen		h				
-ior	Endegen		hʷ				
-ior	Endegen		hʲ				
-ior	Endegen		ɲ				
-ior	Endegen		w̃				
-ior	Endegen		β̃				
-ior	Endegen		r̃				
-ior	Endegen		ʔ	ok			
-ior	Endegen		ʔʷ	ok			
-							
+ior	Endegen		e
+ior	Endegen		a
+ior	Endegen		ʌ
+ior	Endegen		u
+ior	Endegen		o
+ior	Endegen		b
+ior	Endegen		bʷ
+ior	Endegen		d
+ior	Endegen		ɣ
+ior	Endegen		z
+ior	Endegen		ʒ
+ior	Endegen		ɡ
+ior	Endegen		ɡʷ
+ior	Endegen		ɡʲ
+ior	Endegen		f
+ior	Endegen		fʷ
+ior	Endegen		t
+ior	Endegen		t̠ʃ
+ior	Endegen		s
+ior	Endegen		ʃ
+ior	Endegen		k
+ior	Endegen		kʷ
+ior	Endegen		kʲ
+ior	Endegen		tʼ
+ior	Endegen		t̠ʃʼ
+ior	Endegen		kʼ
+ior	Endegen		kʷʼ
+ior	Endegen		kʲʼ
+ior	Endegen		m
+ior	Endegen		mʷ
+ior	Endegen		n
+ior	Endegen		w
+ior	Endegen		r
+ior	Endegen		l
+ior	Endegen		j
+ior	Endegen		h
+ior	Endegen		hʷ
+ior	Endegen		hʲ
+ior	Endegen		ɲ
+ior	Endegen		w̃
+ior	Endegen		β̃
+ior	Endegen		r̃
+ior	Endegen		ʔ	ok
+ior	Endegen		ʔʷ	ok
+
 ior	Ener		i				gunan_gurage.pdf
-ior	Ener		e				
-ior	Ener		a				
-ior	Ener		ʌ				
-ior	Ener		u				
-ior	Ener		o				
-ior	Ener		b				
-ior	Ener		bʷ				
-ior	Ener		d				
-ior	Ener		ɣ				
-ior	Ener		z				
-ior	Ener		ʒ				
-ior	Ener		ɡ				
-ior	Ener		ɡʷ				
-ior	Ener		ɡʲ				
-ior	Ener		f				
-ior	Ener		fʷ				
-ior	Ener		t				
-ior	Ener		t̠ʃ				
-ior	Ener		s				
-ior	Ener		ʃ				
-ior	Ener		k				
-ior	Ener		kʷ				
-ior	Ener		kʲ				
-ior	Ener		tʼ				
-ior	Ener		t̠ʃʼ				
-ior	Ener		q				
-ior	Ener		qʷ				
-ior	Ener		kʼʲ	DRM: change qʲ to kʼʲ in all the languages found in gunan_gurage.pdf			
-ior	Ener		m				
-ior	Ener		mʷ				
-ior	Ener		n				
-ior	Ener		w				
-ior	Ener		r				
-ior	Ener		l				
-ior	Ener		j				
-ior	Ener		h				
-ior	Ener		hʷ				
-ior	Ener		hʲ				
-ior	Ener		ɲ				
-ior	Ener		w̃				
-ior	Ener		β̃				
-ior	Ener		r̃				
-ior	Ener		ʔ	ok			
-ior	Ener		ʔʷ	ok			
-							
+ior	Ener		e
+ior	Ener		a
+ior	Ener		ʌ
+ior	Ener		u
+ior	Ener		o
+ior	Ener		b
+ior	Ener		bʷ
+ior	Ener		d
+ior	Ener		ɣ
+ior	Ener		z
+ior	Ener		ʒ
+ior	Ener		ɡ
+ior	Ener		ɡʷ
+ior	Ener		ɡʲ
+ior	Ener		f
+ior	Ener		fʷ
+ior	Ener		t
+ior	Ener		t̠ʃ
+ior	Ener		s
+ior	Ener		ʃ
+ior	Ener		k
+ior	Ener		kʷ
+ior	Ener		kʲ
+ior	Ener		tʼ
+ior	Ener		t̠ʃʼ
+ior	Ener		kʼ
+ior	Ener		kʷʼ
+ior	Ener		kʲʼ
+ior	Ener		m
+ior	Ener		mʷ
+ior	Ener		n
+ior	Ener		w
+ior	Ener		r
+ior	Ener		l
+ior	Ener		j
+ior	Ener		h
+ior	Ener		hʷ
+ior	Ener		hʲ
+ior	Ener		ɲ
+ior	Ener		w̃
+ior	Ener		β̃
+ior	Ener		r̃
+ior	Ener		ʔ	ok
+ior	Ener		ʔʷ	ok
+
 dnn	Dzuungoo		i		[i]		dnn.pdf
-dnn	Dzuungoo		i		[ĭ]		
-dnn	Dzuungoo		i		[ĩ]		
-dnn	Dzuungoo		i		[ĩ̆]		
-dnn	Dzuungoo		i		[j]		
-dnn	Dzuungoo		ĩ				
-dnn	Dzuungoo		e		[e]		
-dnn	Dzuungoo		e		[ẽ]		
-dnn	Dzuungoo		e		[ĕ]		
-dnn	Dzuungoo		ɛ		[ɛ]		
-dnn	Dzuungoo		ɛ		[ɛ̃]		
-dnn	Dzuungoo		ɛ		[ɛ̆]		
-dnn	Dzuungoo		ɛ		[ɛ̃̆]		
-dnn	Dzuungoo		ɛ̃				
-dnn	Dzuungoo		u		[u]		
-dnn	Dzuungoo		u		[ũ]		
-dnn	Dzuungoo		u		[ŭ]		
-dnn	Dzuungoo		u		[ũ̆]		
-dnn	Dzuungoo		ũ				
-dnn	Dzuungoo		o		[o]		
-dnn	Dzuungoo		o		[õ]		
-dnn	Dzuungoo		o		[ŏ]		
-dnn	Dzuungoo		ɔ		[ɔ]		
-dnn	Dzuungoo		ɔ		[ɔ̃]		
-dnn	Dzuungoo		ɔ		[ɔ̆]		
-dnn	Dzuungoo		ɔ		[ɔ̃̆]		
-dnn	Dzuungoo		ɔ̃				
-dnn	Dzuungoo		a		[a]		
-dnn	Dzuungoo		a		[ã]		
-dnn	Dzuungoo		a		[ă]		
-dnn	Dzuungoo		a		[ã̆]		
-dnn	Dzuungoo		ã				
-dnn	Dzuungoo		p				
-dnn	Dzuungoo		t				
-dnn	Dzuungoo		c				
-dnn	Dzuungoo		k				
-dnn	Dzuungoo		kp				
-dnn	Dzuungoo		d		[d]		
-dnn	Dzuungoo		d		[ɾ]		
-dnn	Dzuungoo		ɟ				
-dnn	Dzuungoo		ɡ		[ɡ]		
-dnn	Dzuungoo		ɡ		[ŋ]		
-dnn	Dzuungoo		ɡb				
-dnn	Dzuungoo		ts				
-dnn	Dzuungoo		dz		[d̠ʒ]		
-dnn	Dzuungoo		dz		[z]		
-dnn	Dzuungoo		f				
-dnn	Dzuungoo		s				
-dnn	Dzuungoo		ʃ				
-dnn	Dzuungoo		x		[x]		
-dnn	Dzuungoo		x		[χ]		
-dnn	Dzuungoo		v				
-dnn	Dzuungoo		ʒ				
-dnn	Dzuungoo		m				
-dnn	Dzuungoo		n				
-dnn	Dzuungoo		ɲ				
-dnn	Dzuungoo		ŋ				
-dnn	Dzuungoo		ŋm				
-dnn	Dzuungoo		w		[w]		
-dnn	Dzuungoo		w		[ɥ]		
-dnn	Dzuungoo		l				
-dnn	Dzuungoo		j		[j]		
-dnn	Dzuungoo		j		[ɥ]		
-dnn	Dzuungoo		b		[b]		
-dnn	Dzuungoo		b		[bʷ]		
-dnn	Dzuungoo		iː				
-dnn	Dzuungoo		eː				
-dnn	Dzuungoo		ɛː				
-dnn	Dzuungoo		aː				
-dnn	Dzuungoo		uː				
-dnn	Dzuungoo		oː				
-dnn	Dzuungoo		ɔː				
-dnn	Dzuungoo		ĩː				
-dnn	Dzuungoo		ẽː				
-dnn	Dzuungoo		ɛ̃ː				
-dnn	Dzuungoo		ãː				
-dnn	Dzuungoo		ũː				
-dnn	Dzuungoo		õː				
-dnn	Dzuungoo		ɔ̃ː				
-dnn	Dzuungoo		˦				
-dnn	Dzuungoo		˨				
-dnn	Dzuungoo		˧				
-							
+dnn	Dzuungoo		i		[ĭ]
+dnn	Dzuungoo		i		[ĩ]
+dnn	Dzuungoo		i		[ĩ̆]
+dnn	Dzuungoo		i		[j]
+dnn	Dzuungoo		ĩ
+dnn	Dzuungoo		e		[e]
+dnn	Dzuungoo		e		[ẽ]
+dnn	Dzuungoo		e		[ĕ]
+dnn	Dzuungoo		ɛ		[ɛ]
+dnn	Dzuungoo		ɛ		[ɛ̃]
+dnn	Dzuungoo		ɛ		[ɛ̆]
+dnn	Dzuungoo		ɛ		[ɛ̃̆]
+dnn	Dzuungoo		ɛ̃
+dnn	Dzuungoo		u		[u]
+dnn	Dzuungoo		u		[ũ]
+dnn	Dzuungoo		u		[ŭ]
+dnn	Dzuungoo		u		[ũ̆]
+dnn	Dzuungoo		ũ
+dnn	Dzuungoo		o		[o]
+dnn	Dzuungoo		o		[õ]
+dnn	Dzuungoo		o		[ŏ]
+dnn	Dzuungoo		ɔ		[ɔ]
+dnn	Dzuungoo		ɔ		[ɔ̃]
+dnn	Dzuungoo		ɔ		[ɔ̆]
+dnn	Dzuungoo		ɔ		[ɔ̃̆]
+dnn	Dzuungoo		ɔ̃
+dnn	Dzuungoo		a		[a]
+dnn	Dzuungoo		a		[ã]
+dnn	Dzuungoo		a		[ă]
+dnn	Dzuungoo		a		[ã̆]
+dnn	Dzuungoo		ã
+dnn	Dzuungoo		p
+dnn	Dzuungoo		t
+dnn	Dzuungoo		c
+dnn	Dzuungoo		k
+dnn	Dzuungoo		kp
+dnn	Dzuungoo		d		[d]
+dnn	Dzuungoo		d		[ɾ]
+dnn	Dzuungoo		ɟ
+dnn	Dzuungoo		ɡ		[ɡ]
+dnn	Dzuungoo		ɡ		[ŋ]
+dnn	Dzuungoo		ɡb
+dnn	Dzuungoo		ts
+dnn	Dzuungoo		dz		[d̠ʒ]
+dnn	Dzuungoo		dz		[z]
+dnn	Dzuungoo		f
+dnn	Dzuungoo		s
+dnn	Dzuungoo		ʃ
+dnn	Dzuungoo		x		[x]
+dnn	Dzuungoo		x		[χ]
+dnn	Dzuungoo		v
+dnn	Dzuungoo		ʒ
+dnn	Dzuungoo		m
+dnn	Dzuungoo		n
+dnn	Dzuungoo		ɲ
+dnn	Dzuungoo		ŋ
+dnn	Dzuungoo		ŋm
+dnn	Dzuungoo		w		[w]
+dnn	Dzuungoo		w		[ɥ]
+dnn	Dzuungoo		l
+dnn	Dzuungoo		j		[j]
+dnn	Dzuungoo		j		[ɥ]
+dnn	Dzuungoo		b		[b]
+dnn	Dzuungoo		b		[bʷ]
+dnn	Dzuungoo		iː
+dnn	Dzuungoo		eː
+dnn	Dzuungoo		ɛː
+dnn	Dzuungoo		aː
+dnn	Dzuungoo		uː
+dnn	Dzuungoo		oː
+dnn	Dzuungoo		ɔː
+dnn	Dzuungoo		ĩː
+dnn	Dzuungoo		ẽː
+dnn	Dzuungoo		ɛ̃ː
+dnn	Dzuungoo		ãː
+dnn	Dzuungoo		ũː
+dnn	Dzuungoo		õː
+dnn	Dzuungoo		ɔ̃ː
+dnn	Dzuungoo		˦
+dnn	Dzuungoo		˨
+dnn	Dzuungoo		˧
+
 bmi	Bagirmi		i		[i]		bmi.pdf
-bmi	Bagirmi		i		[ĩ]		
-bmi	Bagirmi		ɪ				
-bmi	Bagirmi		e				
-bmi	Bagirmi		ɛ				
-bmi	Bagirmi		o		[o]		
-bmi	Bagirmi		o		[õ]		
-bmi	Bagirmi		ɔ				
-bmi	Bagirmi		u				
-bmi	Bagirmi		ʊ				
-bmi	Bagirmi		a				
-bmi	Bagirmi		ɘ				
-bmi	Bagirmi		ʌ				
-bmi	Bagirmi		aː				
-bmi	Bagirmi		eː				
-bmi	Bagirmi		iː				
-bmi	Bagirmi		oː				
-bmi	Bagirmi		uː				
-bmi	Bagirmi		p		[p]		
-bmi	Bagirmi		p		[ʃ]		
-bmi	Bagirmi		p		[pʷ]		
-bmi	Bagirmi		b				
-bmi	Bagirmi		ɓ				
-bmi	Bagirmi		m				
-bmi	Bagirmi		ɸ				
-bmi	Bagirmi		t̪				
-bmi	Bagirmi		d̪				
-bmi	Bagirmi		n̪				
-bmi	Bagirmi		ʈ				
-bmi	Bagirmi		ɖ				
-bmi	Bagirmi		ᶑ				
-bmi	Bagirmi		r				
-bmi	Bagirmi		l				
-bmi	Bagirmi		s				
-bmi	Bagirmi		z				
-bmi	Bagirmi		c				
-bmi	Bagirmi		ɟ				
-bmi	Bagirmi		ɲ				
-bmi	Bagirmi		j				
-bmi	Bagirmi		ʄ				
-bmi	Bagirmi		k				
-bmi	Bagirmi		ɡ				
-bmi	Bagirmi		ŋ		[ŋ]		
-bmi	Bagirmi		ŋ		[ŋʷ]		
-bmi	Bagirmi		w				
-bmi	Bagirmi		ʔ				
-bmi	Bagirmi		<f>	loanwords only			
-bmi	Bagirmi		<v>	loanwords only			
-bmi	Bagirmi		<z>	loanwords only			
-bmi	Bagirmi		<ʃ>	loanwords only			
-bmi	Bagirmi		<h>	loanwords only			
-bmi	Bagirmi		˦				
-bmi	Bagirmi		˨				
-bmi	Bagirmi		˧				
-							
+bmi	Bagirmi		i		[ĩ]
+bmi	Bagirmi		ɪ
+bmi	Bagirmi		e
+bmi	Bagirmi		ɛ
+bmi	Bagirmi		o		[o]
+bmi	Bagirmi		o		[õ]
+bmi	Bagirmi		ɔ
+bmi	Bagirmi		u
+bmi	Bagirmi		ʊ
+bmi	Bagirmi		a
+bmi	Bagirmi		ɘ
+bmi	Bagirmi		ʌ
+bmi	Bagirmi		aː
+bmi	Bagirmi		eː
+bmi	Bagirmi		iː
+bmi	Bagirmi		oː
+bmi	Bagirmi		uː
+bmi	Bagirmi		p		[p]
+bmi	Bagirmi		p		[ʃ]
+bmi	Bagirmi		p		[pʷ]
+bmi	Bagirmi		b
+bmi	Bagirmi		ɓ
+bmi	Bagirmi		m
+bmi	Bagirmi		ɸ
+bmi	Bagirmi		t̪
+bmi	Bagirmi		d̪
+bmi	Bagirmi		n̪
+bmi	Bagirmi		ʈ
+bmi	Bagirmi		ɖ
+bmi	Bagirmi		ᶑ
+bmi	Bagirmi		r
+bmi	Bagirmi		l
+bmi	Bagirmi		s
+bmi	Bagirmi		z
+bmi	Bagirmi		c
+bmi	Bagirmi		ɟ
+bmi	Bagirmi		ɲ
+bmi	Bagirmi		j
+bmi	Bagirmi		ʄ
+bmi	Bagirmi		k
+bmi	Bagirmi		ɡ
+bmi	Bagirmi		ŋ		[ŋ]
+bmi	Bagirmi		ŋ		[ŋʷ]
+bmi	Bagirmi		w
+bmi	Bagirmi		ʔ
+bmi	Bagirmi		<f>	loanwords only
+bmi	Bagirmi		<v>	loanwords only
+bmi	Bagirmi		<z>	loanwords only
+bmi	Bagirmi		<ʃ>	loanwords only
+bmi	Bagirmi		<h>	loanwords only
+bmi	Bagirmi		˦
+bmi	Bagirmi		˨
+bmi	Bagirmi		˧
+
 niy	Ngiti		ɓ̥				niy.pdf
-niy	Ngiti		ɓ				
-niy	Ngiti		p				
-niy	Ngiti		b				
-niy	Ngiti		mb				
-niy	Ngiti		pf				
-niy	Ngiti		bv				
-niy	Ngiti		f				
-niy	Ngiti		v				
-niy	Ngiti		ɱv				
-niy	Ngiti		m				
-niy	Ngiti		β				
-niy	Ngiti		t				
-niy	Ngiti		d				
-niy	Ngiti		nd				
-niy	Ngiti		ts				
-niy	Ngiti		dz				
-niy	Ngiti		s				
-niy	Ngiti		z				
-niy	Ngiti		nz				
-niy	Ngiti		n				
-niy	Ngiti		l				
-niy	Ngiti		ɗ̥				
-niy	Ngiti		ɗ				
-niy	Ngiti		ʈɽ				
-niy	Ngiti		ɖɽ				
-niy	Ngiti		ɳɖɽ				
-niy	Ngiti		r				
-niy	Ngiti		ʄ̥				
-niy	Ngiti		ʄ				
-niy	Ngiti		c				
-niy	Ngiti		ɟ				
-niy	Ngiti		ɲɟ				
-niy	Ngiti		ɲ				
-niy	Ngiti		j				
-niy	Ngiti		k				
-niy	Ngiti		ɡ				
-niy	Ngiti		ŋɡ				
-niy	Ngiti		ʔ				
-niy	Ngiti		h				
-niy	Ngiti		kp				
-niy	Ngiti		ɡb				
-niy	Ngiti		ŋmɡb				
-niy	Ngiti		w				
-niy	Ngiti		i		[i]		
-niy	Ngiti		i		[ɪ]		
-niy	Ngiti		u		[u]		
-niy	Ngiti		u		[ʊ]		
-niy	Ngiti		e		[e]		
-niy	Ngiti		e		[ɛ]		
-niy	Ngiti		o		[o]		
-niy	Ngiti		o		[ɔ]		
-niy	Ngiti		a				
-niy	Ngiti		˦				
-niy	Ngiti		˨				
-niy	Ngiti		˧				
-niy	Ngiti		˨˧				
-niy	Ngiti		˧˨				
-niy	Ngiti		˦˨				
-niy	Ngiti		˨˥˩	low falling; L*			
-							
+niy	Ngiti		ɓ
+niy	Ngiti		p
+niy	Ngiti		b
+niy	Ngiti		mb
+niy	Ngiti		pf
+niy	Ngiti		bv
+niy	Ngiti		f
+niy	Ngiti		v
+niy	Ngiti		ɱv
+niy	Ngiti		m
+niy	Ngiti		β
+niy	Ngiti		t
+niy	Ngiti		d
+niy	Ngiti		nd
+niy	Ngiti		ts
+niy	Ngiti		dz
+niy	Ngiti		s
+niy	Ngiti		z
+niy	Ngiti		nz
+niy	Ngiti		n
+niy	Ngiti		l
+niy	Ngiti		ɗ̥
+niy	Ngiti		ɗ
+niy	Ngiti		ʈɽ
+niy	Ngiti		ɖɽ
+niy	Ngiti		ɳɖɽ
+niy	Ngiti		r
+niy	Ngiti		ʄ̥
+niy	Ngiti		ʄ
+niy	Ngiti		c
+niy	Ngiti		ɟ
+niy	Ngiti		ɲɟ
+niy	Ngiti		ɲ
+niy	Ngiti		j
+niy	Ngiti		k
+niy	Ngiti		ɡ
+niy	Ngiti		ŋɡ
+niy	Ngiti		ʔ
+niy	Ngiti		h
+niy	Ngiti		kp
+niy	Ngiti		ɡb
+niy	Ngiti		ŋmɡb
+niy	Ngiti		w
+niy	Ngiti		i		[i]
+niy	Ngiti		i		[ɪ]
+niy	Ngiti		u		[u]
+niy	Ngiti		u		[ʊ]
+niy	Ngiti		e		[e]
+niy	Ngiti		e		[ɛ]
+niy	Ngiti		o		[o]
+niy	Ngiti		o		[ɔ]
+niy	Ngiti		a
+niy	Ngiti		˦
+niy	Ngiti		˨
+niy	Ngiti		˧
+niy	Ngiti		˨˧
+niy	Ngiti		˧˨
+niy	Ngiti		˦˨
+niy	Ngiti		˨˥˩	low falling; L*
+
 ndh	Chindali		i				ndh.pdf
-ndh	Chindali		e				
-ndh	Chindali		a				
-ndh	Chindali		o				
-ndh	Chindali		u				
-ndh	Chindali		iː				
-ndh	Chindali		eː				
-ndh	Chindali		aː				
-ndh	Chindali		oː				
-ndh	Chindali		uː				
-ndh	Chindali		<z>	rare			
-ndh	Chindali		ʋ		[ʋ]		
-ndh	Chindali		ʋ		[b]		
-ndh	Chindali		m				
-ndh	Chindali		w				
-ndh	Chindali		f				
-ndh	Chindali		ɡ				
-ndh	Chindali		s				
-ndh	Chindali		n		[n]		
-ndh	Chindali		n		[nʲ]		
-ndh	Chindali		l		[l]		
-ndh	Chindali		l		[ɹ]		
-ndh	Chindali		l		[d]		
-ndh	Chindali		t̠ʃ				
-ndh	Chindali		ʃ				
-ndh	Chindali		ɲ				
-ndh	Chindali		j		[j]		
-ndh	Chindali		j		[ʒ]		
-ndh	Chindali		k		[k]		
-ndh	Chindali		k		[ɡ]		
-ndh	Chindali		ɣ		[ɣ]		
-ndh	Chindali		ɣ		[ɰ]		
-ndh	Chindali		ɣ		[ɡ]		
-ndh	Chindali		ŋ				
-ndh	Chindali		h				
-ndh	Chindali		˨˦				
-ndh	Chindali		˦˨				
-ndh	Chindali		˦		[˦]		
-ndh	Chindali		˦		[↓˦]		
-ndh	Chindali		˨				
-							
+ndh	Chindali		e
+ndh	Chindali		a
+ndh	Chindali		o
+ndh	Chindali		u
+ndh	Chindali		iː
+ndh	Chindali		eː
+ndh	Chindali		aː
+ndh	Chindali		oː
+ndh	Chindali		uː
+ndh	Chindali		<z>	rare
+ndh	Chindali		ʋ		[ʋ]
+ndh	Chindali		ʋ		[b]
+ndh	Chindali		m
+ndh	Chindali		w
+ndh	Chindali		f
+ndh	Chindali		ɡ
+ndh	Chindali		s
+ndh	Chindali		n		[n]
+ndh	Chindali		n		[nʲ]
+ndh	Chindali		l		[l]
+ndh	Chindali		l		[ɹ]
+ndh	Chindali		l		[d]
+ndh	Chindali		t̠ʃ
+ndh	Chindali		ʃ
+ndh	Chindali		ɲ
+ndh	Chindali		j		[j]
+ndh	Chindali		j		[ʒ]
+ndh	Chindali		k		[k]
+ndh	Chindali		k		[ɡ]
+ndh	Chindali		ɣ		[ɣ]
+ndh	Chindali		ɣ		[ɰ]
+ndh	Chindali		ɣ		[ɡ]
+ndh	Chindali		ŋ
+ndh	Chindali		h
+ndh	Chindali		˨˦
+ndh	Chindali		˦˨
+ndh	Chindali		˦		[˦]
+ndh	Chindali		˦		[↓˦]
+ndh	Chindali		˨
+
 mym	Me'en		p		[p]		mym.pdf
-mym	Me'en		p		[f]		
-mym	Me'en		p		[ɸ]		
-mym	Me'en		p		[pʰ]		
-mym	Me'en		t		[t]		
-mym	Me'en		t		[tʰ]		
-mym	Me'en		cç				
-mym	Me'en		k		[k]		
-mym	Me'en		k		[kʰ]		
-mym	Me'en		<ʔ>	questionable			
-mym	Me'en		b		[b]		
-mym	Me'en		b		[p]		
-mym	Me'en		d		[d]		
-mym	Me'en		d		[t]		
-mym	Me'en		ɟʝ		[ɟʝ]		
-mym	Me'en		ɟʝ		[cç]		
-mym	Me'en		ɡ		[ɡ]		
-mym	Me'en		ɡ		[k]		
-mym	Me'en		tʼ				
-mym	Me'en		cçʼ				
-mym	Me'en		kʼ				
-mym	Me'en		ɓ				
-mym	Me'en		ɗ				
-mym	Me'en		s				
-mym	Me'en		ʃ				
-mym	Me'en		h				
-mym	Me'en		z				
-mym	Me'en		m				
-mym	Me'en		n				
-mym	Me'en		ɲ				
-mym	Me'en		ŋ				
-mym	Me'en		r				
-mym	Me'en		l				
-mym	Me'en		w				
-mym	Me'en		j				
-mym	Me'en		i				
-mym	Me'en		e				
-mym	Me'en		ɛ				
-mym	Me'en		a				
-mym	Me'en		u				
-mym	Me'en		o				
-mym	Me'en		ɔ				
-mym	Me'en		iː				
-mym	Me'en		eː				
-mym	Me'en		ɛː				
-mym	Me'en		aː				
-mym	Me'en		uː				
-mym	Me'en		oː				
-mym	Me'en		ɔː				
-							
+mym	Me'en		p		[f]
+mym	Me'en		p		[ɸ]
+mym	Me'en		p		[pʰ]
+mym	Me'en		t		[t]
+mym	Me'en		t		[tʰ]
+mym	Me'en		cç
+mym	Me'en		k		[k]
+mym	Me'en		k		[kʰ]
+mym	Me'en		<ʔ>	questionable
+mym	Me'en		b		[b]
+mym	Me'en		b		[p]
+mym	Me'en		d		[d]
+mym	Me'en		d		[t]
+mym	Me'en		ɟʝ		[ɟʝ]
+mym	Me'en		ɟʝ		[cç]
+mym	Me'en		ɡ		[ɡ]
+mym	Me'en		ɡ		[k]
+mym	Me'en		tʼ
+mym	Me'en		cçʼ
+mym	Me'en		kʼ
+mym	Me'en		ɓ
+mym	Me'en		ɗ
+mym	Me'en		s
+mym	Me'en		ʃ
+mym	Me'en		h
+mym	Me'en		z
+mym	Me'en		m
+mym	Me'en		n
+mym	Me'en		ɲ
+mym	Me'en		ŋ
+mym	Me'en		r
+mym	Me'en		l
+mym	Me'en		w
+mym	Me'en		j
+mym	Me'en		i
+mym	Me'en		e
+mym	Me'en		ɛ
+mym	Me'en		a
+mym	Me'en		u
+mym	Me'en		o
+mym	Me'en		ɔ
+mym	Me'en		iː
+mym	Me'en		eː
+mym	Me'en		ɛː
+mym	Me'en		aː
+mym	Me'en		uː
+mym	Me'en		oː
+mym	Me'en		ɔː
+
 nsg	Ongamo		p		[p]		nsg.pdf
-nsg	Ongamo		p		[β]		
-nsg	Ongamo		ɓ				
-nsg	Ongamo		m				
-nsg	Ongamo		w				
-nsg	Ongamo		wː				
-nsg	Ongamo		t̪				
-nsg	Ongamo		d̪				
-nsg	Ongamo		s̪				
-nsg	Ongamo		n̪				
-nsg	Ongamo		l̪				
-nsg	Ongamo		r̪				
-nsg	Ongamo		r̪ː				
-nsg	Ongamo		ʃ				
-nsg	Ongamo		ɽ				
-nsg	Ongamo		ʄ				
-nsg	Ongamo		ɲ				
-nsg	Ongamo		j				
-nsg	Ongamo		jː				
-nsg	Ongamo		k				
-nsg	Ongamo		ɡ				
-nsg	Ongamo		ŋ				
-nsg	Ongamo		h				
-nsg	Ongamo		i				
-nsg	Ongamo		e				
-nsg	Ongamo		a				
-nsg	Ongamo		o				
-nsg	Ongamo		u				
-nsg	Ongamo		ɪ				
-nsg	Ongamo		ɛ				
-nsg	Ongamo		a				
-nsg	Ongamo		ʊ				
-nsg	Ongamo		ɔ				
-							
+nsg	Ongamo		p		[β]
+nsg	Ongamo		ɓ
+nsg	Ongamo		m
+nsg	Ongamo		w
+nsg	Ongamo		wː
+nsg	Ongamo		t̪
+nsg	Ongamo		d̪
+nsg	Ongamo		s̪
+nsg	Ongamo		n̪
+nsg	Ongamo		l̪
+nsg	Ongamo		r̪
+nsg	Ongamo		r̪ː
+nsg	Ongamo		ʃ
+nsg	Ongamo		ɽ
+nsg	Ongamo		ʄ
+nsg	Ongamo		ɲ
+nsg	Ongamo		j
+nsg	Ongamo		jː
+nsg	Ongamo		k
+nsg	Ongamo		ɡ
+nsg	Ongamo		ŋ
+nsg	Ongamo		h
+nsg	Ongamo		i
+nsg	Ongamo		e
+nsg	Ongamo		a
+nsg	Ongamo		o
+nsg	Ongamo		u
+nsg	Ongamo		ɪ
+nsg	Ongamo		ɛ
+nsg	Ongamo		a
+nsg	Ongamo		ʊ
+nsg	Ongamo		ɔ
+
 myb	Mbay		i		[i]		myb.pdf
-myb	Mbay		i		[ɪ]		
-myb	Mbay		e				
-myb	Mbay		ə				
-myb	Mbay		a				
-myb	Mbay		u		[u]		
-myb	Mbay		u		[ʊ]		
-myb	Mbay		o				
-myb	Mbay		ɔ				
-myb	Mbay		m				
-myb	Mbay		n				
-myb	Mbay		l				
-myb	Mbay		r				
-myb	Mbay		ɺ				
-myb	Mbay		j		[j]		
-myb	Mbay		j		[ɲ]		
-myb	Mbay		w				
-myb	Mbay		k				
-myb	Mbay		p				
-myb	Mbay		t				
-myb	Mbay		ɡ				
-myb	Mbay		b				
-myb	Mbay		d				
-myb	Mbay		ɗ				
-myb	Mbay		ɓ				
-myb	Mbay		ŋɡ		[ŋɡ]		
-myb	Mbay		ŋɡ		[ŋ]		
-myb	Mbay		n̠d̠ʒ				
-myb	Mbay		nd				
-myb	Mbay		mb				
-myb	Mbay		h				
-myb	Mbay		d̠ʒ				
-myb	Mbay		s				
-myb	Mbay		iː		[iː]		
-myb	Mbay		iː		[ɪː]		
-myb	Mbay		eː				
-myb	Mbay		əː				
-myb	Mbay		aː				
-myb	Mbay		uː		[uː]		
-myb	Mbay		uː		[ʊː]		
-myb	Mbay		oː				
-myb	Mbay		ɔː				
-myb	Mbay		ĩ		[ĩ]		
-myb	Mbay		ĩ		[ɪ̃]		
-myb	Mbay		ẽ				
-myb	Mbay		ã				
-myb	Mbay		ũ		[ũ]		
-myb	Mbay		ũ		[ʊ̃]		
-myb	Mbay		õ				
-myb	Mbay		˦				
-myb	Mbay		˨				
-myb	Mbay		˧				
-							
+myb	Mbay		i		[ɪ]
+myb	Mbay		e
+myb	Mbay		ə
+myb	Mbay		a
+myb	Mbay		u		[u]
+myb	Mbay		u		[ʊ]
+myb	Mbay		o
+myb	Mbay		ɔ
+myb	Mbay		m
+myb	Mbay		n
+myb	Mbay		l
+myb	Mbay		r
+myb	Mbay		ɺ
+myb	Mbay		j		[j]
+myb	Mbay		j		[ɲ]
+myb	Mbay		w
+myb	Mbay		k
+myb	Mbay		p
+myb	Mbay		t
+myb	Mbay		ɡ
+myb	Mbay		b
+myb	Mbay		d
+myb	Mbay		ɗ
+myb	Mbay		ɓ
+myb	Mbay		ŋɡ		[ŋɡ]
+myb	Mbay		ŋɡ		[ŋ]
+myb	Mbay		n̠d̠ʒ
+myb	Mbay		nd
+myb	Mbay		mb
+myb	Mbay		h
+myb	Mbay		d̠ʒ
+myb	Mbay		s
+myb	Mbay		iː		[iː]
+myb	Mbay		iː		[ɪː]
+myb	Mbay		eː
+myb	Mbay		əː
+myb	Mbay		aː
+myb	Mbay		uː		[uː]
+myb	Mbay		uː		[ʊː]
+myb	Mbay		oː
+myb	Mbay		ɔː
+myb	Mbay		ĩ		[ĩ]
+myb	Mbay		ĩ		[ɪ̃]
+myb	Mbay		ẽ
+myb	Mbay		ã
+myb	Mbay		ũ		[ũ]
+myb	Mbay		ũ		[ʊ̃]
+myb	Mbay		õ
+myb	Mbay		˦
+myb	Mbay		˨
+myb	Mbay		˧
+
 guk	Gumuz	Sese	<pʼ>	rare			sese.pdf
-guk	Gumuz	Sese	p		[p]		
-guk	Gumuz	Sese	p		[pʰ]		
-guk	Gumuz	Sese	b		[b]		
-guk	Gumuz	Sese	b		[p]		
-guk	Gumuz	Sese	ɓ		[ɓ]		
-guk	Gumuz	Sese	ɓ		[ɓ̚]		
-guk	Gumuz	Sese	ɓ		[bʷ]		
-guk	Gumuz	Sese	f				
-guk	Gumuz	Sese	m		[m]		
-guk	Gumuz	Sese	m		[ɱ]		
-guk	Gumuz	Sese	w				
-guk	Gumuz	Sese	tʼ				
-guk	Gumuz	Sese	t		[t]		
-guk	Gumuz	Sese	t		[tː]		
-guk	Gumuz	Sese	d		[d]		
-guk	Gumuz	Sese	d		[t]		
-guk	Gumuz	Sese	ᶑ				
-guk	Gumuz	Sese	s				
-guk	Gumuz	Sese	z				
-guk	Gumuz	Sese	tsʼ				
-guk	Gumuz	Sese	ts				
-guk	Gumuz	Sese	n				
-guk	Gumuz	Sese	l				
-guk	Gumuz	Sese	r		[r]		
-guk	Gumuz	Sese	r		[ɾ]		
-guk	Gumuz	Sese	r		[rː]		
-guk	Gumuz	Sese	ʃ				
-guk	Gumuz	Sese	ʒ				
-guk	Gumuz	Sese	t̠ʃʼ				
-guk	Gumuz	Sese	t̠ʃ				
-guk	Gumuz	Sese	cçʼ				
-guk	Gumuz	Sese	cç				
-guk	Gumuz	Sese	ɟʝ				
-guk	Gumuz	Sese	ɲ				
-guk	Gumuz	Sese	j				
-guk	Gumuz	Sese	kʼ				
-guk	Gumuz	Sese	k		[k]		
-guk	Gumuz	Sese	k		[kː]		
-guk	Gumuz	Sese	ɡ				
-guk	Gumuz	Sese	ɠ				
-guk	Gumuz	Sese	ŋ				
-guk	Gumuz	Sese	ʔ				
-guk	Gumuz	Sese	h				
-guk	Gumuz	Sese	i				
-guk	Gumuz	Sese	e				
-guk	Gumuz	Sese	a		[a]		
-guk	Gumuz	Sese	a		[ʌ]		
-guk	Gumuz	Sese	a		[ə]		
-guk	Gumuz	Sese	a		[ɵ]		
-guk	Gumuz	Sese	o				
-guk	Gumuz	Sese	u				
-guk	Gumuz	Sese	iː				
-guk	Gumuz	Sese	eː				
-guk	Gumuz	Sese	aː				
-guk	Gumuz	Sese	uː				
-guk	Gumuz	Sese	oː				
-							
+guk	Gumuz	Sese	p		[p]
+guk	Gumuz	Sese	p		[pʰ]
+guk	Gumuz	Sese	b		[b]
+guk	Gumuz	Sese	b		[p]
+guk	Gumuz	Sese	ɓ		[ɓ]
+guk	Gumuz	Sese	ɓ		[ɓ̚]
+guk	Gumuz	Sese	ɓ		[bʷ]
+guk	Gumuz	Sese	f
+guk	Gumuz	Sese	m		[m]
+guk	Gumuz	Sese	m		[ɱ]
+guk	Gumuz	Sese	w
+guk	Gumuz	Sese	tʼ
+guk	Gumuz	Sese	t		[t]
+guk	Gumuz	Sese	t		[tː]
+guk	Gumuz	Sese	d		[d]
+guk	Gumuz	Sese	d		[t]
+guk	Gumuz	Sese	ᶑ
+guk	Gumuz	Sese	s
+guk	Gumuz	Sese	z
+guk	Gumuz	Sese	tsʼ
+guk	Gumuz	Sese	ts
+guk	Gumuz	Sese	n
+guk	Gumuz	Sese	l
+guk	Gumuz	Sese	r		[r]
+guk	Gumuz	Sese	r		[ɾ]
+guk	Gumuz	Sese	r		[rː]
+guk	Gumuz	Sese	ʃ
+guk	Gumuz	Sese	ʒ
+guk	Gumuz	Sese	t̠ʃʼ
+guk	Gumuz	Sese	t̠ʃ
+guk	Gumuz	Sese	cçʼ
+guk	Gumuz	Sese	cç
+guk	Gumuz	Sese	ɟʝ
+guk	Gumuz	Sese	ɲ
+guk	Gumuz	Sese	j
+guk	Gumuz	Sese	kʼ
+guk	Gumuz	Sese	k		[k]
+guk	Gumuz	Sese	k		[kː]
+guk	Gumuz	Sese	ɡ
+guk	Gumuz	Sese	ɠ
+guk	Gumuz	Sese	ŋ
+guk	Gumuz	Sese	ʔ
+guk	Gumuz	Sese	h
+guk	Gumuz	Sese	i
+guk	Gumuz	Sese	e
+guk	Gumuz	Sese	a		[a]
+guk	Gumuz	Sese	a		[ʌ]
+guk	Gumuz	Sese	a		[ə]
+guk	Gumuz	Sese	a		[ɵ]
+guk	Gumuz	Sese	o
+guk	Gumuz	Sese	u
+guk	Gumuz	Sese	iː
+guk	Gumuz	Sese	eː
+guk	Gumuz	Sese	aː
+guk	Gumuz	Sese	uː
+guk	Gumuz	Sese	oː
+
 teu	Soo		p				soo.pdf
-teu	Soo		ɓ				
-teu	Soo		m				
-teu	Soo		w				
-teu	Soo		s				
-teu	Soo		n				
-teu	Soo		t				
-teu	Soo		ɗ				
-teu	Soo		l				
-teu	Soo		r				
-teu	Soo		t̠ʃ				
-teu	Soo		ʄ				
-teu	Soo		ɲ				
-teu	Soo		j				
-teu	Soo		k				
-teu	Soo		ɠ				
-teu	Soo		ŋ				
-teu	Soo		<ʔ>	not used by speakers born after about 1950			
-teu	Soo		i				
-teu	Soo		ɪ				
-teu	Soo		e				
-teu	Soo		ɛ				
-teu	Soo		ʌ				
-teu	Soo		a				
-teu	Soo		ɔ				
-teu	Soo		o				
-teu	Soo		ʊ				
-teu	Soo		u				
-							
+teu	Soo		ɓ
+teu	Soo		m
+teu	Soo		w
+teu	Soo		s
+teu	Soo		n
+teu	Soo		t
+teu	Soo		ɗ
+teu	Soo		l
+teu	Soo		r
+teu	Soo		t̠ʃ
+teu	Soo		ʄ
+teu	Soo		ɲ
+teu	Soo		j
+teu	Soo		k
+teu	Soo		ɠ
+teu	Soo		ŋ
+teu	Soo		<ʔ>	not used by speakers born after about 1950
+teu	Soo		i
+teu	Soo		ɪ
+teu	Soo		e
+teu	Soo		ɛ
+teu	Soo		ʌ
+teu	Soo		a
+teu	Soo		ɔ
+teu	Soo		o
+teu	Soo		ʊ
+teu	Soo		u
+
 bcq	Gimira	Benchnon	i				gimira.pdf
-bcq	Gimira	Benchnon	e				
-bcq	Gimira	Benchnon	a				
-bcq	Gimira	Benchnon	u				
-bcq	Gimira	Benchnon	o				
-bcq	Gimira	Benchnon	pʰ		[pʰ]		
-bcq	Gimira	Benchnon	pʰ		[f]		
-bcq	Gimira	Benchnon	pʲ				
-bcq	Gimira	Benchnon	pʷ				
-bcq	Gimira	Benchnon	t				
-bcq	Gimira	Benchnon	tʲ				
-bcq	Gimira	Benchnon	ts				
-bcq	Gimira	Benchnon	t̠ʃ				
-bcq	Gimira	Benchnon	ʈʂ				
-bcq	Gimira	Benchnon	k				
-bcq	Gimira	Benchnon	kʲ				
-bcq	Gimira	Benchnon	ʔ	ok			
-bcq	Gimira	Benchnon	ʔʲ	ok			
-bcq	Gimira	Benchnon	ʔʷ	ok			
-bcq	Gimira	Benchnon	b				
-bcq	Gimira	Benchnon	bʲ				
-bcq	Gimira	Benchnon	bʷ				
-bcq	Gimira	Benchnon	d				
-bcq	Gimira	Benchnon	dʲ				
-bcq	Gimira	Benchnon	ɡ				
-bcq	Gimira	Benchnon	ɡʲ				
-bcq	Gimira	Benchnon	ɡʷ				
-bcq	Gimira	Benchnon	pʼ				
-bcq	Gimira	Benchnon	tʼ				
-bcq	Gimira	Benchnon	tʲʼ				
-bcq	Gimira	Benchnon	tsʼ				
-bcq	Gimira	Benchnon	t̠ʃʼ		[t̠ʃʼ]		
-bcq	Gimira	Benchnon	t̠ʃʼ		[t̠ʃʲʼ]		
-bcq	Gimira	Benchnon	ʈʂʼ				
-bcq	Gimira	Benchnon	kʼ				
-bcq	Gimira	Benchnon	kʲʼ				
-bcq	Gimira	Benchnon	s				
-bcq	Gimira	Benchnon	sʲ				
-bcq	Gimira	Benchnon	sʷ				
-bcq	Gimira	Benchnon	ʃ		[ʃ]		
-bcq	Gimira	Benchnon	ʃ		[ʃʲ]		
-bcq	Gimira	Benchnon	ʂ				
-bcq	Gimira	Benchnon	h				
-bcq	Gimira	Benchnon	z		[z]		
-bcq	Gimira	Benchnon	z		[d̠ʒ]		
-bcq	Gimira	Benchnon	z		[ʒʲ]		
-bcq	Gimira	Benchnon	zʲ				
-bcq	Gimira	Benchnon	ʒ				
-bcq	Gimira	Benchnon	ʐ				
-bcq	Gimira	Benchnon	m				
-bcq	Gimira	Benchnon	mʲ				
-bcq	Gimira	Benchnon	n		[n]		
-bcq	Gimira	Benchnon	n		[ŋ]		
-bcq	Gimira	Benchnon	nʲ				
-bcq	Gimira	Benchnon	l				
-bcq	Gimira	Benchnon	r				
-bcq	Gimira	Benchnon	j		[j]		
-bcq	Gimira	Benchnon	j		[w]		
-bcq	Gimira	Benchnon	˥				
-bcq	Gimira	Benchnon	˩				
-bcq	Gimira	Benchnon	˦				
-bcq	Gimira	Benchnon	˨				
-bcq	Gimira	Benchnon	˧				
-							
+bcq	Gimira	Benchnon	e
+bcq	Gimira	Benchnon	a
+bcq	Gimira	Benchnon	u
+bcq	Gimira	Benchnon	o
+bcq	Gimira	Benchnon	pʰ		[pʰ]
+bcq	Gimira	Benchnon	pʰ		[f]
+bcq	Gimira	Benchnon	pʲ
+bcq	Gimira	Benchnon	pʷ
+bcq	Gimira	Benchnon	t
+bcq	Gimira	Benchnon	tʲ
+bcq	Gimira	Benchnon	ts
+bcq	Gimira	Benchnon	t̠ʃ
+bcq	Gimira	Benchnon	ʈʂ
+bcq	Gimira	Benchnon	k
+bcq	Gimira	Benchnon	kʲ
+bcq	Gimira	Benchnon	ʔ	ok
+bcq	Gimira	Benchnon	ʔʲ	ok
+bcq	Gimira	Benchnon	ʔʷ	ok
+bcq	Gimira	Benchnon	b
+bcq	Gimira	Benchnon	bʲ
+bcq	Gimira	Benchnon	bʷ
+bcq	Gimira	Benchnon	d
+bcq	Gimira	Benchnon	dʲ
+bcq	Gimira	Benchnon	ɡ
+bcq	Gimira	Benchnon	ɡʲ
+bcq	Gimira	Benchnon	ɡʷ
+bcq	Gimira	Benchnon	pʼ
+bcq	Gimira	Benchnon	tʼ
+bcq	Gimira	Benchnon	tʲʼ
+bcq	Gimira	Benchnon	tsʼ
+bcq	Gimira	Benchnon	t̠ʃʼ		[t̠ʃʼ]
+bcq	Gimira	Benchnon	t̠ʃʼ		[t̠ʃʲʼ]
+bcq	Gimira	Benchnon	ʈʂʼ
+bcq	Gimira	Benchnon	kʼ
+bcq	Gimira	Benchnon	kʲʼ
+bcq	Gimira	Benchnon	s
+bcq	Gimira	Benchnon	sʲ
+bcq	Gimira	Benchnon	sʷ
+bcq	Gimira	Benchnon	ʃ		[ʃ]
+bcq	Gimira	Benchnon	ʃ		[ʃʲ]
+bcq	Gimira	Benchnon	ʂ
+bcq	Gimira	Benchnon	h
+bcq	Gimira	Benchnon	z		[z]
+bcq	Gimira	Benchnon	z		[d̠ʒ]
+bcq	Gimira	Benchnon	z		[ʒʲ]
+bcq	Gimira	Benchnon	zʲ
+bcq	Gimira	Benchnon	ʒ
+bcq	Gimira	Benchnon	ʐ
+bcq	Gimira	Benchnon	m
+bcq	Gimira	Benchnon	mʲ
+bcq	Gimira	Benchnon	n		[n]
+bcq	Gimira	Benchnon	n		[ŋ]
+bcq	Gimira	Benchnon	nʲ
+bcq	Gimira	Benchnon	l
+bcq	Gimira	Benchnon	r
+bcq	Gimira	Benchnon	j		[j]
+bcq	Gimira	Benchnon	j		[w]
+bcq	Gimira	Benchnon	˥
+bcq	Gimira	Benchnon	˩
+bcq	Gimira	Benchnon	˦
+bcq	Gimira	Benchnon	˨
+bcq	Gimira	Benchnon	˧
+
 bcq	Bench		p		[p]		bench.pdf
-bcq	Bench		p		[ɸ]		
-bcq	Bench		b				
-bcq	Bench		pʼ				
-bcq	Bench		m				
-bcq	Bench		w				
-bcq	Bench		d				
-bcq	Bench		t				
-bcq	Bench		tʼ				
-bcq	Bench		n				
-bcq	Bench		ts				
-bcq	Bench		tsʼ				
-bcq	Bench		z				
-bcq	Bench		s				
-bcq	Bench		l				
-bcq	Bench		r				
-bcq	Bench		cç				
-bcq	Bench		cçʼ				
-bcq	Bench		ʒ				
-bcq	Bench		ʃ				
-bcq	Bench		j				
-bcq	Bench		ʈʂ				
-bcq	Bench		ʈʂʼ				
-bcq	Bench		ʐ				
-bcq	Bench		ʂ				
-bcq	Bench		ɡ				
-bcq	Bench		k				
-bcq	Bench		kʼ				
-bcq	Bench		ʔ				
-bcq	Bench		h				
-bcq	Bench		i				
-bcq	Bench		e				
-bcq	Bench		a				
-bcq	Bench		u				
-bcq	Bench		o				
-bcq	Bench		˨˧				
-bcq	Bench		˧˨				
-bcq	Bench		˥				
-bcq	Bench		˦				
-bcq	Bench		˨				
-bcq	Bench		˧				
-							
+bcq	Bench		p		[ɸ]
+bcq	Bench		b
+bcq	Bench		pʼ
+bcq	Bench		m
+bcq	Bench		w
+bcq	Bench		d
+bcq	Bench		t
+bcq	Bench		tʼ
+bcq	Bench		n
+bcq	Bench		ts
+bcq	Bench		tsʼ
+bcq	Bench		z
+bcq	Bench		s
+bcq	Bench		l
+bcq	Bench		r
+bcq	Bench		cç
+bcq	Bench		cçʼ
+bcq	Bench		ʒ
+bcq	Bench		ʃ
+bcq	Bench		j
+bcq	Bench		ʈʂ
+bcq	Bench		ʈʂʼ
+bcq	Bench		ʐ
+bcq	Bench		ʂ
+bcq	Bench		ɡ
+bcq	Bench		k
+bcq	Bench		kʼ
+bcq	Bench		ʔ
+bcq	Bench		h
+bcq	Bench		i
+bcq	Bench		e
+bcq	Bench		a
+bcq	Bench		u
+bcq	Bench		o
+bcq	Bench		˨˧
+bcq	Bench		˧˨
+bcq	Bench		˥
+bcq	Bench		˦
+bcq	Bench		˨
+bcq	Bench		˧
+
 jnj	Yemsa		b		[b]		bench.pdf
-jnj	Yemsa		b		[β]		
-jnj	Yemsa		p		[p]		
-jnj	Yemsa		p		[ɸ]		
-jnj	Yemsa		p		[f]		
-jnj	Yemsa		pʼ				
-jnj	Yemsa		m				
-jnj	Yemsa		w				
-jnj	Yemsa		d				
-jnj	Yemsa		t		[t]		
-jnj	Yemsa		t		[tʰ]		
-jnj	Yemsa		tʼ				
-jnj	Yemsa		n				
-jnj	Yemsa		z				
-jnj	Yemsa		s				
-jnj	Yemsa		l				
-jnj	Yemsa		ɾ		[ɾ]		
-jnj	Yemsa		ɾ		[ʔr]		
-jnj	Yemsa		d̠ʒ				
-jnj	Yemsa		t̠ʃ				
-jnj	Yemsa		t̠ʃʼ				
-jnj	Yemsa		ɲ				
-jnj	Yemsa		ʃ		[ʃ]		
-jnj	Yemsa		ʃ		[ʂ]		
-jnj	Yemsa		j				
-jnj	Yemsa		ɡ		[ɡ]		
-jnj	Yemsa		ɡ		[ɣ]		
-jnj	Yemsa		k		[k]		
-jnj	Yemsa		k		[q]		
-jnj	Yemsa		k		[χ]		
-jnj	Yemsa		k		[kʰ]		
-jnj	Yemsa		k		[kχ]		
-jnj	Yemsa		kʼ				
-jnj	Yemsa		ŋ				
-jnj	Yemsa		ʔ				
-jnj	Yemsa		h				
-jnj	Yemsa		i		[i]		
-jnj	Yemsa		i		[ɪ]		
-jnj	Yemsa		iː		[iː]		
-jnj	Yemsa		iː		[ɪː]		
-jnj	Yemsa		e		[e]		
-jnj	Yemsa		e		[ɛ]		
-jnj	Yemsa		e		[ə]		
-jnj	Yemsa		eː		[eː]		
-jnj	Yemsa		eː		[ɛː]		
-jnj	Yemsa		eː		[əː]		
-jnj	Yemsa		a		[a]		
-jnj	Yemsa		a		[ɑ]		
-jnj	Yemsa		a		[ʌ]		
-jnj	Yemsa		aː		[aː]		
-jnj	Yemsa		aː		[ɑː]		
-jnj	Yemsa		aː		[ʌː]		
-jnj	Yemsa		u		[u]		
-jnj	Yemsa		u		[ʊ]		
-jnj	Yemsa		uː		[uː]		
-jnj	Yemsa		uː		[ʊː]		
-jnj	Yemsa		o		[o]		
-jnj	Yemsa		o		[ɔ]		
-jnj	Yemsa		oː		[oː]		
-jnj	Yemsa		oː		[ɔː]		
-jnj	Yemsa		˨˧				
-jnj	Yemsa		˦				
-jnj	Yemsa		˨				
-jnj	Yemsa		˧				
-jnj	Yemsa		˩˥				
-							
+jnj	Yemsa		b		[β]
+jnj	Yemsa		p		[p]
+jnj	Yemsa		p		[ɸ]
+jnj	Yemsa		p		[f]
+jnj	Yemsa		pʼ
+jnj	Yemsa		m
+jnj	Yemsa		w
+jnj	Yemsa		d
+jnj	Yemsa		t		[t]
+jnj	Yemsa		t		[tʰ]
+jnj	Yemsa		tʼ
+jnj	Yemsa		n
+jnj	Yemsa		z
+jnj	Yemsa		s
+jnj	Yemsa		l
+jnj	Yemsa		ɾ		[ɾ]
+jnj	Yemsa		ɾ		[ʔr]
+jnj	Yemsa		d̠ʒ
+jnj	Yemsa		t̠ʃ
+jnj	Yemsa		t̠ʃʼ
+jnj	Yemsa		ɲ
+jnj	Yemsa		ʃ		[ʃ]
+jnj	Yemsa		ʃ		[ʂ]
+jnj	Yemsa		j
+jnj	Yemsa		ɡ		[ɡ]
+jnj	Yemsa		ɡ		[ɣ]
+jnj	Yemsa		k		[k]
+jnj	Yemsa		k		[q]
+jnj	Yemsa		k		[χ]
+jnj	Yemsa		k		[kʰ]
+jnj	Yemsa		k		[kχ]
+jnj	Yemsa		kʼ
+jnj	Yemsa		ŋ
+jnj	Yemsa		ʔ
+jnj	Yemsa		h
+jnj	Yemsa		i		[i]
+jnj	Yemsa		i		[ɪ]
+jnj	Yemsa		iː		[iː]
+jnj	Yemsa		iː		[ɪː]
+jnj	Yemsa		e		[e]
+jnj	Yemsa		e		[ɛ]
+jnj	Yemsa		e		[ə]
+jnj	Yemsa		eː		[eː]
+jnj	Yemsa		eː		[ɛː]
+jnj	Yemsa		eː		[əː]
+jnj	Yemsa		a		[a]
+jnj	Yemsa		a		[ɑ]
+jnj	Yemsa		a		[ʌ]
+jnj	Yemsa		aː		[aː]
+jnj	Yemsa		aː		[ɑː]
+jnj	Yemsa		aː		[ʌː]
+jnj	Yemsa		u		[u]
+jnj	Yemsa		u		[ʊ]
+jnj	Yemsa		uː		[uː]
+jnj	Yemsa		uː		[ʊː]
+jnj	Yemsa		o		[o]
+jnj	Yemsa		o		[ɔ]
+jnj	Yemsa		oː		[oː]
+jnj	Yemsa		oː		[ɔː]
+jnj	Yemsa		˨˧
+jnj	Yemsa		˦
+jnj	Yemsa		˨
+jnj	Yemsa		˧
+jnj	Yemsa		˩˥
+
 zay	Zayse		b		[b]		zay.pdf
-zay	Zayse		b		[bː]		
-zay	Zayse		pʰ		[pʰ]		
-zay	Zayse		pʰ		[f]		
-zay	Zayse		pʰ		[pː]		
-zay	Zayse		ɓ		[ɓ]		
-zay	Zayse		ɓ		[ɓː]		
-zay	Zayse		m		[m]		
-zay	Zayse		m		[mː]		
-zay	Zayse		w				
-zay	Zayse		d̪		[d̪]		
-zay	Zayse		d̪		[d̪ː]		
-zay	Zayse		t̪ʰ		[t̪ʰ]		
-zay	Zayse		t̪ʰ		[t̪ː]		
-zay	Zayse		ɗ		[ɗ]		
-zay	Zayse		ɗ		[ɗː]		
-zay	Zayse		n		[n]		
-zay	Zayse		n		[nː]		
-zay	Zayse		l		[l]		
-zay	Zayse		l		[lː]		
-zay	Zayse		r				
-zay	Zayse		dz		[dz]		
-zay	Zayse		dz		[dzː]		
-zay	Zayse		tsʰ		[tsʰ]		
-zay	Zayse		tsʰ		[tsː]		
-zay	Zayse		tsʼ		[tsʼ]		
-zay	Zayse		tsʼ		[tsʼː]		
-zay	Zayse		s				
-zay	Zayse		z				
-zay	Zayse		d̠ʒ				
-zay	Zayse		t̠ʃʰ		[t̠ʃʰ]		
-zay	Zayse		t̠ʃʰ		[t̠ʃː]		
-zay	Zayse		t̠ʃʼ		[t̠ʃʼ]		
-zay	Zayse		t̠ʃʼ		[t̠ʃʼː]		
-zay	Zayse		ʃ		[ʃ]		
-zay	Zayse		ʃ		[ʃː]		
-zay	Zayse		ʒ		[ʒ]		
-zay	Zayse		ʒ		[ʒː]		
-zay	Zayse		j		[j]		
-zay	Zayse		j		[jː]		
-zay	Zayse		ɡ		[ɡ]		
-zay	Zayse		ɡ		[ɡː]		
-zay	Zayse		kʰ		[kʰ]		
-zay	Zayse		kʰ		[kː]		
-zay	Zayse		kʼ		[kʼ]		
-zay	Zayse		kʼ		[kʼː]		
-zay	Zayse		ʔ				
-zay	Zayse		h				
-zay	Zayse		i				
-zay	Zayse		e				
-zay	Zayse		a				
-zay	Zayse		o				
-zay	Zayse		u				
-							
+zay	Zayse		b		[bː]
+zay	Zayse		pʰ		[pʰ]
+zay	Zayse		pʰ		[f]
+zay	Zayse		pʰ		[pː]
+zay	Zayse		ɓ		[ɓ]
+zay	Zayse		ɓ		[ɓː]
+zay	Zayse		m		[m]
+zay	Zayse		m		[mː]
+zay	Zayse		w
+zay	Zayse		d̪		[d̪]
+zay	Zayse		d̪		[d̪ː]
+zay	Zayse		t̪ʰ		[t̪ʰ]
+zay	Zayse		t̪ʰ		[t̪ː]
+zay	Zayse		ɗ		[ɗ]
+zay	Zayse		ɗ		[ɗː]
+zay	Zayse		n		[n]
+zay	Zayse		n		[nː]
+zay	Zayse		l		[l]
+zay	Zayse		l		[lː]
+zay	Zayse		r
+zay	Zayse		dz		[dz]
+zay	Zayse		dz		[dzː]
+zay	Zayse		tsʰ		[tsʰ]
+zay	Zayse		tsʰ		[tsː]
+zay	Zayse		tsʼ		[tsʼ]
+zay	Zayse		tsʼ		[tsʼː]
+zay	Zayse		s
+zay	Zayse		z
+zay	Zayse		d̠ʒ
+zay	Zayse		t̠ʃʰ		[t̠ʃʰ]
+zay	Zayse		t̠ʃʰ		[t̠ʃː]
+zay	Zayse		t̠ʃʼ		[t̠ʃʼ]
+zay	Zayse		t̠ʃʼ		[t̠ʃʼː]
+zay	Zayse		ʃ		[ʃ]
+zay	Zayse		ʃ		[ʃː]
+zay	Zayse		ʒ		[ʒ]
+zay	Zayse		ʒ		[ʒː]
+zay	Zayse		j		[j]
+zay	Zayse		j		[jː]
+zay	Zayse		ɡ		[ɡ]
+zay	Zayse		ɡ		[ɡː]
+zay	Zayse		kʰ		[kʰ]
+zay	Zayse		kʰ		[kː]
+zay	Zayse		kʼ		[kʼ]
+zay	Zayse		kʼ		[kʼː]
+zay	Zayse		ʔ
+zay	Zayse		h
+zay	Zayse		i
+zay	Zayse		e
+zay	Zayse		a
+zay	Zayse		o
+zay	Zayse		u
+
 gmv	Gamo		pʰ				gamo.pdf
-gmv	Gamo		b				
-gmv	Gamo		ɓ̥				
-gmv	Gamo		f		[f]		
-gmv	Gamo		f		[ɸ]		
-gmv	Gamo		m				
-gmv	Gamo		w				
-gmv	Gamo		t̪ʰ				
-gmv	Gamo		d̪				
-gmv	Gamo		ɗ				
-gmv	Gamo		n				
-gmv	Gamo		l				
-gmv	Gamo		ɾ				
-gmv	Gamo		tsʰ				
-gmv	Gamo		tsʼ				
-gmv	Gamo		s				
-gmv	Gamo		z				
-gmv	Gamo		t̠ʃʰ				
-gmv	Gamo		d̠ʒ				
-gmv	Gamo		t̠ʃʼ				
-gmv	Gamo		ʃ				
-gmv	Gamo		j				
-gmv	Gamo		kʰ				
-gmv	Gamo		ɡ				
-gmv	Gamo		kʼ				
-gmv	Gamo		h				
-gmv	Gamo		ʔ				
-gmv	Gamo		i̞				
-gmv	Gamo		ɛ̝				
-gmv	Gamo		a				
-gmv	Gamo		ɔ̝				
-gmv	Gamo		u̞				
-gmv	Gamo		i̞ː				
-gmv	Gamo		ɛ̝ː				
-gmv	Gamo		aː				
-gmv	Gamo		ɔ̝ː				
-gmv	Gamo		u̞ː				
-							
+gmv	Gamo		b
+gmv	Gamo		ɓ̥
+gmv	Gamo		f		[f]
+gmv	Gamo		f		[ɸ]
+gmv	Gamo		m
+gmv	Gamo		w
+gmv	Gamo		t̪ʰ
+gmv	Gamo		d̪
+gmv	Gamo		ɗ
+gmv	Gamo		n
+gmv	Gamo		l
+gmv	Gamo		ɾ
+gmv	Gamo		tsʰ
+gmv	Gamo		tsʼ
+gmv	Gamo		s
+gmv	Gamo		z
+gmv	Gamo		t̠ʃʰ
+gmv	Gamo		d̠ʒ
+gmv	Gamo		t̠ʃʼ
+gmv	Gamo		ʃ
+gmv	Gamo		j
+gmv	Gamo		kʰ
+gmv	Gamo		ɡ
+gmv	Gamo		kʼ
+gmv	Gamo		h
+gmv	Gamo		ʔ
+gmv	Gamo		i̞
+gmv	Gamo		ɛ̝
+gmv	Gamo		a
+gmv	Gamo		ɔ̝
+gmv	Gamo		u̞
+gmv	Gamo		i̞ː
+gmv	Gamo		ɛ̝ː
+gmv	Gamo		aː
+gmv	Gamo		ɔ̝ː
+gmv	Gamo		u̞ː
+
 kqy	Koorete		b				kqy.pdf
-kqy	Koorete		<pʼ>	loanwords only			
-kqy	Koorete		ɓ	SM removed ʔɓ from CG inputted inventory			
-kqy	Koorete		m				
-kqy	Koorete		ɸʰ				
-kqy	Koorete		w				
-kqy	Koorete		tʰ				
-kqy	Koorete		d				
-kqy	Koorete		<tʼ>	loanwords only			
-kqy	Koorete		ɗ	SM removed ʔɗ from CG inputted inventory			
-kqy	Koorete		n				
-kqy	Koorete		s				
-kqy	Koorete		z				
-kqy	Koorete		l				
-kqy	Koorete		ɾ		[ɾ]		
-kqy	Koorete		ɾ		[r]		
-kqy	Koorete		tsʰ				
-kqy	Koorete		dz				
-kqy	Koorete		tsʼ				
-kqy	Koorete		n				
-kqy	Koorete		t̠ʃʰ				
-kqy	Koorete		d̠ʒ				
-kqy	Koorete		t̠ʃʼ				
-kqy	Koorete		ʃ				
-kqy	Koorete		ʒ				
-kqy	Koorete		j				
-kqy	Koorete		kʰ				
-kqy	Koorete		ɡ				
-kqy	Koorete		kʼ				
-kqy	Koorete		ʔ				
-kqy	Koorete		h				
-kqy	Koorete		ŋ				
-kqy	Koorete		i				
-kqy	Koorete		iː				
-kqy	Koorete		ɛ				
-kqy	Koorete		ɛː				
-kqy	Koorete		a				
-kqy	Koorete		aː				
-kqy	Koorete		u				
-kqy	Koorete		uː				
-kqy	Koorete		ɔ				
-kqy	Koorete		ɔː				
-kqy	Koorete		ʃː				
-kqy	Koorete		sː				
-kqy	Koorete		ɡː				
-kqy	Koorete		bː				
-kqy	Koorete		dː				
-kqy	Koorete		mː				
-kqy	Koorete		ɸː				
-kqy	Koorete		nː				
-kqy	Koorete		zː				
-kqy	Koorete		lː				
-kqy	Koorete		tsː				
-kqy	Koorete		dzː				
-kqy	Koorete		tsʼː				
-kqy	Koorete		nː				
-kqy	Koorete		t̠ʃː				
-kqy	Koorete		d̠ʒː				
-kqy	Koorete		t̠ʃʼː				
-kqy	Koorete		ʒː				
-kqy	Koorete		jː				
-kqy	Koorete		kː				
-kqy	Koorete		ɡː				
-kqy	Koorete		kʼː				
-kqy	Koorete		ŋː				
-							
+kqy	Koorete		<pʼ>	loanwords only
+kqy	Koorete		ɓ	SM removed ʔɓ from CG inputted inventory
+kqy	Koorete		m
+kqy	Koorete		ɸʰ
+kqy	Koorete		w
+kqy	Koorete		tʰ
+kqy	Koorete		d
+kqy	Koorete		<tʼ>	loanwords only
+kqy	Koorete		ɗ	SM removed ʔɗ from CG inputted inventory
+kqy	Koorete		n
+kqy	Koorete		s
+kqy	Koorete		z
+kqy	Koorete		l
+kqy	Koorete		ɾ		[ɾ]
+kqy	Koorete		ɾ		[r]
+kqy	Koorete		tsʰ
+kqy	Koorete		dz
+kqy	Koorete		tsʼ
+kqy	Koorete		n
+kqy	Koorete		t̠ʃʰ
+kqy	Koorete		d̠ʒ
+kqy	Koorete		t̠ʃʼ
+kqy	Koorete		ʃ
+kqy	Koorete		ʒ
+kqy	Koorete		j
+kqy	Koorete		kʰ
+kqy	Koorete		ɡ
+kqy	Koorete		kʼ
+kqy	Koorete		ʔ
+kqy	Koorete		h
+kqy	Koorete		ŋ
+kqy	Koorete		i
+kqy	Koorete		iː
+kqy	Koorete		ɛ
+kqy	Koorete		ɛː
+kqy	Koorete		a
+kqy	Koorete		aː
+kqy	Koorete		u
+kqy	Koorete		uː
+kqy	Koorete		ɔ
+kqy	Koorete		ɔː
+kqy	Koorete		ʃː
+kqy	Koorete		sː
+kqy	Koorete		ɡː
+kqy	Koorete		bː
+kqy	Koorete		dː
+kqy	Koorete		mː
+kqy	Koorete		ɸː
+kqy	Koorete		nː
+kqy	Koorete		zː
+kqy	Koorete		lː
+kqy	Koorete		tsː
+kqy	Koorete		dzː
+kqy	Koorete		tsʼː
+kqy	Koorete		nː
+kqy	Koorete		t̠ʃː
+kqy	Koorete		d̠ʒː
+kqy	Koorete		t̠ʃʼː
+kqy	Koorete		ʒː
+kqy	Koorete		jː
+kqy	Koorete		kː
+kqy	Koorete		ɡː
+kqy	Koorete		kʼː
+kqy	Koorete		ŋː
+
 aiw	Aari		b				aiw.pdf
-aiw	Aari		ɓ̥				
-aiw	Aari		f		[f]		
-aiw	Aari		f		[ɸ]		
-aiw	Aari		m				
-aiw	Aari		w				
-aiw	Aari		t̪		[t̪]		
-aiw	Aari		t̪		[t̪ʰ]		
-aiw	Aari		d̪				
-aiw	Aari		ɗ				
-aiw	Aari		s				
-aiw	Aari		z				
-aiw	Aari		n		[n]		
-aiw	Aari		n		[n̪]		
-aiw	Aari		n		[ŋ]		
-aiw	Aari		n		[ɲ]		
-aiw	Aari		l				
-aiw	Aari		r				
-aiw	Aari		ts		[ts]		
-aiw	Aari		ts		[tsʰ]		
-aiw	Aari		tsʼ				
-aiw	Aari		t̠ʃ		[t̠ʃ]		
-aiw	Aari		t̠ʃ		[t̠ʃʰ]		
-aiw	Aari		d̠ʒ				
-aiw	Aari		t̠ʃʼ				
-aiw	Aari		ʃ				
-aiw	Aari		ʒ				
-aiw	Aari		j				
-aiw	Aari		k		[k]		
-aiw	Aari		k		[kʰ]		
-aiw	Aari		ɡ				
-aiw	Aari		q				
-aiw	Aari		ʔ				
-aiw	Aari		ɦ				
-aiw	Aari		i̞		[i̞]		
-aiw	Aari		i̞		[i̤]		
-aiw	Aari		ɛ		[ɛ]		
-aiw	Aari		ɛ		[ɛ̤]		
-aiw	Aari		a		[a]		
-aiw	Aari		a		[a̤]		
-aiw	Aari		ɔ̝		[ɔ̝]		
-aiw	Aari		ɔ̝		[ɔ̤]		
-aiw	Aari		u				
-aiw	Aari		iː				
-aiw	Aari		e̞ː				
-aiw	Aari		aː		[aː]		
-aiw	Aari		aː		[a̤ː]		
-aiw	Aari		o̞ː				
-aiw	Aari		uː				
-							
+aiw	Aari		ɓ̥
+aiw	Aari		f		[f]
+aiw	Aari		f		[ɸ]
+aiw	Aari		m
+aiw	Aari		w
+aiw	Aari		t̪		[t̪]
+aiw	Aari		t̪		[t̪ʰ]
+aiw	Aari		d̪
+aiw	Aari		ɗ
+aiw	Aari		s
+aiw	Aari		z
+aiw	Aari		n		[n]
+aiw	Aari		n		[n̪]
+aiw	Aari		n		[ŋ]
+aiw	Aari		n		[ɲ]
+aiw	Aari		l
+aiw	Aari		r
+aiw	Aari		ts		[ts]
+aiw	Aari		ts		[tsʰ]
+aiw	Aari		tsʼ
+aiw	Aari		t̠ʃ		[t̠ʃ]
+aiw	Aari		t̠ʃ		[t̠ʃʰ]
+aiw	Aari		d̠ʒ
+aiw	Aari		t̠ʃʼ
+aiw	Aari		ʃ
+aiw	Aari		ʒ
+aiw	Aari		j
+aiw	Aari		k		[k]
+aiw	Aari		k		[kʰ]
+aiw	Aari		ɡ
+aiw	Aari		q
+aiw	Aari		ʔ
+aiw	Aari		ɦ
+aiw	Aari		i̞		[i̞]
+aiw	Aari		i̞		[i̤]
+aiw	Aari		ɛ		[ɛ]
+aiw	Aari		ɛ		[ɛ̤]
+aiw	Aari		a		[a]
+aiw	Aari		a		[a̤]
+aiw	Aari		ɔ̝		[ɔ̝]
+aiw	Aari		ɔ̝		[ɔ̤]
+aiw	Aari		u
+aiw	Aari		iː
+aiw	Aari		e̞ː
+aiw	Aari		aː		[aː]
+aiw	Aari		aː		[a̤ː]
+aiw	Aari		o̞ː
+aiw	Aari		uː
+
 xom	Komo		p				omotic_bender.pdf
-xom	Komo		b				
-xom	Komo		pʼ				
-xom	Komo		ɓ				
-xom	Komo		m				
-xom	Komo		w				
-xom	Komo		t				
-xom	Komo		d				
-xom	Komo		tʼ				
-xom	Komo		ɗ				
-xom	Komo		s				
-xom	Komo		sʼ				
-xom	Komo		l				
-xom	Komo		r				
-xom	Komo		n				
-xom	Komo		ʃ				
-xom	Komo		j				
-xom	Komo		k				
-xom	Komo		ɡ				
-xom	Komo		kʼ				
-xom	Komo		ɠ				
-xom	Komo		h				
-xom	Komo		ʔ				
-xom	Komo		i				
-xom	Komo		e				
-xom	Komo		a				
-xom	Komo		o				
-xom	Komo		u				
-							
+xom	Komo		b
+xom	Komo		pʼ
+xom	Komo		ɓ
+xom	Komo		m
+xom	Komo		w
+xom	Komo		t
+xom	Komo		d
+xom	Komo		tʼ
+xom	Komo		ɗ
+xom	Komo		s
+xom	Komo		sʼ
+xom	Komo		l
+xom	Komo		r
+xom	Komo		n
+xom	Komo		ʃ
+xom	Komo		j
+xom	Komo		k
+xom	Komo		ɡ
+xom	Komo		kʼ
+xom	Komo		ɠ
+xom	Komo		h
+xom	Komo		ʔ
+xom	Komo		i
+xom	Komo		e
+xom	Komo		a
+xom	Komo		o
+xom	Komo		u
+
 udu	Twampa		p				omotic_bender.pdf
-udu	Twampa		b				
-udu	Twampa		pʼ				
-udu	Twampa		ɓ				
-udu	Twampa		m				
-udu	Twampa		w				
-udu	Twampa		t				
-udu	Twampa		d				
-udu	Twampa		tʼ				
-udu	Twampa		ɗ				
-udu	Twampa		s				
-udu	Twampa		t̠ʃʼ				
-udu	Twampa		d̠ʒ				
-udu	Twampa		l				
-udu	Twampa		r				
-udu	Twampa		n				
-udu	Twampa		ʃ				
-udu	Twampa		j				
-udu	Twampa		k				
-udu	Twampa		ɡ				
-udu	Twampa		kʼ				
-udu	Twampa		h				
-udu	Twampa		ʔ				
-udu	Twampa		i				
-udu	Twampa		e				
-udu	Twampa		a				
-udu	Twampa		o				
-udu	Twampa		u				
-							
+udu	Twampa		b
+udu	Twampa		pʼ
+udu	Twampa		ɓ
+udu	Twampa		m
+udu	Twampa		w
+udu	Twampa		t
+udu	Twampa		d
+udu	Twampa		tʼ
+udu	Twampa		ɗ
+udu	Twampa		s
+udu	Twampa		t̠ʃʼ
+udu	Twampa		d̠ʒ
+udu	Twampa		l
+udu	Twampa		r
+udu	Twampa		n
+udu	Twampa		ʃ
+udu	Twampa		j
+udu	Twampa		k
+udu	Twampa		ɡ
+udu	Twampa		kʼ
+udu	Twampa		h
+udu	Twampa		ʔ
+udu	Twampa		i
+udu	Twampa		e
+udu	Twampa		a
+udu	Twampa		o
+udu	Twampa		u
+
 lgn	Opo		p				omotic_bender.pdf
-lgn	Opo		ɓ				
-lgn	Opo		m				
-lgn	Opo		w				
-lgn	Opo		t				
-lgn	Opo		tʼ				
-lgn	Opo		d				
-lgn	Opo		s				
-lgn	Opo		t̠ʃʼ				
-lgn	Opo		l				
-lgn	Opo		j				
-lgn	Opo		r				
-lgn	Opo		n				
-lgn	Opo		ʃ				
-lgn	Opo		d̠ʒ				
-lgn	Opo		k				
-lgn	Opo		kʼ				
-lgn	Opo		ɡ				
-lgn	Opo		h				
-lgn	Opo		ʔ				
-lgn	Opo		i				
-lgn	Opo		e				
-lgn	Opo		a				
-lgn	Opo		o				
-lgn	Opo		u				
-							
+lgn	Opo		ɓ
+lgn	Opo		m
+lgn	Opo		w
+lgn	Opo		t
+lgn	Opo		tʼ
+lgn	Opo		d
+lgn	Opo		s
+lgn	Opo		t̠ʃʼ
+lgn	Opo		l
+lgn	Opo		j
+lgn	Opo		r
+lgn	Opo		n
+lgn	Opo		ʃ
+lgn	Opo		d̠ʒ
+lgn	Opo		k
+lgn	Opo		kʼ
+lgn	Opo		ɡ
+lgn	Opo		h
+lgn	Opo		ʔ
+lgn	Opo		i
+lgn	Opo		e
+lgn	Opo		a
+lgn	Opo		o
+lgn	Opo		u
+
 kmq	Kwama		p				omotic_bender.pdf
-kmq	Kwama		pʼ				
-kmq	Kwama		b				
-kmq	Kwama		m				
-kmq	Kwama		w				
-kmq	Kwama		t				
-kmq	Kwama		tʼ				
-kmq	Kwama		d				
-kmq	Kwama		s				
-kmq	Kwama		sʼ				
-kmq	Kwama		l				
-kmq	Kwama		r				
-kmq	Kwama		n				
-kmq	Kwama		ʃ				
-kmq	Kwama		j				
-kmq	Kwama		k				
-kmq	Kwama		kʼ				
-kmq	Kwama		ɡ				
-kmq	Kwama		h				
-kmq	Kwama		ʔ				
-kmq	Kwama		i				
-kmq	Kwama		e				
-kmq	Kwama		a				
-kmq	Kwama		o				
-kmq	Kwama		u				
+kmq	Kwama		pʼ
+kmq	Kwama		b
+kmq	Kwama		m
+kmq	Kwama		w
+kmq	Kwama		t
+kmq	Kwama		tʼ
+kmq	Kwama		d
+kmq	Kwama		s
+kmq	Kwama		sʼ
+kmq	Kwama		l
+kmq	Kwama		r
+kmq	Kwama		n
+kmq	Kwama		ʃ
+kmq	Kwama		j
+kmq	Kwama		k
+kmq	Kwama		kʼ
+kmq	Kwama		ɡ
+kmq	Kwama		h
+kmq	Kwama		ʔ
+kmq	Kwama		i
+kmq	Kwama		e
+kmq	Kwama		a
+kmq	Kwama		o
+kmq	Kwama		u
 
 mdm	Mayogo		p				mdm.pdf
-mdm	Mayogo		b				
-mdm	Mayogo		mb				
-mdm	Mayogo		ɓ				
-mdm	Mayogo		f				
-mdm	Mayogo		v				
-mdm	Mayogo		ɱv				
-mdm	Mayogo		m				
-mdm	Mayogo		w				
-mdm	Mayogo		t				
-mdm	Mayogo		d				
-mdm	Mayogo		nd				
-mdm	Mayogo		ɗ				
-mdm	Mayogo		s				
-mdm	Mayogo		z				
-mdm	Mayogo		n				
-mdm	Mayogo		l				
-mdm	Mayogo		r				
-mdm	Mayogo		t̠ʃ				
-mdm	Mayogo		d̠ʒ				
-mdm	Mayogo		n̠d̠ʒ				
-mdm	Mayogo		ɗʲ				
-mdm	Mayogo		ɲ				
-mdm	Mayogo		j				
-mdm	Mayogo		k				
-mdm	Mayogo		ɡ				
-mdm	Mayogo		ŋɡ				
-mdm	Mayogo		x				
-mdm	Mayogo		kp				
-mdm	Mayogo		ɡb				
-mdm	Mayogo		ŋmɡb				
-mdm	Mayogo		ʔ				
-mdm	Mayogo		ɦ				
-mdm	Mayogo		i				
-mdm	Mayogo		ɪ				
-mdm	Mayogo		e				
-mdm	Mayogo		ɛ				
-mdm	Mayogo		a				
-mdm	Mayogo		ɨ				
-mdm	Mayogo		u				
-mdm	Mayogo		ʊ				
-mdm	Mayogo		o				
-mdm	Mayogo		ɔ				
-mdm	Mayogo		˦				
-mdm	Mayogo		˨				
-mdm	Mayogo		˧				
-							
+mdm	Mayogo		b
+mdm	Mayogo		mb
+mdm	Mayogo		ɓ
+mdm	Mayogo		f
+mdm	Mayogo		v
+mdm	Mayogo		ɱv
+mdm	Mayogo		m
+mdm	Mayogo		w
+mdm	Mayogo		t
+mdm	Mayogo		d
+mdm	Mayogo		nd
+mdm	Mayogo		ɗ
+mdm	Mayogo		s
+mdm	Mayogo		z
+mdm	Mayogo		n
+mdm	Mayogo		l
+mdm	Mayogo		r
+mdm	Mayogo		t̠ʃ
+mdm	Mayogo		d̠ʒ
+mdm	Mayogo		n̠d̠ʒ
+mdm	Mayogo		ɗʲ
+mdm	Mayogo		ɲ
+mdm	Mayogo		j
+mdm	Mayogo		k
+mdm	Mayogo		ɡ
+mdm	Mayogo		ŋɡ
+mdm	Mayogo		x
+mdm	Mayogo		kp
+mdm	Mayogo		ɡb
+mdm	Mayogo		ŋmɡb
+mdm	Mayogo		ʔ
+mdm	Mayogo		ɦ
+mdm	Mayogo		i
+mdm	Mayogo		ɪ
+mdm	Mayogo		e
+mdm	Mayogo		ɛ
+mdm	Mayogo		a
+mdm	Mayogo		ɨ
+mdm	Mayogo		u
+mdm	Mayogo		ʊ
+mdm	Mayogo		o
+mdm	Mayogo		ɔ
+mdm	Mayogo		˦
+mdm	Mayogo		˨
+mdm	Mayogo		˧
+
 lsm	Lusaamia		˨˦				lsm.pdf
-lsm	Lusaamia		˦˨				
-lsm	Lusaamia		˦				
-lsm	Lusaamia		˨				
-lsm	Lusaamia		b				
-lsm	Lusaamia		β				
-lsm	Lusaamia		m				
-lsm	Lusaamia		w				
-lsm	Lusaamia		f				
-lsm	Lusaamia		t				
-lsm	Lusaamia		d				
-lsm	Lusaamia		s				
-lsm	Lusaamia		n				
-lsm	Lusaamia		l		[l]		
-lsm	Lusaamia		l		[ɭ]		
-lsm	Lusaamia		l		[r]		
-lsm	Lusaamia		l		[d]		
-lsm	Lusaamia		r				
-lsm	Lusaamia		t̠ʃ				
-lsm	Lusaamia		d̠ʒ				
-lsm	Lusaamia		ɲ				
-lsm	Lusaamia		j				
-lsm	Lusaamia		ŋ				
-lsm	Lusaamia		k				
-lsm	Lusaamia		ɡ				
-lsm	Lusaamia		x				
-lsm	Lusaamia		h				
-lsm	Lusaamia		i		[i̥]		
-lsm	Lusaamia		e		[e̥]		
-lsm	Lusaamia		a		[ḁ]		
-lsm	Lusaamia		o		[o̥]		
-lsm	Lusaamia		u		[u̥]		
-lsm	Lusaamia		i		[i]		
-lsm	Lusaamia		e		[e]		
-lsm	Lusaamia		a		[a]		
-lsm	Lusaamia		o		[o]		
-lsm	Lusaamia		u		[u]		
-lsm	Lusaamia		iː				
-lsm	Lusaamia		eː				
-lsm	Lusaamia		aː				
-lsm	Lusaamia		oː				
-lsm	Lusaamia		uː				
-							
+lsm	Lusaamia		˦˨
+lsm	Lusaamia		˦
+lsm	Lusaamia		˨
+lsm	Lusaamia		b
+lsm	Lusaamia		β
+lsm	Lusaamia		m
+lsm	Lusaamia		w
+lsm	Lusaamia		f
+lsm	Lusaamia		t
+lsm	Lusaamia		d
+lsm	Lusaamia		s
+lsm	Lusaamia		n
+lsm	Lusaamia		l		[l]
+lsm	Lusaamia		l		[ɭ]
+lsm	Lusaamia		l		[r]
+lsm	Lusaamia		l		[d]
+lsm	Lusaamia		r
+lsm	Lusaamia		t̠ʃ
+lsm	Lusaamia		d̠ʒ
+lsm	Lusaamia		ɲ
+lsm	Lusaamia		j
+lsm	Lusaamia		ŋ
+lsm	Lusaamia		k
+lsm	Lusaamia		ɡ
+lsm	Lusaamia		x
+lsm	Lusaamia		h
+lsm	Lusaamia		i		[i̥]
+lsm	Lusaamia		e		[e̥]
+lsm	Lusaamia		a		[ḁ]
+lsm	Lusaamia		o		[o̥]
+lsm	Lusaamia		u		[u̥]
+lsm	Lusaamia		i		[i]
+lsm	Lusaamia		e		[e]
+lsm	Lusaamia		a		[a]
+lsm	Lusaamia		o		[o]
+lsm	Lusaamia		u		[u]
+lsm	Lusaamia		iː
+lsm	Lusaamia		eː
+lsm	Lusaamia		aː
+lsm	Lusaamia		oː
+lsm	Lusaamia		uː
+
 nnw	Nouni		p				nnw.pdf
-nnw	Nouni		pʷ				
-nnw	Nouni		b				
-nnw	Nouni		bʷ				
-nnw	Nouni		f				
-nnw	Nouni		fʷ				
-nnw	Nouni		v				
-nnw	Nouni		vʷ				
-nnw	Nouni		m				
-nnw	Nouni		mʷ				
-nnw	Nouni		t				
-nnw	Nouni		tʷ				
-nnw	Nouni		d				
-nnw	Nouni		dʷ				
-nnw	Nouni		s				
-nnw	Nouni		sʷ				
-nnw	Nouni		z				
-nnw	Nouni		zʷ				
-nnw	Nouni		n				
-nnw	Nouni		ɹ				
-nnw	Nouni		l				
-nnw	Nouni		lʷ				
-nnw	Nouni		c				
-nnw	Nouni		cʷ				
-nnw	Nouni		ɟ				
-nnw	Nouni		ɟʷ				
-nnw	Nouni		ɲ				
-nnw	Nouni		ɲʷ				
-nnw	Nouni		j				
-nnw	Nouni		jʷ				
-nnw	Nouni		k				
-nnw	Nouni		kʷ				
-nnw	Nouni		ɡ				
-nnw	Nouni		ɡʷ				
-nnw	Nouni		h				
-nnw	Nouni		ŋ				
-nnw	Nouni		ŋʷ				
-nnw	Nouni		w				
-nnw	Nouni		i				
-nnw	Nouni		ɪ				
-nnw	Nouni		e				
-nnw	Nouni		ɛ				
-nnw	Nouni		ʉ				
-nnw	Nouni		ə				
-nnw	Nouni		a				
-nnw	Nouni		u				
-nnw	Nouni		ʊ				
-nnw	Nouni		o				
-nnw	Nouni		ɔ				
-nnw	Nouni		ĩ				
-nnw	Nouni		ɪ̃				
-nnw	Nouni		ɛ̃				
-nnw	Nouni		ə̃				
-nnw	Nouni		ã				
-nnw	Nouni		ũ				
-nnw	Nouni		ʊ̃				
-nnw	Nouni		˨˦				
-nnw	Nouni		˦				
-nnw	Nouni		˨				
-nnw	Nouni		˧				
-							
+nnw	Nouni		pʷ
+nnw	Nouni		b
+nnw	Nouni		bʷ
+nnw	Nouni		f
+nnw	Nouni		fʷ
+nnw	Nouni		v
+nnw	Nouni		vʷ
+nnw	Nouni		m
+nnw	Nouni		mʷ
+nnw	Nouni		t
+nnw	Nouni		tʷ
+nnw	Nouni		d
+nnw	Nouni		dʷ
+nnw	Nouni		s
+nnw	Nouni		sʷ
+nnw	Nouni		z
+nnw	Nouni		zʷ
+nnw	Nouni		n
+nnw	Nouni		ɹ
+nnw	Nouni		l
+nnw	Nouni		lʷ
+nnw	Nouni		c
+nnw	Nouni		cʷ
+nnw	Nouni		ɟ
+nnw	Nouni		ɟʷ
+nnw	Nouni		ɲ
+nnw	Nouni		ɲʷ
+nnw	Nouni		j
+nnw	Nouni		jʷ
+nnw	Nouni		k
+nnw	Nouni		kʷ
+nnw	Nouni		ɡ
+nnw	Nouni		ɡʷ
+nnw	Nouni		h
+nnw	Nouni		ŋ
+nnw	Nouni		ŋʷ
+nnw	Nouni		w
+nnw	Nouni		i
+nnw	Nouni		ɪ
+nnw	Nouni		e
+nnw	Nouni		ɛ
+nnw	Nouni		ʉ
+nnw	Nouni		ə
+nnw	Nouni		a
+nnw	Nouni		u
+nnw	Nouni		ʊ
+nnw	Nouni		o
+nnw	Nouni		ɔ
+nnw	Nouni		ĩ
+nnw	Nouni		ɪ̃
+nnw	Nouni		ɛ̃
+nnw	Nouni		ə̃
+nnw	Nouni		ã
+nnw	Nouni		ũ
+nnw	Nouni		ʊ̃
+nnw	Nouni		˨˦
+nnw	Nouni		˦
+nnw	Nouni		˨
+nnw	Nouni		˧
+
 nde	Ndebele		i				nbl.pdf
-nde	Ndebele		e				
-nde	Ndebele		ɑ				
-nde	Ndebele		o				
-nde	Ndebele		u				
-nde	Ndebele		b				
-nde	Ndebele		pʰ				
-nde	Ndebele		pʼ				
-nde	Ndebele		mb				
-nde	Ndebele		mp				
-nde	Ndebele		m				
-nde	Ndebele		β				
-nde	Ndebele		w				
-nde	Ndebele		v				
-nde	Ndebele		f				
-nde	Ndebele		ɱv				
-nde	Ndebele		ɱf				
-nde	Ndebele		d				
-nde	Ndebele		tʰ				
-nde	Ndebele		tʼ				
-nde	Ndebele		nd				
-nde	Ndebele		nt				
-nde	Ndebele		n				
-nde	Ndebele		z				
-nde	Ndebele		s				
-nde	Ndebele		nz				
-nde	Ndebele		ns				
-nde	Ndebele		ɮ				
-nde	Ndebele		ɬ				
-nde	Ndebele		nɮ				
-nde	Ndebele		nɬ				
-nde	Ndebele		l				
-nde	Ndebele		ɲ				
-nde	Ndebele		ʒ				
-nde	Ndebele		j				
-nde	Ndebele		ɡ				
-nde	Ndebele		kʰ				
-nde	Ndebele		kʼ				
-nde	Ndebele		ŋɡ				
-nde	Ndebele		ŋk				
-nde	Ndebele		ŋ				
-nde	Ndebele		ɣ				
-nde	Ndebele		ɦ				
-nde	Ndebele		h				
-nde	Ndebele		kǀ				
-nde	Ndebele		kǀʰ				
-nde	Ndebele		ɡǀ				
-nde	Ndebele		ŋǀ	changed from nǀ to ŋǀ			
-nde	Ndebele		kǃ				
-nde	Ndebele		kǃʰ				
-nde	Ndebele		ɡǃ				
-nde	Ndebele		ŋǃ	changed from nǃ to ŋǃ			
-nde	Ndebele		kǁ				
-nde	Ndebele		kǁʰ				
-nde	Ndebele		ɡǁ				
-nde	Ndebele		ŋǁ	changed from nǁ to nǁ			
-nde	Ndebele		tsʰ				
-nde	Ndebele		tsʼ				
-nde	Ndebele		ntsʼ				
-nde	Ndebele		d̠ʒ				
-nde	Ndebele		t̠ʃʰ				
-nde	Ndebele		t̠ʃʼ				
-nde	Ndebele		n̠d̠ʒ				
-nde	Ndebele		n̠t̠ʃʼ				
-nde	Ndebele		kx				
-nde	Ndebele		ŋkx				
-nde	Ndebele		˦				
-nde	Ndebele		˨				
-							
+nde	Ndebele		e
+nde	Ndebele		ɑ
+nde	Ndebele		o
+nde	Ndebele		u
+nde	Ndebele		b
+nde	Ndebele		pʰ
+nde	Ndebele		pʼ
+nde	Ndebele		mb
+nde	Ndebele		mp
+nde	Ndebele		m
+nde	Ndebele		β
+nde	Ndebele		w
+nde	Ndebele		v
+nde	Ndebele		f
+nde	Ndebele		ɱv
+nde	Ndebele		ɱf
+nde	Ndebele		d
+nde	Ndebele		tʰ
+nde	Ndebele		tʼ
+nde	Ndebele		nd
+nde	Ndebele		nt
+nde	Ndebele		n
+nde	Ndebele		z
+nde	Ndebele		s
+nde	Ndebele		nz
+nde	Ndebele		ns
+nde	Ndebele		ɮ
+nde	Ndebele		ɬ
+nde	Ndebele		nɮ
+nde	Ndebele		nɬ
+nde	Ndebele		l
+nde	Ndebele		ɲ
+nde	Ndebele		ʒ
+nde	Ndebele		j
+nde	Ndebele		ɡ
+nde	Ndebele		kʰ
+nde	Ndebele		kʼ
+nde	Ndebele		ŋɡ
+nde	Ndebele		ŋk
+nde	Ndebele		ŋ
+nde	Ndebele		ɣ
+nde	Ndebele		ɦ
+nde	Ndebele		h
+nde	Ndebele		kǀ
+nde	Ndebele		kǀʰ
+nde	Ndebele		ɡǀ
+nde	Ndebele		ŋǀ	changed from nǀ to ŋǀ
+nde	Ndebele		kǃ
+nde	Ndebele		kǃʰ
+nde	Ndebele		ɡǃ
+nde	Ndebele		ŋǃ	changed from nǃ to ŋǃ
+nde	Ndebele		kǁ
+nde	Ndebele		kǁʰ
+nde	Ndebele		ɡǁ
+nde	Ndebele		ŋǁ	changed from nǁ to nǁ
+nde	Ndebele		tsʰ
+nde	Ndebele		tsʼ
+nde	Ndebele		ntsʼ
+nde	Ndebele		d̠ʒ
+nde	Ndebele		t̠ʃʰ
+nde	Ndebele		t̠ʃʼ
+nde	Ndebele		n̠d̠ʒ
+nde	Ndebele		n̠t̠ʃʼ
+nde	Ndebele		kx
+nde	Ndebele		ŋkx
+nde	Ndebele		˦
+nde	Ndebele		˨
+
 sxw	Saxwe, Gbe		b				sxw.pdf
-sxw	Saxwe, Gbe		m				
-sxw	Saxwe, Gbe		w				
-sxw	Saxwe, Gbe		f				
-sxw	Saxwe, Gbe		v				
-sxw	Saxwe, Gbe		t̪				
-sxw	Saxwe, Gbe		d̪				
-sxw	Saxwe, Gbe		s				
-sxw	Saxwe, Gbe		z				
-sxw	Saxwe, Gbe		ɖ				
-sxw	Saxwe, Gbe		ɳ				
-sxw	Saxwe, Gbe		ɭ				
-sxw	Saxwe, Gbe		t̠ʃ				
-sxw	Saxwe, Gbe		d̠ʒ				
-sxw	Saxwe, Gbe		ɲ				
-sxw	Saxwe, Gbe		j				
-sxw	Saxwe, Gbe		k				
-sxw	Saxwe, Gbe		ɡ				
-sxw	Saxwe, Gbe		kp				
-sxw	Saxwe, Gbe		ɡb				
-sxw	Saxwe, Gbe		x				
-sxw	Saxwe, Gbe		ɦ				
-sxw	Saxwe, Gbe		xʷ				
-sxw	Saxwe, Gbe		ɦʷ				
-sxw	Saxwe, Gbe		i				
-sxw	Saxwe, Gbe		e				
-sxw	Saxwe, Gbe		ɛ				
-sxw	Saxwe, Gbe		a				
-sxw	Saxwe, Gbe		u				
-sxw	Saxwe, Gbe		o				
-sxw	Saxwe, Gbe		ɔ				
-sxw	Saxwe, Gbe		ĩ				
-sxw	Saxwe, Gbe		ɛ̃				
-sxw	Saxwe, Gbe		ã				
-sxw	Saxwe, Gbe		ũ				
-sxw	Saxwe, Gbe		ɔ̃				
-sxw	Saxwe, Gbe		˦				
-sxw	Saxwe, Gbe		˨				
-							
+sxw	Saxwe, Gbe		m
+sxw	Saxwe, Gbe		w
+sxw	Saxwe, Gbe		f
+sxw	Saxwe, Gbe		v
+sxw	Saxwe, Gbe		t̪
+sxw	Saxwe, Gbe		d̪
+sxw	Saxwe, Gbe		s
+sxw	Saxwe, Gbe		z
+sxw	Saxwe, Gbe		ɖ
+sxw	Saxwe, Gbe		ɳ
+sxw	Saxwe, Gbe		ɭ
+sxw	Saxwe, Gbe		t̠ʃ
+sxw	Saxwe, Gbe		d̠ʒ
+sxw	Saxwe, Gbe		ɲ
+sxw	Saxwe, Gbe		j
+sxw	Saxwe, Gbe		k
+sxw	Saxwe, Gbe		ɡ
+sxw	Saxwe, Gbe		kp
+sxw	Saxwe, Gbe		ɡb
+sxw	Saxwe, Gbe		x
+sxw	Saxwe, Gbe		ɦ
+sxw	Saxwe, Gbe		xʷ
+sxw	Saxwe, Gbe		ɦʷ
+sxw	Saxwe, Gbe		i
+sxw	Saxwe, Gbe		e
+sxw	Saxwe, Gbe		ɛ
+sxw	Saxwe, Gbe		a
+sxw	Saxwe, Gbe		u
+sxw	Saxwe, Gbe		o
+sxw	Saxwe, Gbe		ɔ
+sxw	Saxwe, Gbe		ĩ
+sxw	Saxwe, Gbe		ɛ̃
+sxw	Saxwe, Gbe		ã
+sxw	Saxwe, Gbe		ũ
+sxw	Saxwe, Gbe		ɔ̃
+sxw	Saxwe, Gbe		˦
+sxw	Saxwe, Gbe		˨
+
 loh	Laarim		p				laarim_stirtz.pdf
-loh	Laarim		b				
-loh	Laarim		v				
-loh	Laarim		m				
-loh	Laarim		w				
-loh	Laarim		t̪				
-loh	Laarim		d̪				
-loh	Laarim		ð				
-loh	Laarim		ɖ				
-loh	Laarim		n				
-loh	Laarim		l				
-loh	Laarim		r				
-loh	Laarim		c				
-loh	Laarim		ɟ				
-loh	Laarim		ɲ				
-loh	Laarim		j				
-loh	Laarim		k				
-loh	Laarim		ɡ				
-loh	Laarim		ŋ				
-loh	Laarim		kʷ				
-loh	Laarim		ɡʷ				
-loh	Laarim		h				
-loh	Laarim		i				
-loh	Laarim		ɪ				
-loh	Laarim		e				
-loh	Laarim		ɛ				
-loh	Laarim		a				
-loh	Laarim		u				
-loh	Laarim		ʊ				
-loh	Laarim		o				
-loh	Laarim		ɔ				
-loh	Laarim		˦˨				
-loh	Laarim		˦				
-loh	Laarim		˨				
-							
+loh	Laarim		b
+loh	Laarim		v
+loh	Laarim		m
+loh	Laarim		w
+loh	Laarim		t̪
+loh	Laarim		d̪
+loh	Laarim		ð
+loh	Laarim		ɖ
+loh	Laarim		n
+loh	Laarim		l
+loh	Laarim		r
+loh	Laarim		c
+loh	Laarim		ɟ
+loh	Laarim		ɲ
+loh	Laarim		j
+loh	Laarim		k
+loh	Laarim		ɡ
+loh	Laarim		ŋ
+loh	Laarim		kʷ
+loh	Laarim		ɡʷ
+loh	Laarim		h
+loh	Laarim		i
+loh	Laarim		ɪ
+loh	Laarim		e
+loh	Laarim		ɛ
+loh	Laarim		a
+loh	Laarim		u
+loh	Laarim		ʊ
+loh	Laarim		o
+loh	Laarim		ɔ
+loh	Laarim		˦˨
+loh	Laarim		˦
+loh	Laarim		˨
+
 bjg	Bijogo		p				bjg.pdf
-bjg	Bijogo		t				
-bjg	Bijogo		s		[s]		
-bjg	Bijogo		s		[ʂ]		
-bjg	Bijogo		s		[ʃ]		
-bjg	Bijogo		ʈ				
-bjg	Bijogo		k				
-bjg	Bijogo		kp				
-bjg	Bijogo		b				
-bjg	Bijogo		d				
-bjg	Bijogo		ɟ				
-bjg	Bijogo		ɡ				
-bjg	Bijogo		ɡb				
-bjg	Bijogo		m				
-bjg	Bijogo		n				
-bjg	Bijogo		ɲ				
-bjg	Bijogo		ŋ				
-bjg	Bijogo		w				
-bjg	Bijogo		r				
-bjg	Bijogo		j				
-bjg	Bijogo		i				
-bjg	Bijogo		e				
-bjg	Bijogo		ɛ				
-bjg	Bijogo		a				
-bjg	Bijogo		ɔ				
-bjg	Bijogo		o				
-bjg	Bijogo		u				
-							
+bjg	Bijogo		t
+bjg	Bijogo		s		[s]
+bjg	Bijogo		s		[ʂ]
+bjg	Bijogo		s		[ʃ]
+bjg	Bijogo		ʈ
+bjg	Bijogo		k
+bjg	Bijogo		kp
+bjg	Bijogo		b
+bjg	Bijogo		d
+bjg	Bijogo		ɟ
+bjg	Bijogo		ɡ
+bjg	Bijogo		ɡb
+bjg	Bijogo		m
+bjg	Bijogo		n
+bjg	Bijogo		ɲ
+bjg	Bijogo		ŋ
+bjg	Bijogo		w
+bjg	Bijogo		r
+bjg	Bijogo		j
+bjg	Bijogo		i
+bjg	Bijogo		e
+bjg	Bijogo		ɛ
+bjg	Bijogo		a
+bjg	Bijogo		ɔ
+bjg	Bijogo		o
+bjg	Bijogo		u
+
 doy	Dompo		i				doy.pdf
-doy	Dompo		e				
-doy	Dompo		ɛ				
-doy	Dompo		a				
-doy	Dompo		ɔ				
-doy	Dompo		o				
-doy	Dompo		u				
-doy	Dompo		p				
-doy	Dompo		b				
-doy	Dompo		m				
-doy	Dompo		f				
-doy	Dompo		v				
-doy	Dompo		t				
-doy	Dompo		d				
-doy	Dompo		n				
-doy	Dompo		r	inventory marks square brackets, unclear of underlyinɡ form			
-doy	Dompo		s				
-doy	Dompo		z				
-doy	Dompo		l				
-doy	Dompo		ʃ				
-doy	Dompo		ʒ				
-doy	Dompo		c	inventory marks square brackets, unclear of underlyinɡ form			
-doy	Dompo		ɟ				
-doy	Dompo		j				
-doy	Dompo		k				
-doy	Dompo		ɡ				
-doy	Dompo		ŋ				
-doy	Dompo		w				
-doy	Dompo		h				
-doy	Dompo		˦	author states only that system is quite restricted with only two tones, however H vs. L is assumed here			
-doy	Dompo		˨	author states only that system is quite restricted with only two tones, however H vs. L is assumed here			
-							
+doy	Dompo		e
+doy	Dompo		ɛ
+doy	Dompo		a
+doy	Dompo		ɔ
+doy	Dompo		o
+doy	Dompo		u
+doy	Dompo		p
+doy	Dompo		b
+doy	Dompo		m
+doy	Dompo		f
+doy	Dompo		v
+doy	Dompo		t
+doy	Dompo		d
+doy	Dompo		n
+doy	Dompo		r	inventory marks square brackets, unclear of underlyinɡ form
+doy	Dompo		s
+doy	Dompo		z
+doy	Dompo		l
+doy	Dompo		ʃ
+doy	Dompo		ʒ
+doy	Dompo		c	inventory marks square brackets, unclear of underlyinɡ form
+doy	Dompo		ɟ
+doy	Dompo		j
+doy	Dompo		k
+doy	Dompo		ɡ
+doy	Dompo		ŋ
+doy	Dompo		w
+doy	Dompo		h
+doy	Dompo		˦	author states only that system is quite restricted with only two tones, however H vs. L is assumed here
+doy	Dompo		˨	author states only that system is quite restricted with only two tones, however H vs. L is assumed here
+
 bam	Bamana	Beledugu	i				beledugu_bam.pdf
-bam	Bamana	Beledugu	e				
-bam	Bamana	Beledugu	ɛ				
-bam	Bamana	Beledugu	a				
-bam	Bamana	Beledugu	ɔ				
-bam	Bamana	Beledugu	o				
-bam	Bamana	Beledugu	u				
-bam	Bamana	Beledugu	iː				
-bam	Bamana	Beledugu	eː				
-bam	Bamana	Beledugu	ɛː				
-bam	Bamana	Beledugu	aː				
-bam	Bamana	Beledugu	ɔː				
-bam	Bamana	Beledugu	oː				
-bam	Bamana	Beledugu	uː				
-bam	Bamana	Beledugu	ĩ				
-bam	Bamana	Beledugu	ẽ				
-bam	Bamana	Beledugu	ɛ̃				
-bam	Bamana	Beledugu	ã				
-bam	Bamana	Beledugu	ɔ̃				
-bam	Bamana	Beledugu	õ				
-bam	Bamana	Beledugu	ũ				
-bam	Bamana	Beledugu	<ũː>	questionable			
-bam	Bamana	Beledugu	<ɔ̃ː>	questionable			
-bam	Bamana	Beledugu	aː̃				
-bam	Bamana	Beledugu	mp				
-bam	Bamana	Beledugu	p				
-bam	Bamana	Beledugu	b				
-bam	Bamana	Beledugu	f				
-bam	Bamana	Beledugu	v				
-bam	Bamana	Beledugu	m				
-bam	Bamana	Beledugu	nt				
-bam	Bamana	Beledugu	t				
-bam	Bamana	Beledugu	d				
-bam	Bamana	Beledugu	s		[s]		
-bam	Bamana	Beledugu	s		[sʲ]		
-bam	Bamana	Beledugu	z				
-bam	Bamana	Beledugu	l				
-bam	Bamana	Beledugu	r				
-bam	Bamana	Beledugu	ɲc				
-bam	Bamana	Beledugu	c		[c]		
-bam	Bamana	Beledugu	c		[cʷ]		
-bam	Bamana	Beledugu	ɟ		[ɟ]		
-bam	Bamana	Beledugu	ɟ		[ɟʷ]		
-bam	Bamana	Beledugu	j				
-bam	Bamana	Beledugu	ɲ				
-bam	Bamana	Beledugu	ŋk				
-bam	Bamana	Beledugu	k				
-bam	Bamana	Beledugu	ɡ				
-bam	Bamana	Beledugu	<h>	borrowinɡs only			
-bam	Bamana	Beledugu	w				
-bam	Bamana	Beledugu	ŋ				
-bam	Bamana	Beledugu	mpʲ				
-bam	Bamana	Beledugu	bʷ		[bʷ]		
-bam	Bamana	Beledugu	bʷ		[bʲ]		
-bam	Bamana	Beledugu	fʷ		[ʃʲʷ]		
-bam	Bamana	Beledugu	fʷ		[fʷ]		
-bam	Bamana	Beledugu	mʲ				
-bam	Bamana	Beledugu	ɲʷ				
-bam	Bamana	Beledugu	kʷ				
-bam	Bamana	Beledugu	ɡʷ				
-bam	Bamana	Beledugu	ŋʷ				
-bam	Bamana	Beledugu	˦				
-bam	Bamana	Beledugu	˨				
-							
+bam	Bamana	Beledugu	e
+bam	Bamana	Beledugu	ɛ
+bam	Bamana	Beledugu	a
+bam	Bamana	Beledugu	ɔ
+bam	Bamana	Beledugu	o
+bam	Bamana	Beledugu	u
+bam	Bamana	Beledugu	iː
+bam	Bamana	Beledugu	eː
+bam	Bamana	Beledugu	ɛː
+bam	Bamana	Beledugu	aː
+bam	Bamana	Beledugu	ɔː
+bam	Bamana	Beledugu	oː
+bam	Bamana	Beledugu	uː
+bam	Bamana	Beledugu	ĩ
+bam	Bamana	Beledugu	ẽ
+bam	Bamana	Beledugu	ɛ̃
+bam	Bamana	Beledugu	ã
+bam	Bamana	Beledugu	ɔ̃
+bam	Bamana	Beledugu	õ
+bam	Bamana	Beledugu	ũ
+bam	Bamana	Beledugu	<ũː>	questionable
+bam	Bamana	Beledugu	<ɔ̃ː>	questionable
+bam	Bamana	Beledugu	aː̃
+bam	Bamana	Beledugu	mp
+bam	Bamana	Beledugu	p
+bam	Bamana	Beledugu	b
+bam	Bamana	Beledugu	f
+bam	Bamana	Beledugu	v
+bam	Bamana	Beledugu	m
+bam	Bamana	Beledugu	nt
+bam	Bamana	Beledugu	t
+bam	Bamana	Beledugu	d
+bam	Bamana	Beledugu	s		[s]
+bam	Bamana	Beledugu	s		[sʲ]
+bam	Bamana	Beledugu	z
+bam	Bamana	Beledugu	l
+bam	Bamana	Beledugu	r
+bam	Bamana	Beledugu	ɲc
+bam	Bamana	Beledugu	c		[c]
+bam	Bamana	Beledugu	c		[cʷ]
+bam	Bamana	Beledugu	ɟ		[ɟ]
+bam	Bamana	Beledugu	ɟ		[ɟʷ]
+bam	Bamana	Beledugu	j
+bam	Bamana	Beledugu	ɲ
+bam	Bamana	Beledugu	ŋk
+bam	Bamana	Beledugu	k
+bam	Bamana	Beledugu	ɡ
+bam	Bamana	Beledugu	<h>	borrowinɡs only
+bam	Bamana	Beledugu	w
+bam	Bamana	Beledugu	ŋ
+bam	Bamana	Beledugu	mpʲ
+bam	Bamana	Beledugu	bʷ		[bʷ]
+bam	Bamana	Beledugu	bʷ		[bʲ]
+bam	Bamana	Beledugu	fʷ		[ʃʲʷ]
+bam	Bamana	Beledugu	fʷ		[fʷ]
+bam	Bamana	Beledugu	mʲ
+bam	Bamana	Beledugu	ɲʷ
+bam	Bamana	Beledugu	kʷ
+bam	Bamana	Beledugu	ɡʷ
+bam	Bamana	Beledugu	ŋʷ
+bam	Bamana	Beledugu	˦
+bam	Bamana	Beledugu	˨
+
 hbn	Heiban		p				hbn.pdf
-hbn	Heiban		b				
-hbn	Heiban		m				
-hbn	Heiban		w				
-hbn	Heiban		ɓ				
-hbn	Heiban		<f>	arabic loanwords			
-hbn	Heiban		<v>	arabic loanwords			
-hbn	Heiban		t̪				
-hbn	Heiban		d̪				
-hbn	Heiban		t				
-hbn	Heiban		d				
-hbn	Heiban		<s>	arabic loanwords			
-hbn	Heiban		<z>	arabic loanwords			
-hbn	Heiban		n				
-hbn	Heiban		l				
-hbn	Heiban		r				
-hbn	Heiban		ɗ				
-hbn	Heiban		ɽ				
-hbn	Heiban		c				
-hbn	Heiban		ɟ				
-hbn	Heiban		ɲ				
-hbn	Heiban		j				
-hbn	Heiban		k				
-hbn	Heiban		ɡ				
-hbn	Heiban		<x>	arabic loanwords			
-hbn	Heiban		ŋ				
-hbn	Heiban		<h>	arabic loanwords			
-hbn	Heiban		i				
-hbn	Heiban		e				
-hbn	Heiban		ɘ				
-hbn	Heiban		a				
-hbn	Heiban		u				
-hbn	Heiban		o				
-hbn	Heiban		ɔ				
-							
+hbn	Heiban		b
+hbn	Heiban		m
+hbn	Heiban		w
+hbn	Heiban		ɓ
+hbn	Heiban		<f>	arabic loanwords
+hbn	Heiban		<v>	arabic loanwords
+hbn	Heiban		t̪
+hbn	Heiban		d̪
+hbn	Heiban		t
+hbn	Heiban		d
+hbn	Heiban		<s>	arabic loanwords
+hbn	Heiban		<z>	arabic loanwords
+hbn	Heiban		n
+hbn	Heiban		l
+hbn	Heiban		r
+hbn	Heiban		ɗ
+hbn	Heiban		ɽ
+hbn	Heiban		c
+hbn	Heiban		ɟ
+hbn	Heiban		ɲ
+hbn	Heiban		j
+hbn	Heiban		k
+hbn	Heiban		ɡ
+hbn	Heiban		<x>	arabic loanwords
+hbn	Heiban		ŋ
+hbn	Heiban		<h>	arabic loanwords
+hbn	Heiban		i
+hbn	Heiban		e
+hbn	Heiban		ɘ
+hbn	Heiban		a
+hbn	Heiban		u
+hbn	Heiban		o
+hbn	Heiban		ɔ
+
 kga	Koyaga		i				kga.pdf
-kga	Koyaga		ĩ				
-kga	Koyaga		e				
-kga	Koyaga		ɛ				
-kga	Koyaga		ɛ̃				
-kga	Koyaga		a				
-kga	Koyaga		ã				
-kga	Koyaga		ɔ				
-kga	Koyaga		ɔ̃				
-kga	Koyaga		o				
-kga	Koyaga		u				
-kga	Koyaga		ũ				
-kga	Koyaga		b				
-kga	Koyaga		m				
-kga	Koyaga		f				
-kga	Koyaga		w				
-kga	Koyaga		t				
-kga	Koyaga		d				
-kga	Koyaga		n				
-kga	Koyaga		s				
-kga	Koyaga		l				
-kga	Koyaga		c				
-kga	Koyaga		ɟ				
-kga	Koyaga		ɲ				
-kga	Koyaga		ʃ				
-kga	Koyaga		j				
-kga	Koyaga		k				
-kga	Koyaga		ɡ				
-kga	Koyaga		ŋ				
-kga	Koyaga		h				
-kga	Koyaga		ɡb				
-kga	Koyaga		w		[w]		
-kga	Koyaga		w		[ɥ]		
-kga	Koyaga		w		[ʋ]		
-kga	Koyaga		ɣ				
-kga	Koyaga		<r>	rare			
-kga	Koyaga		<p>	rare			
-kga	Koyaga		<v>	rare			
-kga	Koyaga		<z>	rare			
-kga	Koyaga		<w̃>	rare			
-kga	Koyaga		<ʒ>	rare			
-kga	Koyaga		<ɦ>	rare			
-kga	Koyaga		<kp>	rare			
-kga	Koyaga		<ŋm>	rare			
-kga	Koyaga		˨˦				
-kga	Koyaga		˦				
-							
+kga	Koyaga		ĩ
+kga	Koyaga		e
+kga	Koyaga		ɛ
+kga	Koyaga		ɛ̃
+kga	Koyaga		a
+kga	Koyaga		ã
+kga	Koyaga		ɔ
+kga	Koyaga		ɔ̃
+kga	Koyaga		o
+kga	Koyaga		u
+kga	Koyaga		ũ
+kga	Koyaga		b
+kga	Koyaga		m
+kga	Koyaga		f
+kga	Koyaga		w
+kga	Koyaga		t
+kga	Koyaga		d
+kga	Koyaga		n
+kga	Koyaga		s
+kga	Koyaga		l
+kga	Koyaga		c
+kga	Koyaga		ɟ
+kga	Koyaga		ɲ
+kga	Koyaga		ʃ
+kga	Koyaga		j
+kga	Koyaga		k
+kga	Koyaga		ɡ
+kga	Koyaga		ŋ
+kga	Koyaga		h
+kga	Koyaga		ɡb
+kga	Koyaga		w		[w]
+kga	Koyaga		w		[ɥ]
+kga	Koyaga		w		[ʋ]
+kga	Koyaga		ɣ
+kga	Koyaga		<r>	rare
+kga	Koyaga		<p>	rare
+kga	Koyaga		<v>	rare
+kga	Koyaga		<z>	rare
+kga	Koyaga		<w̃>	rare
+kga	Koyaga		<ʒ>	rare
+kga	Koyaga		<ɦ>	rare
+kga	Koyaga		<kp>	rare
+kga	Koyaga		<ŋm>	rare
+kga	Koyaga		˨˦
+kga	Koyaga		˦
+
 shw	Cwaya		p				shw.pdf
-shw	Cwaya		b				
-shw	Cwaya		m				
-shw	Cwaya		f				
-shw	Cwaya		v				
-shw	Cwaya		w				
-shw	Cwaya		t̪				
-shw	Cwaya		ð				
-shw	Cwaya		ʈ				
-shw	Cwaya		ɗ				
-shw	Cwaya		n				
-shw	Cwaya		s				
-shw	Cwaya		ʃ				
-shw	Cwaya		l				
-shw	Cwaya		r				
-shw	Cwaya		ɽ				
-shw	Cwaya		c				
-shw	Cwaya		ɟ				
-shw	Cwaya		ɲ				
-shw	Cwaya		j				
-shw	Cwaya		k				
-shw	Cwaya		ɡ				
-shw	Cwaya		ŋ				
-shw	Cwaya		x				
-shw	Cwaya		d̪				
-shw	Cwaya		i				
-shw	Cwaya		ɪ				
-shw	Cwaya		e				
-shw	Cwaya		ɛ				
-shw	Cwaya		ə				
-shw	Cwaya		a				
-shw	Cwaya		u				
-shw	Cwaya		ʊ				
-shw	Cwaya		o				
-shw	Cwaya		ɔ				
-shw	Cwaya		˦˨				
-shw	Cwaya		˦				
-shw	Cwaya		˨				
-							
+shw	Cwaya		b
+shw	Cwaya		m
+shw	Cwaya		f
+shw	Cwaya		v
+shw	Cwaya		w
+shw	Cwaya		t̪
+shw	Cwaya		ð
+shw	Cwaya		ʈ
+shw	Cwaya		ɗ
+shw	Cwaya		n
+shw	Cwaya		s
+shw	Cwaya		ʃ
+shw	Cwaya		l
+shw	Cwaya		r
+shw	Cwaya		ɽ
+shw	Cwaya		c
+shw	Cwaya		ɟ
+shw	Cwaya		ɲ
+shw	Cwaya		j
+shw	Cwaya		k
+shw	Cwaya		ɡ
+shw	Cwaya		ŋ
+shw	Cwaya		x
+shw	Cwaya		d̪
+shw	Cwaya		i
+shw	Cwaya		ɪ
+shw	Cwaya		e
+shw	Cwaya		ɛ
+shw	Cwaya		ə
+shw	Cwaya		a
+shw	Cwaya		u
+shw	Cwaya		ʊ
+shw	Cwaya		o
+shw	Cwaya		ɔ
+shw	Cwaya		˦˨
+shw	Cwaya		˦
+shw	Cwaya		˨
+
 ttb	Tiba		m		[m]		ttb.pdf
-ttb	Tiba		m		[mʷ]	initial position only	
-ttb	Tiba		p				
-ttb	Tiba		b				
-ttb	Tiba		ɓ				
-ttb	Tiba		ⱱ				
-ttb	Tiba		f				
-ttb	Tiba		v				
-ttb	Tiba		n				
-ttb	Tiba		t				
-ttb	Tiba		d				
-ttb	Tiba		ɗ				
-ttb	Tiba		l				
-ttb	Tiba		s		[s]		
-ttb	Tiba		s		[c]	before hiɡh front vowels	
-ttb	Tiba		d̠ʒ				
-ttb	Tiba		ɟ		[ɟ]		
-ttb	Tiba		ɟ		[d̠ʒ]	before hiɡh front vowels	
-ttb	Tiba		k				
-ttb	Tiba		ɡ				
-ttb	Tiba		n				
-ttb	Tiba		km				
-ttb	Tiba		ɡm				
-ttb	Tiba		kp				
-ttb	Tiba		ɡb				
-ttb	Tiba		w				
-ttb	Tiba		i		[i]		
-ttb	Tiba		e		[e]		
-ttb	Tiba		ɛ		[ɛ]		
-ttb	Tiba		a		[a]		
-ttb	Tiba		o		[o]		
-ttb	Tiba		ɔ		[ɔ]		
-ttb	Tiba		u		[u]		
-ttb	Tiba		y		[y]		
-ttb	Tiba		œ		[œ]		
-ttb	Tiba		i		[ĩ]		
-ttb	Tiba		e		[ẽ]		
-ttb	Tiba		ɛ		[ɛ̃]		
-ttb	Tiba		a		[ã]		
-ttb	Tiba		o		[õ]		
-ttb	Tiba		ɔ		[ɔ̃]		
-ttb	Tiba		u		[ũ]		
-ttb	Tiba		y		[ỹ]		
-ttb	Tiba		œ		[œ̃]		
-ttb	Tiba		˦				
-ttb	Tiba		˨				
-ttb	Tiba		˧				
-							
+ttb	Tiba		m		[mʷ]	initial position only
+ttb	Tiba		p
+ttb	Tiba		b
+ttb	Tiba		ɓ
+ttb	Tiba		ⱱ
+ttb	Tiba		f
+ttb	Tiba		v
+ttb	Tiba		n
+ttb	Tiba		t
+ttb	Tiba		d
+ttb	Tiba		ɗ
+ttb	Tiba		l
+ttb	Tiba		s		[s]
+ttb	Tiba		s		[c]	before hiɡh front vowels
+ttb	Tiba		d̠ʒ
+ttb	Tiba		ɟ		[ɟ]
+ttb	Tiba		ɟ		[d̠ʒ]	before hiɡh front vowels
+ttb	Tiba		k
+ttb	Tiba		ɡ
+ttb	Tiba		n
+ttb	Tiba		km
+ttb	Tiba		ɡm
+ttb	Tiba		kp
+ttb	Tiba		ɡb
+ttb	Tiba		w
+ttb	Tiba		i		[i]
+ttb	Tiba		e		[e]
+ttb	Tiba		ɛ		[ɛ]
+ttb	Tiba		a		[a]
+ttb	Tiba		o		[o]
+ttb	Tiba		ɔ		[ɔ]
+ttb	Tiba		u		[u]
+ttb	Tiba		y		[y]
+ttb	Tiba		œ		[œ]
+ttb	Tiba		i		[ĩ]
+ttb	Tiba		e		[ẽ]
+ttb	Tiba		ɛ		[ɛ̃]
+ttb	Tiba		a		[ã]
+ttb	Tiba		o		[õ]
+ttb	Tiba		ɔ		[ɔ̃]
+ttb	Tiba		u		[ũ]
+ttb	Tiba		y		[ỹ]
+ttb	Tiba		œ		[œ̃]
+ttb	Tiba		˦
+ttb	Tiba		˨
+ttb	Tiba		˧
+
 kua	Kwanyama		m̥				wambo.pdf
-kua	Kwanyama		n̥				
-kua	Kwanyama		ŋ̥				
-kua	Kwanyama		mb				
-kua	Kwanyama		nd				
-kua	Kwanyama		ndʲ				
-kua	Kwanyama		n̠d̠ʒ				
-kua	Kwanyama		ŋɡ				
-kua	Kwanyama		p				
-kua	Kwanyama		t				
-kua	Kwanyama		k				
-kua	Kwanyama		d				
-kua	Kwanyama		d̠ʒ				
-kua	Kwanyama		f				
-kua	Kwanyama		fʲ				
-kua	Kwanyama		ʃ				
-kua	Kwanyama		x				
-kua	Kwanyama		v				
-kua	Kwanyama		ʒ				
-kua	Kwanyama		l				
-kua	Kwanyama		lʲ				
-kua	Kwanyama		n				
-kua	Kwanyama		ɲ				
-kua	Kwanyama		m				
-kua	Kwanyama		j				
-kua	Kwanyama		w				
-kua	Kwanyama		i				
-kua	Kwanyama		ɛ				
-kua	Kwanyama		a				
-kua	Kwanyama		ɔ				
-kua	Kwanyama		u				
-kua	Kwanyama		˦				
-kua	Kwanyama		˨				
-							
+kua	Kwanyama		n̥
+kua	Kwanyama		ŋ̥
+kua	Kwanyama		mb
+kua	Kwanyama		nd
+kua	Kwanyama		ndʲ
+kua	Kwanyama		n̠d̠ʒ
+kua	Kwanyama		ŋɡ
+kua	Kwanyama		p
+kua	Kwanyama		t
+kua	Kwanyama		k
+kua	Kwanyama		d
+kua	Kwanyama		d̠ʒ
+kua	Kwanyama		f
+kua	Kwanyama		fʲ
+kua	Kwanyama		ʃ
+kua	Kwanyama		x
+kua	Kwanyama		v
+kua	Kwanyama		ʒ
+kua	Kwanyama		l
+kua	Kwanyama		lʲ
+kua	Kwanyama		n
+kua	Kwanyama		ɲ
+kua	Kwanyama		m
+kua	Kwanyama		j
+kua	Kwanyama		w
+kua	Kwanyama		i
+kua	Kwanyama		ɛ
+kua	Kwanyama		a
+kua	Kwanyama		ɔ
+kua	Kwanyama		u
+kua	Kwanyama		˦
+kua	Kwanyama		˨
+
 lnb	Mbalanhu		m̥				wambo.pdf
-lnb	Mbalanhu		n̥				
-lnb	Mbalanhu		ɲ̥				
-lnb	Mbalanhu		ŋ̥				
-lnb	Mbalanhu		mb				
-lnb	Mbalanhu		nd				
-lnb	Mbalanhu		n̠d̠ʒ				
-lnb	Mbalanhu		ŋɡ				
-lnb	Mbalanhu		p				
-lnb	Mbalanhu		t				
-lnb	Mbalanhu		k				
-lnb	Mbalanhu		f				
-lnb	Mbalanhu		s				
-lnb	Mbalanhu		ʃ				
-lnb	Mbalanhu		h				
-lnb	Mbalanhu		v				
-lnb	Mbalanhu		z				
-lnb	Mbalanhu		l				
-lnb	Mbalanhu		lʲ				
-lnb	Mbalanhu		m				
-lnb	Mbalanhu		n				
-lnb	Mbalanhu		ɲ				
-lnb	Mbalanhu		y				
-lnb	Mbalanhu		w				
-lnb	Mbalanhu		i				
-lnb	Mbalanhu		ɛ				
-lnb	Mbalanhu		a				
-lnb	Mbalanhu		ɔ				
-lnb	Mbalanhu		u				
-lnb	Mbalanhu		˦				
-lnb	Mbalanhu		˨				
-							
+lnb	Mbalanhu		n̥
+lnb	Mbalanhu		ɲ̥
+lnb	Mbalanhu		ŋ̥
+lnb	Mbalanhu		mb
+lnb	Mbalanhu		nd
+lnb	Mbalanhu		n̠d̠ʒ
+lnb	Mbalanhu		ŋɡ
+lnb	Mbalanhu		p
+lnb	Mbalanhu		t
+lnb	Mbalanhu		k
+lnb	Mbalanhu		f
+lnb	Mbalanhu		s
+lnb	Mbalanhu		ʃ
+lnb	Mbalanhu		h
+lnb	Mbalanhu		v
+lnb	Mbalanhu		z
+lnb	Mbalanhu		l
+lnb	Mbalanhu		lʲ
+lnb	Mbalanhu		m
+lnb	Mbalanhu		n
+lnb	Mbalanhu		ɲ
+lnb	Mbalanhu		y
+lnb	Mbalanhu		w
+lnb	Mbalanhu		i
+lnb	Mbalanhu		ɛ
+lnb	Mbalanhu		a
+lnb	Mbalanhu		ɔ
+lnb	Mbalanhu		u
+lnb	Mbalanhu		˦
+lnb	Mbalanhu		˨
+
 kwm	Kwambi		m̥p				wambo.pdf
-kwm	Kwambi		n̥				
-kwm	Kwambi		ŋk				
-kwm	Kwambi		mb				
-kwm	Kwambi		nd				
-kwm	Kwambi		n̠d̠ʒ				
-kwm	Kwambi		ŋɡ				
-kwm	Kwambi		ɱv				
-kwm	Kwambi		ɲʒ				
-kwm	Kwambi		p				
-kwm	Kwambi		t				
-kwm	Kwambi		k				
-kwm	Kwambi		θ				
-kwm	Kwambi		s				
-kwm	Kwambi		ʃ				
-kwm	Kwambi		x				
-kwm	Kwambi		h				
-kwm	Kwambi		v				
-kwm	Kwambi		ð				
-kwm	Kwambi		z				
-kwm	Kwambi		ɣ				
-kwm	Kwambi		ts				
-kwm	Kwambi		t̠ʃ				
-kwm	Kwambi		r				
-kwm	Kwambi		rʲ				
-kwm	Kwambi		m				
-kwm	Kwambi		n				
-kwm	Kwambi		ɲ				
-kwm	Kwambi		y				
-kwm	Kwambi		w				
-kwm	Kwambi		i				
-kwm	Kwambi		ɛ				
-kwm	Kwambi		a				
-kwm	Kwambi		ɔ				
-kwm	Kwambi		u				
-kwm	Kwambi		˦				
-kwm	Kwambi		˨				
-							
+kwm	Kwambi		n̥
+kwm	Kwambi		ŋk
+kwm	Kwambi		mb
+kwm	Kwambi		nd
+kwm	Kwambi		n̠d̠ʒ
+kwm	Kwambi		ŋɡ
+kwm	Kwambi		ɱv
+kwm	Kwambi		ɲʒ
+kwm	Kwambi		p
+kwm	Kwambi		t
+kwm	Kwambi		k
+kwm	Kwambi		θ
+kwm	Kwambi		s
+kwm	Kwambi		ʃ
+kwm	Kwambi		x
+kwm	Kwambi		h
+kwm	Kwambi		v
+kwm	Kwambi		ð
+kwm	Kwambi		z
+kwm	Kwambi		ɣ
+kwm	Kwambi		ts
+kwm	Kwambi		t̠ʃ
+kwm	Kwambi		r
+kwm	Kwambi		rʲ
+kwm	Kwambi		m
+kwm	Kwambi		n
+kwm	Kwambi		ɲ
+kwm	Kwambi		y
+kwm	Kwambi		w
+kwm	Kwambi		i
+kwm	Kwambi		ɛ
+kwm	Kwambi		a
+kwm	Kwambi		ɔ
+kwm	Kwambi		u
+kwm	Kwambi		˦
+kwm	Kwambi		˨
+
 nne	Ngandjera		m̥				wambo.pdf
-nne	Ngandjera		n̥				
-nne	Ngandjera		ɲ̥				
-nne	Ngandjera		ŋ̥				
-nne	Ngandjera		mb				
-nne	Ngandjera		nd				
-nne	Ngandjera		ndʲ				
-nne	Ngandjera		n̠d̠ʒ				
-nne	Ngandjera		ŋɡ				
-nne	Ngandjera		ɲʒ				
-nne	Ngandjera		p				
-nne	Ngandjera		t				
-nne	Ngandjera		k				
-nne	Ngandjera		θ				
-nne	Ngandjera		s				
-nne	Ngandjera		ʃ				
-nne	Ngandjera		v				
-nne	Ngandjera		ð				
-nne	Ngandjera		z				
-nne	Ngandjera		ʒ				
-nne	Ngandjera		ɣ				
-nne	Ngandjera		ts				
-nne	Ngandjera		t̠ʃ				
-nne	Ngandjera		l				
-nne	Ngandjera		lʲ				
-nne	Ngandjera		m				
-nne	Ngandjera		n				
-nne	Ngandjera		ɲ				
-nne	Ngandjera		j				
-nne	Ngandjera		w				
-nne	Ngandjera		i				
-nne	Ngandjera		ɛ				
-nne	Ngandjera		a				
-nne	Ngandjera		ɔ				
-nne	Ngandjera		u				
-nne	Ngandjera		˦				
-nne	Ngandjera		˨				
-							
+nne	Ngandjera		n̥
+nne	Ngandjera		ɲ̥
+nne	Ngandjera		ŋ̥
+nne	Ngandjera		mb
+nne	Ngandjera		nd
+nne	Ngandjera		ndʲ
+nne	Ngandjera		n̠d̠ʒ
+nne	Ngandjera		ŋɡ
+nne	Ngandjera		ɲʒ
+nne	Ngandjera		p
+nne	Ngandjera		t
+nne	Ngandjera		k
+nne	Ngandjera		θ
+nne	Ngandjera		s
+nne	Ngandjera		ʃ
+nne	Ngandjera		v
+nne	Ngandjera		ð
+nne	Ngandjera		z
+nne	Ngandjera		ʒ
+nne	Ngandjera		ɣ
+nne	Ngandjera		ts
+nne	Ngandjera		t̠ʃ
+nne	Ngandjera		l
+nne	Ngandjera		lʲ
+nne	Ngandjera		m
+nne	Ngandjera		n
+nne	Ngandjera		ɲ
+nne	Ngandjera		j
+nne	Ngandjera		w
+nne	Ngandjera		i
+nne	Ngandjera		ɛ
+nne	Ngandjera		a
+nne	Ngandjera		ɔ
+nne	Ngandjera		u
+nne	Ngandjera		˦
+nne	Ngandjera		˨
+
 ndo	Ndonga (Kwaluudhi)	Kwaluudhi	m̥				wambo.pdf
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	n̥				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɲ̥				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	mb				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	nd				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ndʲ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	n̠d̠ʒ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ŋɡ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	p				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	t				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	k				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	θ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	s				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ʃ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	v				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ð				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	z				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ʒ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɣ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ts				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	t̠ʃ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	l				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	lʲ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	m				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	n				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɲ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ŋ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	j				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	w				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	i				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɛ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	a				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɔ				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	u				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	˦				
-ndo	Ndonga (Kwaluudhi)	Kwaluudhi	˨				
-							
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	n̥
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɲ̥
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	mb
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	nd
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ndʲ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	n̠d̠ʒ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ŋɡ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	p
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	t
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	k
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	θ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	s
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ʃ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	v
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ð
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	z
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ʒ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɣ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ts
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	t̠ʃ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	l
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	lʲ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	m
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	n
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɲ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ŋ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	j
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	w
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	i
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɛ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	a
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	ɔ
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	u
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	˦
+ndo	Ndonga (Kwaluudhi)	Kwaluudhi	˨
+
 ndo	Ndonga (Kolonkadhi)	Kolonkadhi	m̥				wambo.pdf
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	n̥				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɲ̥				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	mb				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	nd				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ndʲ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	n̠d̠ʒ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ŋɡ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	p				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	t				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	k				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	θ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	s				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ʃ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	v				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ð				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	z				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ʒ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɣ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ts				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	t̠ʃ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	l				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	dʲ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	m				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	n				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɲ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ŋ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	j				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	w				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	i				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɛ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	a				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɔ				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	u				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	˦				
-ndo	Ndonga (Kolonkadhi)	Kolonkadhi	˨				
-							
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	n̥
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɲ̥
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	mb
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	nd
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ndʲ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	n̠d̠ʒ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ŋɡ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	p
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	t
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	k
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	θ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	s
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ʃ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	v
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ð
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	z
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ʒ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɣ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ts
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	t̠ʃ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	l
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	dʲ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	m
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	n
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɲ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ŋ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	j
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	w
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	i
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɛ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	a
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	ɔ
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	u
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	˦
+ndo	Ndonga (Kolonkadhi)	Kolonkadhi	˨
+
 ndo	Ndonga (Eunda)	Eunda	m̥ʰ				wambo.pdf
-ndo	Ndonga (Eunda)	Eunda	n̥				
-ndo	Ndonga (Eunda)	Eunda	ɲ̥				
-ndo	Ndonga (Eunda)	Eunda	mb				
-ndo	Ndonga (Eunda)	Eunda	nd				
-ndo	Ndonga (Eunda)	Eunda	ndʲ				
-ndo	Ndonga (Eunda)	Eunda	n̠d̠ʒ				
-ndo	Ndonga (Eunda)	Eunda	ŋɡ				
-ndo	Ndonga (Eunda)	Eunda	p				
-ndo	Ndonga (Eunda)	Eunda	t				
-ndo	Ndonga (Eunda)	Eunda	k				
-ndo	Ndonga (Eunda)	Eunda	θ				
-ndo	Ndonga (Eunda)	Eunda	s				
-ndo	Ndonga (Eunda)	Eunda	ʃ				
-ndo	Ndonga (Eunda)	Eunda	v				
-ndo	Ndonga (Eunda)	Eunda	ð				
-ndo	Ndonga (Eunda)	Eunda	z				
-ndo	Ndonga (Eunda)	Eunda	ɲʒ				
-ndo	Ndonga (Eunda)	Eunda	ɣ				
-ndo	Ndonga (Eunda)	Eunda	ts				
-ndo	Ndonga (Eunda)	Eunda	t̠ʃ				
-ndo	Ndonga (Eunda)	Eunda	l				
-ndo	Ndonga (Eunda)	Eunda	dʲ				
-ndo	Ndonga (Eunda)	Eunda	m				
-ndo	Ndonga (Eunda)	Eunda	n				
-ndo	Ndonga (Eunda)	Eunda	ɲ				
-ndo	Ndonga (Eunda)	Eunda	ŋ				
-ndo	Ndonga (Eunda)	Eunda	j				
-ndo	Ndonga (Eunda)	Eunda	w				
-ndo	Ndonga (Eunda)	Eunda	i				
-ndo	Ndonga (Eunda)	Eunda	ɛ				
-ndo	Ndonga (Eunda)	Eunda	a				
-ndo	Ndonga (Eunda)	Eunda	ɔ				
-ndo	Ndonga (Eunda)	Eunda	u				
-ndo	Ndonga (Eunda)	Eunda	˦				
-ndo	Ndonga (Eunda)	Eunda	˨				
-							
-							
+ndo	Ndonga (Eunda)	Eunda	n̥
+ndo	Ndonga (Eunda)	Eunda	ɲ̥
+ndo	Ndonga (Eunda)	Eunda	mb
+ndo	Ndonga (Eunda)	Eunda	nd
+ndo	Ndonga (Eunda)	Eunda	ndʲ
+ndo	Ndonga (Eunda)	Eunda	n̠d̠ʒ
+ndo	Ndonga (Eunda)	Eunda	ŋɡ
+ndo	Ndonga (Eunda)	Eunda	p
+ndo	Ndonga (Eunda)	Eunda	t
+ndo	Ndonga (Eunda)	Eunda	k
+ndo	Ndonga (Eunda)	Eunda	θ
+ndo	Ndonga (Eunda)	Eunda	s
+ndo	Ndonga (Eunda)	Eunda	ʃ
+ndo	Ndonga (Eunda)	Eunda	v
+ndo	Ndonga (Eunda)	Eunda	ð
+ndo	Ndonga (Eunda)	Eunda	z
+ndo	Ndonga (Eunda)	Eunda	ɲʒ
+ndo	Ndonga (Eunda)	Eunda	ɣ
+ndo	Ndonga (Eunda)	Eunda	ts
+ndo	Ndonga (Eunda)	Eunda	t̠ʃ
+ndo	Ndonga (Eunda)	Eunda	l
+ndo	Ndonga (Eunda)	Eunda	dʲ
+ndo	Ndonga (Eunda)	Eunda	m
+ndo	Ndonga (Eunda)	Eunda	n
+ndo	Ndonga (Eunda)	Eunda	ɲ
+ndo	Ndonga (Eunda)	Eunda	ŋ
+ndo	Ndonga (Eunda)	Eunda	j
+ndo	Ndonga (Eunda)	Eunda	w
+ndo	Ndonga (Eunda)	Eunda	i
+ndo	Ndonga (Eunda)	Eunda	ɛ
+ndo	Ndonga (Eunda)	Eunda	a
+ndo	Ndonga (Eunda)	Eunda	ɔ
+ndo	Ndonga (Eunda)	Eunda	u
+ndo	Ndonga (Eunda)	Eunda	˦
+ndo	Ndonga (Eunda)	Eunda	˨
+
+
 xon	Konkomba	Nawaré	p				xon_naware.pdf
-xon	Konkomba	Nawaré	b				
-xon	Konkomba	Nawaré	m				
-xon	Konkomba	Nawaré	f				
-xon	Konkomba	Nawaré	w				
-xon	Konkomba	Nawaré	t				
-xon	Konkomba	Nawaré	d				
-xon	Konkomba	Nawaré	n				
-xon	Konkomba	Nawaré	s				
-xon	Konkomba	Nawaré	l				
-xon	Konkomba	Nawaré	r				
-xon	Konkomba	Nawaré	c				
-xon	Konkomba	Nawaré	ɟ				
-xon	Konkomba	Nawaré	j				
-xon	Konkomba	Nawaré	k				
-xon	Konkomba	Nawaré	ɡ				
-xon	Konkomba	Nawaré	ŋ				
-xon	Konkomba	Nawaré	kp				
-xon	Konkomba	Nawaré	ɡb				
-xon	Konkomba	Nawaré	ŋm				
-xon	Konkomba	Nawaré	ʔ				
-xon	Konkomba	Nawaré	i				
-xon	Konkomba	Nawaré	iː				
-xon	Konkomba	Nawaré	eː				
-xon	Konkomba	Nawaré	a				
-xon	Konkomba	Nawaré	aː				
-xon	Konkomba	Nawaré	ɨ				
-xon	Konkomba	Nawaré	u				
-xon	Konkomba	Nawaré	uː				
-xon	Konkomba	Nawaré	o				
-xon	Konkomba	Nawaré	oː				
-xon	Konkomba	Nawaré	ʌː				
-xon	Konkomba	Nawaré	ɔ				
-xon	Konkomba	Nawaré	ɔː				
-xon	Konkomba	Nawaré	å				
-xon	Konkomba	Nawaré	˦				
-xon	Konkomba	Nawaré	˨				
-xon	Konkomba	Nawaré	˧				
-							
+xon	Konkomba	Nawaré	b
+xon	Konkomba	Nawaré	m
+xon	Konkomba	Nawaré	f
+xon	Konkomba	Nawaré	w
+xon	Konkomba	Nawaré	t
+xon	Konkomba	Nawaré	d
+xon	Konkomba	Nawaré	n
+xon	Konkomba	Nawaré	s
+xon	Konkomba	Nawaré	l
+xon	Konkomba	Nawaré	r
+xon	Konkomba	Nawaré	c
+xon	Konkomba	Nawaré	ɟ
+xon	Konkomba	Nawaré	j
+xon	Konkomba	Nawaré	k
+xon	Konkomba	Nawaré	ɡ
+xon	Konkomba	Nawaré	ŋ
+xon	Konkomba	Nawaré	kp
+xon	Konkomba	Nawaré	ɡb
+xon	Konkomba	Nawaré	ŋm
+xon	Konkomba	Nawaré	ʔ
+xon	Konkomba	Nawaré	i
+xon	Konkomba	Nawaré	iː
+xon	Konkomba	Nawaré	eː
+xon	Konkomba	Nawaré	a
+xon	Konkomba	Nawaré	aː
+xon	Konkomba	Nawaré	ɨ
+xon	Konkomba	Nawaré	u
+xon	Konkomba	Nawaré	uː
+xon	Konkomba	Nawaré	o
+xon	Konkomba	Nawaré	oː
+xon	Konkomba	Nawaré	ʌː
+xon	Konkomba	Nawaré	ɔ
+xon	Konkomba	Nawaré	ɔː
+xon	Konkomba	Nawaré	å
+xon	Konkomba	Nawaré	˦
+xon	Konkomba	Nawaré	˨
+xon	Konkomba	Nawaré	˧
+
 zag	Beria		b				zag.pdf
-zag	Beria		f				
-zag	Beria		m				
-zag	Beria		w				
-zag	Beria		t		[t]		
-zag	Beria		t		[t̚]	word final	
-zag	Beria		d				
-zag	Beria		s				
-zag	Beria		n				
-zag	Beria		r				
-zag	Beria		r				
-zag	Beria		<l>	marɡinal			
-zag	Beria		<c>	marɡinal	[c]		
-zag	Beria		<c>	marɡinal	[c̚]	word final	
-zag	Beria		ɟ				
-zag	Beria		<ʃ>	marɡinal			
-zag	Beria		ɲ				
-zag	Beria		j				
-zag	Beria		k		[k]		
-zag	Beria		k		[k̚]	word final	
-zag	Beria		ɡ				
-zag	Beria		ŋ				
-zag	Beria		h				
-zag	Beria		p		[p]	word medial	
-zag	Beria		p		[p̚]	word final	
-zag	Beria		ʔ	never word initial			
-zag	Beria		i				
-zag	Beria		e				
-zag	Beria		o				
-zag	Beria		u				
-zag	Beria		ɪ				
-zag	Beria		ɛ				
-zag	Beria		ɔ				
-zag	Beria		ʊ				
-zag	Beria		a				
-zag	Beria		˦				
-zag	Beria		˨				
-zag	Beria		˧				
-							
+zag	Beria		f
+zag	Beria		m
+zag	Beria		w
+zag	Beria		t		[t]
+zag	Beria		t		[t̚]	word final
+zag	Beria		d
+zag	Beria		s
+zag	Beria		n
+zag	Beria		r
+zag	Beria		r
+zag	Beria		<l>	marɡinal
+zag	Beria		<c>	marɡinal	[c]
+zag	Beria		<c>	marɡinal	[c̚]	word final
+zag	Beria		ɟ
+zag	Beria		<ʃ>	marɡinal
+zag	Beria		ɲ
+zag	Beria		j
+zag	Beria		k		[k]
+zag	Beria		k		[k̚]	word final
+zag	Beria		ɡ
+zag	Beria		ŋ
+zag	Beria		h
+zag	Beria		p		[p]	word medial
+zag	Beria		p		[p̚]	word final
+zag	Beria		ʔ	never word initial
+zag	Beria		i
+zag	Beria		e
+zag	Beria		o
+zag	Beria		u
+zag	Beria		ɪ
+zag	Beria		ɛ
+zag	Beria		ɔ
+zag	Beria		ʊ
+zag	Beria		a
+zag	Beria		˦
+zag	Beria		˨
+zag	Beria		˧
+
 zwa	Zway		b				zwa.pdf
-zwa	Zway		f				
-zwa	Zway		m				
-zwa	Zway		w				
-zwa	Zway		t		[t]		
-zwa	Zway		t		[tʲ]		
-zwa	Zway		d		[d]		
-zwa	Zway		d		[dʲ]		
-zwa	Zway		tˀ		[tˀ]		
-zwa	Zway		tˀ		[tˀʲ]		
-zwa	Zway		s		[s]		
-zwa	Zway		s		[sʲ]		
-zwa	Zway		z		[z]		
-zwa	Zway		z		[zʲ]		
-zwa	Zway		n		[n]		
-zwa	Zway		n		[nʲ]		
-zwa	Zway		l		[l]		
-zwa	Zway		l		[lʲ]		
-zwa	Zway		r				
-zwa	Zway		k				
-zwa	Zway		d̠ʒ				
-zwa	Zway		t̠ʃˀ				
-zwa	Zway		ʃ				
-zwa	Zway		ʒ				
-zwa	Zway		ɲ				
-zwa	Zway		j				
-zwa	Zway		ɡ				
-zwa	Zway		k				
-zwa	Zway		q				
-zwa	Zway		ʔ				
-zwa	Zway		h				
-zwa	Zway		i				
-zwa	Zway		e				
-zwa	Zway		ɨ				
-zwa	Zway		ə				
-zwa	Zway		a				
-zwa	Zway		u				
-zwa	Zway		o				
-zwa	Zway		iː				
-zwa	Zway		eː				
-zwa	Zway		ɨː				
-zwa	Zway		əː				
-zwa	Zway		aː				
-zwa	Zway		uː				
-zwa	Zway		oː				
-							
+zwa	Zway		f
+zwa	Zway		m
+zwa	Zway		w
+zwa	Zway		t		[t]
+zwa	Zway		t		[tʲ]
+zwa	Zway		d		[d]
+zwa	Zway		d		[dʲ]
+zwa	Zway		tˀ		[tˀ]
+zwa	Zway		tˀ		[tˀʲ]
+zwa	Zway		s		[s]
+zwa	Zway		s		[sʲ]
+zwa	Zway		z		[z]
+zwa	Zway		z		[zʲ]
+zwa	Zway		n		[n]
+zwa	Zway		n		[nʲ]
+zwa	Zway		l		[l]
+zwa	Zway		l		[lʲ]
+zwa	Zway		r
+zwa	Zway		k
+zwa	Zway		d̠ʒ
+zwa	Zway		t̠ʃˀ
+zwa	Zway		ʃ
+zwa	Zway		ʒ
+zwa	Zway		ɲ
+zwa	Zway		j
+zwa	Zway		ɡ
+zwa	Zway		k
+zwa	Zway		q
+zwa	Zway		ʔ
+zwa	Zway		h
+zwa	Zway		i
+zwa	Zway		e
+zwa	Zway		ɨ
+zwa	Zway		ə
+zwa	Zway		a
+zwa	Zway		u
+zwa	Zway		o
+zwa	Zway		iː
+zwa	Zway		eː
+zwa	Zway		ɨː
+zwa	Zway		əː
+zwa	Zway		aː
+zwa	Zway		uː
+zwa	Zway		oː
+
 zmx	Leke		i				zmx.pdf
-zmx	Leke		ĩ				
-zmx	Leke		e				
-zmx	Leke		ɛ				
-zmx	Leke		a				
-zmx	Leke		ã				
-zmx	Leke		u				
-zmx	Leke		ũ				
-zmx	Leke		o				
-zmx	Leke		õ				
-zmx	Leke		p				
-zmx	Leke		b				
-zmx	Leke		m		[m]		
-zmx	Leke		m		[ɱ]		
-zmx	Leke		t				
-zmx	Leke		d		[d]		
-zmx	Leke		d		[l]		
-zmx	Leke		n		[n]		
-zmx	Leke		n		[ŋ]		
-zmx	Leke		k		[k]		
-zmx	Leke		k		[kʲ]		
-zmx	Leke		ɡ		[ɡ]		
-zmx	Leke		ɡ		[ɡʲ]		
-zmx	Leke		kp				
-zmx	Leke		ɡb				
-zmx	Leke		f				
-zmx	Leke		v				
-zmx	Leke		s				
-zmx	Leke		z		[z]		
-zmx	Leke		z		[dz]		
-zmx	Leke		j				
-zmx	Leke		w				
-zmx	Leke		˦				
-zmx	Leke		˨				
+zmx	Leke		ĩ
+zmx	Leke		e
+zmx	Leke		ɛ
+zmx	Leke		a
+zmx	Leke		ã
+zmx	Leke		u
+zmx	Leke		ũ
+zmx	Leke		o
+zmx	Leke		õ
+zmx	Leke		p
+zmx	Leke		b
+zmx	Leke		m		[m]
+zmx	Leke		m		[ɱ]
+zmx	Leke		t
+zmx	Leke		d		[d]
+zmx	Leke		d		[l]
+zmx	Leke		n		[n]
+zmx	Leke		n		[ŋ]
+zmx	Leke		k		[k]
+zmx	Leke		k		[kʲ]
+zmx	Leke		ɡ		[ɡ]
+zmx	Leke		ɡ		[ɡʲ]
+zmx	Leke		kp
+zmx	Leke		ɡb
+zmx	Leke		f
+zmx	Leke		v
+zmx	Leke		s
+zmx	Leke		z		[z]
+zmx	Leke		z		[dz]
+zmx	Leke		j
+zmx	Leke		w
+zmx	Leke		˦
+zmx	Leke		˨
 
 bbo	Bobo, North	Tansila	i				bbo_new.pdf
-bbo	Bobo, North	Tansila	e		[e]		
-bbo	Bobo, North	Tansila	ɛ		[ɛ]		
-bbo	Bobo, North	Tansila	a				
-bbo	Bobo, North	Tansila	ɔ				
-bbo	Bobo, North	Tansila	o				
-bbo	Bobo, North	Tansila	u				
-bbo	Bobo, North	Tansila	ã				
-bbo	Bobo, North	Tansila	ĩ				
-bbo	Bobo, North	Tansila	ẽ				
-bbo	Bobo, North	Tansila	õ				
-bbo	Bobo, North	Tansila	ũ				
-bbo	Bobo, North	Tansila	ə				
-bbo	Bobo, North	Tansila	p				
-bbo	Bobo, North	Tansila	b				
-bbo	Bobo, North	Tansila	f				
-bbo	Bobo, North	Tansila	m				
-bbo	Bobo, North	Tansila	w				
-bbo	Bobo, North	Tansila	t̪				
-bbo	Bobo, North	Tansila	d̪				
-bbo	Bobo, North	Tansila	n̪				
-bbo	Bobo, North	Tansila	l̪				
-bbo	Bobo, North	Tansila	r̪				
-bbo	Bobo, North	Tansila	ɟ				
-bbo	Bobo, North	Tansila	ɲ				
-bbo	Bobo, North	Tansila	j				
-bbo	Bobo, North	Tansila	k				
-bbo	Bobo, North	Tansila	ɡ				
-bbo	Bobo, North	Tansila	ɣ		[ɣ]		
-bbo	Bobo, North	Tansila	ɣ		[x]		
-bbo	Bobo, North	Tansila	ŋ				
-bbo	Bobo, North	Tansila	ŋʷ				
-bbo	Bobo, North	Tansila	kp				
-bbo	Bobo, North	Tansila	ɡb				
-bbo	Bobo, North	Tansila	h				
-bbo	Bobo, North	Tansila	˦				
-bbo	Bobo, North	Tansila	˨				
-bbo	Bobo, North	Tansila	˧				
-							
+bbo	Bobo, North	Tansila	e		[e]
+bbo	Bobo, North	Tansila	ɛ		[ɛ]
+bbo	Bobo, North	Tansila	a
+bbo	Bobo, North	Tansila	ɔ
+bbo	Bobo, North	Tansila	o
+bbo	Bobo, North	Tansila	u
+bbo	Bobo, North	Tansila	ã
+bbo	Bobo, North	Tansila	ĩ
+bbo	Bobo, North	Tansila	ẽ
+bbo	Bobo, North	Tansila	õ
+bbo	Bobo, North	Tansila	ũ
+bbo	Bobo, North	Tansila	ə
+bbo	Bobo, North	Tansila	p
+bbo	Bobo, North	Tansila	b
+bbo	Bobo, North	Tansila	f
+bbo	Bobo, North	Tansila	m
+bbo	Bobo, North	Tansila	w
+bbo	Bobo, North	Tansila	t̪
+bbo	Bobo, North	Tansila	d̪
+bbo	Bobo, North	Tansila	n̪
+bbo	Bobo, North	Tansila	l̪
+bbo	Bobo, North	Tansila	r̪
+bbo	Bobo, North	Tansila	ɟ
+bbo	Bobo, North	Tansila	ɲ
+bbo	Bobo, North	Tansila	j
+bbo	Bobo, North	Tansila	k
+bbo	Bobo, North	Tansila	ɡ
+bbo	Bobo, North	Tansila	ɣ		[ɣ]
+bbo	Bobo, North	Tansila	ɣ		[x]
+bbo	Bobo, North	Tansila	ŋ
+bbo	Bobo, North	Tansila	ŋʷ
+bbo	Bobo, North	Tansila	kp
+bbo	Bobo, North	Tansila	ɡb
+bbo	Bobo, North	Tansila	h
+bbo	Bobo, North	Tansila	˦
+bbo	Bobo, North	Tansila	˨
+bbo	Bobo, North	Tansila	˧
+
 bez	Bena		pʰ				bez_Morrison.pdf
-bez	Bena		b				
-bez	Bena		m				
-bez	Bena		mb				
-bez	Bena		w				
-bez	Bena		f				
-bez	Bena		v		[ʋ]	intervocalic	
-bez	Bena		v		[v]		
-bez	Bena		tʰ				
-bez	Bena		d		[ɖ]	before lonɡ, non-hiɡh vowels	
-bez	Bena		d		[d]		
-bez	Bena		n				
-bez	Bena		s				
-bez	Bena		ts				
-bez	Bena		nd				
-bez	Bena		ns				
-bez	Bena		l				
-bez	Bena		ɲ				
-bez	Bena		j				
-bez	Bena		kʰ		[x]	in prefixes, and root-medially	
-bez	Bena		kʰ		[kʰ]		
-bez	Bena		ɡ				
-bez	Bena		ŋ				
-bez	Bena		ŋɡ				
-bez	Bena		h				
-bez	Bena		i		[i]		
-bez	Bena		i		[i̥]		
-bez	Bena		ɛ		[ɛ]		
-bez	Bena		ɛ		[ɛ̥]		
-bez	Bena		a		[a]		
-bez	Bena		a		[ḁ]		
-bez	Bena		u		[u]		
-bez	Bena		u		[u̥]		
-bez	Bena		o		[o]		
-bez	Bena		o		[o̥]		
-bez	Bena		iː				
-bez	Bena		eː				
-bez	Bena		aː				
-bez	Bena		uː				
-bez	Bena		oː				
-bez	Bena		˦		[˦˨]		
-bez	Bena		˦		[˦]		
-bez	Bena		˨				
-							
+bez	Bena		b
+bez	Bena		m
+bez	Bena		mb
+bez	Bena		w
+bez	Bena		f
+bez	Bena		v		[ʋ]	intervocalic
+bez	Bena		v		[v]
+bez	Bena		tʰ
+bez	Bena		d		[ɖ]	before lonɡ, non-hiɡh vowels
+bez	Bena		d		[d]
+bez	Bena		n
+bez	Bena		s
+bez	Bena		ts
+bez	Bena		nd
+bez	Bena		ns
+bez	Bena		l
+bez	Bena		ɲ
+bez	Bena		j
+bez	Bena		kʰ		[x]	in prefixes, and root-medially
+bez	Bena		kʰ		[kʰ]
+bez	Bena		ɡ
+bez	Bena		ŋ
+bez	Bena		ŋɡ
+bez	Bena		h
+bez	Bena		i		[i]
+bez	Bena		i		[i̥]
+bez	Bena		ɛ		[ɛ]
+bez	Bena		ɛ		[ɛ̥]
+bez	Bena		a		[a]
+bez	Bena		a		[ḁ]
+bez	Bena		u		[u]
+bez	Bena		u		[u̥]
+bez	Bena		o		[o]
+bez	Bena		o		[o̥]
+bez	Bena		iː
+bez	Bena		eː
+bez	Bena		aː
+bez	Bena		uː
+bez	Bena		oː
+bez	Bena		˦		[˦˨]
+bez	Bena		˦		[˦]
+bez	Bena		˨
+
 gkp	Kpelle, North		i				kpelle_guinea.pdf
-gkp	Kpelle, North		ĩ				
-gkp	Kpelle, North		e				
-gkp	Kpelle, North		ɛ				
-gkp	Kpelle, North		ɛ̃				
-gkp	Kpelle, North		a				
-gkp	Kpelle, North		ã				
-gkp	Kpelle, North		u				
-gkp	Kpelle, North		ũ				
-gkp	Kpelle, North		o				
-gkp	Kpelle, North		ɔ				
-gkp	Kpelle, North		ɔ̃				
-gkp	Kpelle, North		p				
-gkp	Kpelle, North		b				
-gkp	Kpelle, North		ɓ				
-gkp	Kpelle, North		m				
-gkp	Kpelle, North		hv				
-gkp	Kpelle, North		v				
-gkp	Kpelle, North		t				
-gkp	Kpelle, North		d				
-gkp	Kpelle, North		l				
-gkp	Kpelle, North		n				
-gkp	Kpelle, North		dz				
-gkp	Kpelle, North		j				
-gkp	Kpelle, North		ɲ				
-gkp	Kpelle, North		k				
-gkp	Kpelle, North		ɡ				
-gkp	Kpelle, North		h				
-gkp	Kpelle, North		ɣ				
-gkp	Kpelle, North		ŋ				
-gkp	Kpelle, North		kp				
-gkp	Kpelle, North		ɡb				
-gkp	Kpelle, North		w				
-gkp	Kpelle, North		ŋʷ				
-gkp	Kpelle, North		kʷ				
-gkp	Kpelle, North		ɡʷ				
-gkp	Kpelle, North		˦				
-gkp	Kpelle, North		˨				
-gkp	Kpelle, North		˧				
-							
+gkp	Kpelle, North		ĩ
+gkp	Kpelle, North		e
+gkp	Kpelle, North		ɛ
+gkp	Kpelle, North		ɛ̃
+gkp	Kpelle, North		a
+gkp	Kpelle, North		ã
+gkp	Kpelle, North		u
+gkp	Kpelle, North		ũ
+gkp	Kpelle, North		o
+gkp	Kpelle, North		ɔ
+gkp	Kpelle, North		ɔ̃
+gkp	Kpelle, North		p
+gkp	Kpelle, North		b
+gkp	Kpelle, North		ɓ
+gkp	Kpelle, North		m
+gkp	Kpelle, North		hv
+gkp	Kpelle, North		v
+gkp	Kpelle, North		t
+gkp	Kpelle, North		d
+gkp	Kpelle, North		l
+gkp	Kpelle, North		n
+gkp	Kpelle, North		dz
+gkp	Kpelle, North		j
+gkp	Kpelle, North		ɲ
+gkp	Kpelle, North		k
+gkp	Kpelle, North		ɡ
+gkp	Kpelle, North		h
+gkp	Kpelle, North		ɣ
+gkp	Kpelle, North		ŋ
+gkp	Kpelle, North		kp
+gkp	Kpelle, North		ɡb
+gkp	Kpelle, North		w
+gkp	Kpelle, North		ŋʷ
+gkp	Kpelle, North		kʷ
+gkp	Kpelle, North		ɡʷ
+gkp	Kpelle, North		˦
+gkp	Kpelle, North		˨
+gkp	Kpelle, North		˧
+
 kke	Kakabe		i				kke_russian.pdf
-kke	Kakabe		iː				
-kke	Kakabe		e				
-kke	Kakabe		eː				
-kke	Kakabe		ɛ				
-kke	Kakabe		ɛː				
-kke	Kakabe		u				
-kke	Kakabe		uː				
-kke	Kakabe		o				
-kke	Kakabe		oː				
-kke	Kakabe		ɔ				
-kke	Kakabe		ɔː				
-kke	Kakabe		a				
-kke	Kakabe		aː				
-kke	Kakabe		nd				
-kke	Kakabe		n̠d̠ʒ				
-kke	Kakabe		p				
-kke	Kakabe		t				
-kke	Kakabe		t̠ʃ				
-kke	Kakabe		k				
-kke	Kakabe		b				
-kke	Kakabe		d				
-kke	Kakabe		d̠ʒ				
-kke	Kakabe		ɡ				
-kke	Kakabe		ɡb				
-kke	Kakabe		f				
-kke	Kakabe		s				
-kke	Kakabe		h				
-kke	Kakabe		l				
-kke	Kakabe		r				
-kke	Kakabe		m				
-kke	Kakabe		n				
-kke	Kakabe		ɲ				
-kke	Kakabe		ŋ				
-kke	Kakabe		w				
-kke	Kakabe		j				
-kke	Kakabe		˦				
-kke	Kakabe		˨				
-							
+kke	Kakabe		iː
+kke	Kakabe		e
+kke	Kakabe		eː
+kke	Kakabe		ɛ
+kke	Kakabe		ɛː
+kke	Kakabe		u
+kke	Kakabe		uː
+kke	Kakabe		o
+kke	Kakabe		oː
+kke	Kakabe		ɔ
+kke	Kakabe		ɔː
+kke	Kakabe		a
+kke	Kakabe		aː
+kke	Kakabe		nd
+kke	Kakabe		n̠d̠ʒ
+kke	Kakabe		p
+kke	Kakabe		t
+kke	Kakabe		t̠ʃ
+kke	Kakabe		k
+kke	Kakabe		b
+kke	Kakabe		d
+kke	Kakabe		d̠ʒ
+kke	Kakabe		ɡ
+kke	Kakabe		ɡb
+kke	Kakabe		f
+kke	Kakabe		s
+kke	Kakabe		h
+kke	Kakabe		l
+kke	Kakabe		r
+kke	Kakabe		m
+kke	Kakabe		n
+kke	Kakabe		ɲ
+kke	Kakabe		ŋ
+kke	Kakabe		w
+kke	Kakabe		j
+kke	Kakabe		˦
+kke	Kakabe		˨
+
 llc	Lele		i				Lele_vydrine.pdf
-llc	Lele		e				
-llc	Lele		ɛ				
-llc	Lele		a				
-llc	Lele		ɔ				
-llc	Lele		o				
-llc	Lele		u				
-llc	Lele		ɓ				
-llc	Lele		ɗ				
-llc	Lele		k		[t̠ʃ]		
-llc	Lele		k		[k]		
-llc	Lele		d̠ʒ	free variation with [j]			
-llc	Lele		<ɡ>	rare			
-llc	Lele		kp	free variation with [ɡb]			
-llc	Lele		<v>	rare			
-llc	Lele		r		[r]		
-llc	Lele		r		[ɗ]		
-llc	Lele		p				
-llc	Lele		f				
-llc	Lele		w				
-llc	Lele		m				
-llc	Lele		t				
-llc	Lele		s				
-llc	Lele		l				
-llc	Lele		n				
-llc	Lele		j				
-llc	Lele		ɲ				
-llc	Lele		h				
-llc	Lele		˦				
-llc	Lele		˨				
-							
+llc	Lele		e
+llc	Lele		ɛ
+llc	Lele		a
+llc	Lele		ɔ
+llc	Lele		o
+llc	Lele		u
+llc	Lele		ɓ
+llc	Lele		ɗ
+llc	Lele		k		[t̠ʃ]
+llc	Lele		k		[k]
+llc	Lele		d̠ʒ	free variation with [j]
+llc	Lele		<ɡ>	rare
+llc	Lele		kp	free variation with [ɡb]
+llc	Lele		<v>	rare
+llc	Lele		r		[r]
+llc	Lele		r		[ɗ]
+llc	Lele		p
+llc	Lele		f
+llc	Lele		w
+llc	Lele		m
+llc	Lele		t
+llc	Lele		s
+llc	Lele		l
+llc	Lele		n
+llc	Lele		j
+llc	Lele		ɲ
+llc	Lele		h
+llc	Lele		˦
+llc	Lele		˨
+
 lom	Looma		pʰ				looma_mandenkan.pdf
-lom	Looma		b				
-lom	Looma		ɓ				
-lom	Looma		v				
-lom	Looma		tʰ				
-lom	Looma		d				
-lom	Looma		kʰ		[k̟]		
-lom	Looma		ɡ		[ɡ̟]		
-lom	Looma		kʰ		[kʰ]		
-lom	Looma		ɡ		[ɡ]		
-lom	Looma		kp				
-lom	Looma		ɡb				
-lom	Looma		f				
-lom	Looma		ʋ				
-lom	Looma		s				
-lom	Looma		ɣ				
-lom	Looma		m				
-lom	Looma		n				
-lom	Looma		ŋ				
-lom	Looma		l		[ɾ]		
-lom	Looma		l		[l]		
-lom	Looma		j				
-lom	Looma		w				
-lom	Looma		i		[i̠]		
-lom	Looma		e		[e̠]		
-lom	Looma		ɛ		[ɛ̠]		
-lom	Looma		i		[i]		
-lom	Looma		e		[e]		
-lom	Looma		ɛ		[ɛ]		
-lom	Looma		i		[i̞]		
-lom	Looma		a				
-lom	Looma		u				
-lom	Looma		o		[o̞]		
-lom	Looma		o		[o]		
-lom	Looma		ɔ				
-lom	Looma		z				
-lom	Looma		iː				
-lom	Looma		eː				
-lom	Looma		ɛː				
-lom	Looma		aː				
-lom	Looma		uː				
-lom	Looma		oː				
-lom	Looma		ɔː				
-lom	Looma		ĩ				
-lom	Looma		ẽ				
-lom	Looma		ɛ̃				
-lom	Looma		ã				
-lom	Looma		ũ				
-lom	Looma		õ				
-lom	Looma		ɔ̃				
-lom	Looma		ĩː				
-lom	Looma		ẽː				
-lom	Looma		ɛ̃ː				
-lom	Looma		ãː				
-lom	Looma		ũː				
-lom	Looma		õː				
-lom	Looma		ɔ̃ː				
-lom	Looma		˦				
-lom	Looma		˨				
-							
+lom	Looma		b
+lom	Looma		ɓ
+lom	Looma		v
+lom	Looma		tʰ
+lom	Looma		d
+lom	Looma		kʰ		[k̟]
+lom	Looma		ɡ		[ɡ̟]
+lom	Looma		kʰ		[kʰ]
+lom	Looma		ɡ		[ɡ]
+lom	Looma		kp
+lom	Looma		ɡb
+lom	Looma		f
+lom	Looma		ʋ
+lom	Looma		s
+lom	Looma		ɣ
+lom	Looma		m
+lom	Looma		n
+lom	Looma		ŋ
+lom	Looma		l		[ɾ]
+lom	Looma		l		[l]
+lom	Looma		j
+lom	Looma		w
+lom	Looma		i		[i̠]
+lom	Looma		e		[e̠]
+lom	Looma		ɛ		[ɛ̠]
+lom	Looma		i		[i]
+lom	Looma		e		[e]
+lom	Looma		ɛ		[ɛ]
+lom	Looma		i		[i̞]
+lom	Looma		a
+lom	Looma		u
+lom	Looma		o		[o̞]
+lom	Looma		o		[o]
+lom	Looma		ɔ
+lom	Looma		z
+lom	Looma		iː
+lom	Looma		eː
+lom	Looma		ɛː
+lom	Looma		aː
+lom	Looma		uː
+lom	Looma		oː
+lom	Looma		ɔː
+lom	Looma		ĩ
+lom	Looma		ẽ
+lom	Looma		ɛ̃
+lom	Looma		ã
+lom	Looma		ũ
+lom	Looma		õ
+lom	Looma		ɔ̃
+lom	Looma		ĩː
+lom	Looma		ẽː
+lom	Looma		ɛ̃ː
+lom	Looma		ãː
+lom	Looma		ũː
+lom	Looma		õː
+lom	Looma		ɔ̃ː
+lom	Looma		˦
+lom	Looma		˨
+
 mev	Mano		ɓ				mev.pdf
-mev	Mano		p				
-mev	Mano		b				
-mev	Mano		f				
-mev	Mano		v				
-mev	Mano		m				
-mev	Mano		w				
-mev	Mano		t				
-mev	Mano		d				
-mev	Mano		s				
-mev	Mano		z				
-mev	Mano		n				
-mev	Mano		l		[r]		
-mev	Mano		l		[l]		
-mev	Mano		ɲ				
-mev	Mano		j				
-mev	Mano		kɡ				
-mev	Mano		ŋ				
-mev	Mano		kʷ				
-mev	Mano		ɡʷ				
-mev	Mano		ŋʷ				
-mev	Mano		kp				
-mev	Mano		ɡb				
-mev	Mano		i				
-mev	Mano		ɛ				
-mev	Mano		e				
-mev	Mano		a				
-mev	Mano		ɔ				
-mev	Mano		o				
-mev	Mano		u				
-mev	Mano		ĩ				
-mev	Mano		ɛ̃				
-mev	Mano		ẽ				
-mev	Mano		ã				
-mev	Mano		ũ				
-mev	Mano		õ				
-mev	Mano		ɔ̃				
-mev	Mano		˦				
-mev	Mano		˨				
-mev	Mano		˧				
-							
+mev	Mano		p
+mev	Mano		b
+mev	Mano		f
+mev	Mano		v
+mev	Mano		m
+mev	Mano		w
+mev	Mano		t
+mev	Mano		d
+mev	Mano		s
+mev	Mano		z
+mev	Mano		n
+mev	Mano		l		[r]
+mev	Mano		l		[l]
+mev	Mano		ɲ
+mev	Mano		j
+mev	Mano		kɡ
+mev	Mano		ŋ
+mev	Mano		kʷ
+mev	Mano		ɡʷ
+mev	Mano		ŋʷ
+mev	Mano		kp
+mev	Mano		ɡb
+mev	Mano		i
+mev	Mano		ɛ
+mev	Mano		e
+mev	Mano		a
+mev	Mano		ɔ
+mev	Mano		o
+mev	Mano		u
+mev	Mano		ĩ
+mev	Mano		ɛ̃
+mev	Mano		ẽ
+mev	Mano		ã
+mev	Mano		ũ
+mev	Mano		õ
+mev	Mano		ɔ̃
+mev	Mano		˦
+mev	Mano		˨
+mev	Mano		˧
+
 tye	Kyanga		i				ross_kyanga.pdf
-tye	Kyanga		ĩ				
-tye	Kyanga		e				
-tye	Kyanga		ɛ				
-tye	Kyanga		ɛ̃				
-tye	Kyanga		a				
-tye	Kyanga		ã				
-tye	Kyanga		ɔ				
-tye	Kyanga		ɔ̃				
-tye	Kyanga		o				
-tye	Kyanga		u				
-tye	Kyanga		ũ				
-tye	Kyanga		b				
-tye	Kyanga		p				
-tye	Kyanga		v				
-tye	Kyanga		m				
-tye	Kyanga		w				
-tye	Kyanga		d				
-tye	Kyanga		t		[t̠ʃ]		
-tye	Kyanga		z		[ʒ]		
-tye	Kyanga		t		[t]		
-tye	Kyanga		z		[z]		
-tye	Kyanga		z		[d̠ʒ]		
-tye	Kyanga		n				
-tye	Kyanga		ŋ				
-tye	Kyanga		l		[n]		
-tye	Kyanga		l		[l]		
-tye	Kyanga		r				
-tye	Kyanga		f				
-tye	Kyanga		h				
-tye	Kyanga		j		[ɲ]		
-tye	Kyanga		j		[j]		
-tye	Kyanga		ɲ				
-tye	Kyanga		ɡ				
-tye	Kyanga		k				
-tye	Kyanga		s		[ʃ]		
-tye	Kyanga		s		[s]		
-tye	Kyanga		ɡb				
-tye	Kyanga		kp				
-tye	Kyanga		ʔ				
-tye	Kyanga		˦				
-tye	Kyanga		˨				
-tye	Kyanga		˧				
-							
+tye	Kyanga		ĩ
+tye	Kyanga		e
+tye	Kyanga		ɛ
+tye	Kyanga		ɛ̃
+tye	Kyanga		a
+tye	Kyanga		ã
+tye	Kyanga		ɔ
+tye	Kyanga		ɔ̃
+tye	Kyanga		o
+tye	Kyanga		u
+tye	Kyanga		ũ
+tye	Kyanga		b
+tye	Kyanga		p
+tye	Kyanga		v
+tye	Kyanga		m
+tye	Kyanga		w
+tye	Kyanga		d
+tye	Kyanga		t		[t̠ʃ]
+tye	Kyanga		z		[ʒ]
+tye	Kyanga		t		[t]
+tye	Kyanga		z		[z]
+tye	Kyanga		z		[d̠ʒ]
+tye	Kyanga		n
+tye	Kyanga		ŋ
+tye	Kyanga		l		[n]
+tye	Kyanga		l		[l]
+tye	Kyanga		r
+tye	Kyanga		f
+tye	Kyanga		h
+tye	Kyanga		j		[ɲ]
+tye	Kyanga		j		[j]
+tye	Kyanga		ɲ
+tye	Kyanga		ɡ
+tye	Kyanga		k
+tye	Kyanga		s		[ʃ]
+tye	Kyanga		s		[s]
+tye	Kyanga		ɡb
+tye	Kyanga		kp
+tye	Kyanga		ʔ
+tye	Kyanga		˦
+tye	Kyanga		˨
+tye	Kyanga		˧
+
 sho	Shanga		i				ross_kyanga.pdf
-sho	Shanga		ĩ				
-sho	Shanga		e				
-sho	Shanga		ɛ				
-sho	Shanga		ɛ̃				
-sho	Shanga		a				
-sho	Shanga		ã				
-sho	Shanga		ɔ				
-sho	Shanga		ɔ̃				
-sho	Shanga		o				
-sho	Shanga		u				
-sho	Shanga		ũ				
-sho	Shanga		b				
-sho	Shanga		p				
-sho	Shanga		v				
-sho	Shanga		m				
-sho	Shanga		w				
-sho	Shanga		d				
-sho	Shanga		t		[t̠ʃ]		
-sho	Shanga		z		[d̠ʒ]		
-sho	Shanga		t		[t]		
-sho	Shanga		z		[z]		
-sho	Shanga		n				
-sho	Shanga		ŋ				
-sho	Shanga		l		[n]		
-sho	Shanga		l		[l]		
-sho	Shanga		r				
-sho	Shanga		f				
-sho	Shanga		h				
-sho	Shanga		j		[ɲ]		
-sho	Shanga		j		[j]		
-sho	Shanga		ɲ				
-sho	Shanga		ɡ				
-sho	Shanga		k				
-sho	Shanga		s		[ʃ]		
-sho	Shanga		s		[s]		
-sho	Shanga		ɡb				
-sho	Shanga		kp				
-sho	Shanga		ʔ				
-sho	Shanga		˦				
-sho	Shanga		˨				
-sho	Shanga		˧				
-							
+sho	Shanga		ĩ
+sho	Shanga		e
+sho	Shanga		ɛ
+sho	Shanga		ɛ̃
+sho	Shanga		a
+sho	Shanga		ã
+sho	Shanga		ɔ
+sho	Shanga		ɔ̃
+sho	Shanga		o
+sho	Shanga		u
+sho	Shanga		ũ
+sho	Shanga		b
+sho	Shanga		p
+sho	Shanga		v
+sho	Shanga		m
+sho	Shanga		w
+sho	Shanga		d
+sho	Shanga		t		[t̠ʃ]
+sho	Shanga		z		[d̠ʒ]
+sho	Shanga		t		[t]
+sho	Shanga		z		[z]
+sho	Shanga		n
+sho	Shanga		ŋ
+sho	Shanga		l		[n]
+sho	Shanga		l		[l]
+sho	Shanga		r
+sho	Shanga		f
+sho	Shanga		h
+sho	Shanga		j		[ɲ]
+sho	Shanga		j		[j]
+sho	Shanga		ɲ
+sho	Shanga		ɡ
+sho	Shanga		k
+sho	Shanga		s		[ʃ]
+sho	Shanga		s		[s]
+sho	Shanga		ɡb
+sho	Shanga		kp
+sho	Shanga		ʔ
+sho	Shanga		˦
+sho	Shanga		˨
+sho	Shanga		˧
+
 abu	Abure		ʊ				abu.pdf
-abu	Abure		ʊ̃				
-abu	Abure		ɪ				
-abu	Abure		ɪ̃				
-abu	Abure		c		[c]		
-abu	Abure		ɟ		[ɟ]		
-abu	Abure		ɲ				
-abu	Abure		i				
-abu	Abure		u				
-abu	Abure		e				
-abu	Abure		o				
-abu	Abure		ɛ				
-abu	Abure		ɔ				
-abu	Abure		a				
-abu	Abure		ĩ				
-abu	Abure		ũ				
-abu	Abure		ã				
-abu	Abure		p				
-abu	Abure		b				
-abu	Abure		t				
-abu	Abure		d				
-abu	Abure		c		[t̠ʃ]		
-abu	Abure		ɟ		[d̠ʒ]		
-abu	Abure		k		[k]		
-abu	Abure		k		[ɡ]	post nasal	
-abu	Abure		kp				
-abu	Abure		ɡb				
-abu	Abure		f				
-abu	Abure		v		[v]		
-abu	Abure		v		[ɱ]	post nasal	
-abu	Abure		m				
-abu	Abure		n				
-abu	Abure		ɲ				
-abu	Abure		ŋ				
-abu	Abure		l		[ɬ]		
-abu	Abure		l		[r]		
-abu	Abure		l		[t]		
-abu	Abure		l		[d]		
-abu	Abure		l		[c]		
-abu	Abure		l		[ɟ]		
-abu	Abure		l		[r]		
-abu	Abure		j				
-abu	Abure		w		[w]		
-abu	Abure		w		[ŋm]	post nasal	
-abu	Abure		s				
-abu	Abure		h				
-abu	Abure		˦		[˦]		
-abu	Abure		˨		[˨]		
-abu	Abure		˦		[M+]	raised mid	
-abu	Abure		˨		[M-]	lowered mid	
-							
+abu	Abure		ʊ̃
+abu	Abure		ɪ
+abu	Abure		ɪ̃
+abu	Abure		c		[c]
+abu	Abure		ɟ		[ɟ]
+abu	Abure		ɲ
+abu	Abure		i
+abu	Abure		u
+abu	Abure		e
+abu	Abure		o
+abu	Abure		ɛ
+abu	Abure		ɔ
+abu	Abure		a
+abu	Abure		ĩ
+abu	Abure		ũ
+abu	Abure		ã
+abu	Abure		p
+abu	Abure		b
+abu	Abure		t
+abu	Abure		d
+abu	Abure		c		[t̠ʃ]
+abu	Abure		ɟ		[d̠ʒ]
+abu	Abure		k		[k]
+abu	Abure		k		[ɡ]	post nasal
+abu	Abure		kp
+abu	Abure		ɡb
+abu	Abure		f
+abu	Abure		v		[v]
+abu	Abure		v		[ɱ]	post nasal
+abu	Abure		m
+abu	Abure		n
+abu	Abure		ɲ
+abu	Abure		ŋ
+abu	Abure		l		[ɬ]
+abu	Abure		l		[r]
+abu	Abure		l		[t]
+abu	Abure		l		[d]
+abu	Abure		l		[c]
+abu	Abure		l		[ɟ]
+abu	Abure		l		[r]
+abu	Abure		j
+abu	Abure		w		[w]
+abu	Abure		w		[ŋm]	post nasal
+abu	Abure		s
+abu	Abure		h
+abu	Abure		˦		[˦]
+abu	Abure		˨		[˨]
+abu	Abure		˦		[M+]	raised mid
+abu	Abure		˨		[M-]	lowered mid
+
 abb	Bankon		˨˦				abb.pdf
-abb	Bankon		˦˨				
-abb	Bankon		˦				
-abb	Bankon		˨				
-abb	Bankon		i				
-abb	Bankon		e				
-abb	Bankon		ɛ				
-abb	Bankon		a				
-abb	Bankon		u				
-abb	Bankon		o				
-abb	Bankon		ɔ				
-abb	Bankon		ɓ		[ɓ]		
-abb	Bankon		ɓ		[b]	before hiɡh vowels	
-abb	Bankon		k		[k]		
-abb	Bankon		k		[ɡ]		
-abb	Bankon		k		[ɣ]	intervocalic	
-abb	Bankon		<r>				
-abb	Bankon		l		[l]		
-abb	Bankon		l		[d]		
-abb	Bankon		<ŋɡʷ>				
-abb	Bankon		<mbʷ>				
-abb	Bankon		p				
-abb	Bankon		m				
-abb	Bankon		bʷ	assumed to be phonemique, althouɡh this is not discussed by author, despite complementary distribution between ɓ and b			
-abb	Bankon		mʷ				
-abb	Bankon		w				
-abb	Bankon		f				
-abb	Bankon		t				
-abb	Bankon		d				
-abb	Bankon		s				
-abb	Bankon		n				
-abb	Bankon		nd				
-abb	Bankon		t̠ʃ				
-abb	Bankon		d̠ʒ				
-abb	Bankon		ɲ				
-abb	Bankon		n̠d̠ʒ				
-abb	Bankon		j				
-abb	Bankon		k				
-abb	Bankon		ŋ				
-abb	Bankon		ŋɡ				
-abb	Bankon		kʷ	free variation with kp			
-abb	Bankon		kp	free variation with kʷ			
-							
+abb	Bankon		˦˨
+abb	Bankon		˦
+abb	Bankon		˨
+abb	Bankon		i
+abb	Bankon		e
+abb	Bankon		ɛ
+abb	Bankon		a
+abb	Bankon		u
+abb	Bankon		o
+abb	Bankon		ɔ
+abb	Bankon		ɓ		[ɓ]
+abb	Bankon		ɓ		[b]	before hiɡh vowels
+abb	Bankon		k		[k]
+abb	Bankon		k		[ɡ]
+abb	Bankon		k		[ɣ]	intervocalic
+abb	Bankon		<r>
+abb	Bankon		l		[l]
+abb	Bankon		l		[d]
+abb	Bankon		<ŋɡʷ>
+abb	Bankon		<mbʷ>
+abb	Bankon		p
+abb	Bankon		m
+abb	Bankon		bʷ	assumed to be phonemique, althouɡh this is not discussed by author, despite complementary distribution between ɓ and b
+abb	Bankon		mʷ
+abb	Bankon		w
+abb	Bankon		f
+abb	Bankon		t
+abb	Bankon		d
+abb	Bankon		s
+abb	Bankon		n
+abb	Bankon		nd
+abb	Bankon		t̠ʃ
+abb	Bankon		d̠ʒ
+abb	Bankon		ɲ
+abb	Bankon		n̠d̠ʒ
+abb	Bankon		j
+abb	Bankon		k
+abb	Bankon		ŋ
+abb	Bankon		ŋɡ
+abb	Bankon		kʷ	free variation with kp
+abb	Bankon		kp	free variation with kʷ
+
 afu	Efutu		i				afu.pdf
-afu	Efutu		e				
-afu	Efutu		ɪ				
-afu	Efutu		ɛ				
-afu	Efutu		ɑ		[a]		
-afu	Efutu		ɑ		[æ]		
-afu	Efutu		ɑ		[ə]		
-afu	Efutu		o				
-afu	Efutu		ʊ				
-afu	Efutu		ɔ				
-afu	Efutu		u				
-afu	Efutu		ĩ				
-afu	Efutu		ẽ				
-afu	Efutu		ɪ̃				
-afu	Efutu		ɛ̃				
-afu	Efutu		ɑ̃		[ã]		
-afu	Efutu		ɑ̃		[æ̃]		
-afu	Efutu		ɑ̃		[ə̃]		
-afu	Efutu		õ				
-afu	Efutu		ʊ̃				
-afu	Efutu		ɔ̃				
-afu	Efutu		ũ				
-afu	Efutu		p				
-afu	Efutu		b				
-afu	Efutu		f				
-afu	Efutu		t				
-afu	Efutu		d				
-afu	Efutu		dᶣ				
-afu	Efutu		ts				
-afu	Efutu		s				
-afu	Efutu		tɕ				
-afu	Efutu		dʑ				
-afu	Efutu		r				
-afu	Efutu		l				
-afu	Efutu		ɕ				
-afu	Efutu		ʑ				
-afu	Efutu		j				
-afu	Efutu		k				
-afu	Efutu		ɡ				
-afu	Efutu		h				
-afu	Efutu		ʔ				
-afu	Efutu		m				
-afu	Efutu		n				
-afu	Efutu		ɲ				
-afu	Efutu		ɲᶣ				
-afu	Efutu		ɱ				
-afu	Efutu		ŋ				
-afu	Efutu		ŋʷ				
-afu	Efutu		ɥ				
-afu	Efutu		tɕᶣ				
-afu	Efutu		dʑᶣ				
-afu	Efutu		w				
-afu	Efutu		˦				
-afu	Efutu		˨				
-							
+afu	Efutu		e
+afu	Efutu		ɪ
+afu	Efutu		ɛ
+afu	Efutu		ɑ		[a]
+afu	Efutu		ɑ		[æ]
+afu	Efutu		ɑ		[ə]
+afu	Efutu		o
+afu	Efutu		ʊ
+afu	Efutu		ɔ
+afu	Efutu		u
+afu	Efutu		ĩ
+afu	Efutu		ẽ
+afu	Efutu		ɪ̃
+afu	Efutu		ɛ̃
+afu	Efutu		ɑ̃		[ã]
+afu	Efutu		ɑ̃		[æ̃]
+afu	Efutu		ɑ̃		[ə̃]
+afu	Efutu		õ
+afu	Efutu		ʊ̃
+afu	Efutu		ɔ̃
+afu	Efutu		ũ
+afu	Efutu		p
+afu	Efutu		b
+afu	Efutu		f
+afu	Efutu		t
+afu	Efutu		d
+afu	Efutu		dᶣ
+afu	Efutu		ts
+afu	Efutu		s
+afu	Efutu		tɕ
+afu	Efutu		dʑ
+afu	Efutu		r
+afu	Efutu		l
+afu	Efutu		ɕ
+afu	Efutu		ʑ
+afu	Efutu		j
+afu	Efutu		k
+afu	Efutu		ɡ
+afu	Efutu		h
+afu	Efutu		ʔ
+afu	Efutu		m
+afu	Efutu		n
+afu	Efutu		ɲ
+afu	Efutu		ɲᶣ
+afu	Efutu		ɱ
+afu	Efutu		ŋ
+afu	Efutu		ŋʷ
+afu	Efutu		ɥ
+afu	Efutu		tɕᶣ
+afu	Efutu		dʑᶣ
+afu	Efutu		w
+afu	Efutu		˦
+afu	Efutu		˨
+
 agq	Aghem		pʰ	only found before [u]			agq_hyman.pdf
-agq	Aghem		b				
-agq	Aghem		tʰ				
-agq	Aghem		d				
-agq	Aghem		kʰ				
-agq	Aghem		<ɡ>	rare			
-agq	Aghem		<kp>	rare			
-agq	Aghem		<ɡb>	rare			
-agq	Aghem		ʔ				
-agq	Aghem		f				
-agq	Aghem		v	only before [ʊ]			
-agq	Aghem		<ʃ>	rare			
-agq	Aghem		<ʒ>	rare			
-agq	Aghem		ɣ				
-agq	Aghem		pf	only before [ʊ]			
-agq	Aghem		ts				
-agq	Aghem		<t̠ʃ>	rare			
-agq	Aghem		bv				
-agq	Aghem		dz				
-agq	Aghem		<d̠ʒ>	rare			
-agq	Aghem		l				
-agq	Aghem		j				
-agq	Aghem		w		[w]		
-agq	Aghem		w		[ɥ]	before [i]	
-agq	Aghem		m				
-agq	Aghem		n				
-agq	Aghem		ɲ				
-agq	Aghem		ŋ				
-agq	Aghem		ŋm				
-agq	Aghem		i				
-agq	Aghem		ɪ		[ɪ]		
-agq	Aghem		ɪ		[ə]		
-agq	Aghem		e				
-agq	Aghem		ɛ				
-agq	Aghem		a				
-agq	Aghem		u				
-agq	Aghem		ʊ				
-agq	Aghem		o				
-agq	Aghem		ɔ				
-agq	Aghem		ɒ				
-agq	Aghem		iː				
-agq	Aghem		ɪː				
-agq	Aghem		eː				
-agq	Aghem		ɛː				
-agq	Aghem		aː				
-agq	Aghem		uː				
-agq	Aghem		oː				
-agq	Aghem		ɔː				
-agq	Aghem		ɒː				
-agq	Aghem		˦		[˦]		
-agq	Aghem		˨		[˨]		
-agq	Aghem		˦		[↓˦]		
-agq	Aghem		˨		[˨˥˩]	Low falling	
-							
+agq	Aghem		b
+agq	Aghem		tʰ
+agq	Aghem		d
+agq	Aghem		kʰ
+agq	Aghem		<ɡ>	rare
+agq	Aghem		<kp>	rare
+agq	Aghem		<ɡb>	rare
+agq	Aghem		ʔ
+agq	Aghem		f
+agq	Aghem		v	only before [ʊ]
+agq	Aghem		<ʃ>	rare
+agq	Aghem		<ʒ>	rare
+agq	Aghem		ɣ
+agq	Aghem		pf	only before [ʊ]
+agq	Aghem		ts
+agq	Aghem		<t̠ʃ>	rare
+agq	Aghem		bv
+agq	Aghem		dz
+agq	Aghem		<d̠ʒ>	rare
+agq	Aghem		l
+agq	Aghem		j
+agq	Aghem		w		[w]
+agq	Aghem		w		[ɥ]	before [i]
+agq	Aghem		m
+agq	Aghem		n
+agq	Aghem		ɲ
+agq	Aghem		ŋ
+agq	Aghem		ŋm
+agq	Aghem		i
+agq	Aghem		ɪ		[ɪ]
+agq	Aghem		ɪ		[ə]
+agq	Aghem		e
+agq	Aghem		ɛ
+agq	Aghem		a
+agq	Aghem		u
+agq	Aghem		ʊ
+agq	Aghem		o
+agq	Aghem		ɔ
+agq	Aghem		ɒ
+agq	Aghem		iː
+agq	Aghem		ɪː
+agq	Aghem		eː
+agq	Aghem		ɛː
+agq	Aghem		aː
+agq	Aghem		uː
+agq	Aghem		oː
+agq	Aghem		ɔː
+agq	Aghem		ɒː
+agq	Aghem		˦		[˦]
+agq	Aghem		˨		[˨]
+agq	Aghem		˦		[↓˦]
+agq	Aghem		˨		[˨˥˩]	Low falling
+
 arv	Arbore		<pʰ>	rare, likely restricted to loans			arv.pdf
-arv	Arbore		b				
-arv	Arbore		ɓ̥				
-arv	Arbore		m				
-arv	Arbore		f				
-arv	Arbore		<t̪ʰ>	rare, likely restricted to loans			
-arv	Arbore		d̪				
-arv	Arbore		ɗ				
-arv	Arbore		t̪ʼ				
-arv	Arbore		n				
-arv	Arbore		s				
-arv	Arbore		z				
-arv	Arbore		l				
-arv	Arbore		ɾ				
-arv	Arbore		t̠ʃʰ				
-arv	Arbore		d̠ʒ				
-arv	Arbore		t̠ʃʼ				
-arv	Arbore		ɲ				
-arv	Arbore		<ʃ>	marginal, sometimes in free variation with [s]			
-arv	Arbore		j				
-arv	Arbore		i̞				
-arv	Arbore		ɛ̝				
-arv	Arbore		kʰ				
-arv	Arbore		ɡ				
-arv	Arbore		kʼ				
-arv	Arbore		ŋ				
-arv	Arbore		w				
-arv	Arbore		u̞				
-arv	Arbore		ɔ̝				
-arv	Arbore		a				
-arv	Arbore		ʔ				
-arv	Arbore		h				
-arv	Arbore		bː				
-arv	Arbore		ɓ̥ː				
-arv	Arbore		mː				
-arv	Arbore		fː				
-arv	Arbore		<t̪ʰː>				
-arv	Arbore		d̪ː				
-arv	Arbore		ɗː				
-arv	Arbore		t̪ʼː				
-arv	Arbore		nː				
-arv	Arbore		sː				
-arv	Arbore		zː				
-arv	Arbore		lː				
-arv	Arbore		ɾː				
-arv	Arbore		t̠ʃʰː				
-arv	Arbore		d̠ʒː				
-arv	Arbore		t̠ʃʼː				
-arv	Arbore		ɲː				
-arv	Arbore		jː				
-arv	Arbore		kʰː				
-arv	Arbore		ɡː				
-arv	Arbore		kʼː				
-arv	Arbore		wː				
-arv	Arbore		i̞ː				
-arv	Arbore		ɛ̝ː				
-arv	Arbore		aː				
-arv	Arbore		u̞ː				
-arv	Arbore		ɔ̝ː				
-							
+arv	Arbore		b
+arv	Arbore		ɓ̥
+arv	Arbore		m
+arv	Arbore		f
+arv	Arbore		<t̪ʰ>	rare, likely restricted to loans
+arv	Arbore		d̪
+arv	Arbore		ɗ
+arv	Arbore		t̪ʼ
+arv	Arbore		n
+arv	Arbore		s
+arv	Arbore		z
+arv	Arbore		l
+arv	Arbore		ɾ
+arv	Arbore		t̠ʃʰ
+arv	Arbore		d̠ʒ
+arv	Arbore		t̠ʃʼ
+arv	Arbore		ɲ
+arv	Arbore		<ʃ>	marginal, sometimes in free variation with [s]
+arv	Arbore		j
+arv	Arbore		i̞
+arv	Arbore		ɛ̝
+arv	Arbore		kʰ
+arv	Arbore		ɡ
+arv	Arbore		kʼ
+arv	Arbore		ŋ
+arv	Arbore		w
+arv	Arbore		u̞
+arv	Arbore		ɔ̝
+arv	Arbore		a
+arv	Arbore		ʔ
+arv	Arbore		h
+arv	Arbore		bː
+arv	Arbore		ɓ̥ː
+arv	Arbore		mː
+arv	Arbore		fː
+arv	Arbore		<t̪ʰː>
+arv	Arbore		d̪ː
+arv	Arbore		ɗː
+arv	Arbore		t̪ʼː
+arv	Arbore		nː
+arv	Arbore		sː
+arv	Arbore		zː
+arv	Arbore		lː
+arv	Arbore		ɾː
+arv	Arbore		t̠ʃʰː
+arv	Arbore		d̠ʒː
+arv	Arbore		t̠ʃʼː
+arv	Arbore		ɲː
+arv	Arbore		jː
+arv	Arbore		kʰː
+arv	Arbore		ɡː
+arv	Arbore		kʼː
+arv	Arbore		wː
+arv	Arbore		i̞ː
+arv	Arbore		ɛ̝ː
+arv	Arbore		aː
+arv	Arbore		u̞ː
+arv	Arbore		ɔ̝ː
+
 abi	Abidji		i				abi_tresbarats.pdf
-abi	Abidji		ɪ				
-abi	Abidji		a				
-abi	Abidji		u				
-abi	Abidji		ʊ				
-abi	Abidji		o				
-abi	Abidji		ɔ				
-abi	Abidji		ĩ				
-abi	Abidji		ɪ̃				
-abi	Abidji		ã				
-abi	Abidji		ũ				
-abi	Abidji		ʊ̃				
-abi	Abidji		õ				
-abi	Abidji		ɔ̃				
-abi	Abidji		p				
-abi	Abidji		b		[b]		
-abi	Abidji		b		[mb]	post-nasal	
-abi	Abidji		f				
-abi	Abidji		m				
-abi	Abidji		w		[ɥ]	before [i]	
-abi	Abidji		w		[w̃]	nasal environment	
-abi	Abidji		w		[w]		
-abi	Abidji		t				
-abi	Abidji		d		[d]		
-abi	Abidji		d		[nd]	post-nasal	
-abi	Abidji		s				
-abi	Abidji		n				
-abi	Abidji		l	free variation with [r]			
-abi	Abidji		r		[r]		
-abi	Abidji		r		[n]	nasal environment	
-abi	Abidji		cç				
-abi	Abidji		ɟʝ		[ɟʝ]		
-abi	Abidji		ɟʝ		[ɲɟʝ]	post-nasal	
-abi	Abidji		ɲ				
-abi	Abidji		j		[j]		
-abi	Abidji		j		[j̃]	nasal environment	
-abi	Abidji		k				
-abi	Abidji		ɡ		[ɡ]		
-abi	Abidji		ɡ		[ŋɡ]	post-nasal	
-abi	Abidji		kp				
-abi	Abidji		ɡb		[ɡb]		
-abi	Abidji		ɡb		[ŋmɡb]	post-nasal	
-abi	Abidji		ʔ				
-abi	Abidji		h				
-abi	Abidji		i		[i]		
-abi	Abidji		i		[ĩ]		
-abi	Abidji		i		[ɪ]		
-abi	Abidji		i		[ɪ̃]		
-abi	Abidji		u		[u]		
-abi	Abidji		u		[ũ]		
-abi	Abidji		u		[ʊ]		
-abi	Abidji		u		[ʊ̃]		
-abi	Abidji		e		[e]		
-abi	Abidji		e		[ẽ]		
-abi	Abidji		e		[ɛ]		
-abi	Abidji		e		[ɛ̃]		
-abi	Abidji		o		[o]		
-abi	Abidji		o		[õ]		
-abi	Abidji		o		[ɔ]		
-abi	Abidji		o		[ɔ̃]		
-abi	Abidji		a		[a]		
-abi	Abidji		a		[ã]		
-abi	Abidji		˦				
-abi	Abidji		˨				
-							
+abi	Abidji		ɪ
+abi	Abidji		a
+abi	Abidji		u
+abi	Abidji		ʊ
+abi	Abidji		o
+abi	Abidji		ɔ
+abi	Abidji		ĩ
+abi	Abidji		ɪ̃
+abi	Abidji		ã
+abi	Abidji		ũ
+abi	Abidji		ʊ̃
+abi	Abidji		õ
+abi	Abidji		ɔ̃
+abi	Abidji		p
+abi	Abidji		b		[b]
+abi	Abidji		b		[mb]	post-nasal
+abi	Abidji		f
+abi	Abidji		m
+abi	Abidji		w		[ɥ]	before [i]
+abi	Abidji		w		[w̃]	nasal environment
+abi	Abidji		w		[w]
+abi	Abidji		t
+abi	Abidji		d		[d]
+abi	Abidji		d		[nd]	post-nasal
+abi	Abidji		s
+abi	Abidji		n
+abi	Abidji		l	free variation with [r]
+abi	Abidji		r		[r]
+abi	Abidji		r		[n]	nasal environment
+abi	Abidji		cç
+abi	Abidji		ɟʝ		[ɟʝ]
+abi	Abidji		ɟʝ		[ɲɟʝ]	post-nasal
+abi	Abidji		ɲ
+abi	Abidji		j		[j]
+abi	Abidji		j		[j̃]	nasal environment
+abi	Abidji		k
+abi	Abidji		ɡ		[ɡ]
+abi	Abidji		ɡ		[ŋɡ]	post-nasal
+abi	Abidji		kp
+abi	Abidji		ɡb		[ɡb]
+abi	Abidji		ɡb		[ŋmɡb]	post-nasal
+abi	Abidji		ʔ
+abi	Abidji		h
+abi	Abidji		i		[i]
+abi	Abidji		i		[ĩ]
+abi	Abidji		i		[ɪ]
+abi	Abidji		i		[ɪ̃]
+abi	Abidji		u		[u]
+abi	Abidji		u		[ũ]
+abi	Abidji		u		[ʊ]
+abi	Abidji		u		[ʊ̃]
+abi	Abidji		e		[e]
+abi	Abidji		e		[ẽ]
+abi	Abidji		e		[ɛ]
+abi	Abidji		e		[ɛ̃]
+abi	Abidji		o		[o]
+abi	Abidji		o		[õ]
+abi	Abidji		o		[ɔ]
+abi	Abidji		o		[ɔ̃]
+abi	Abidji		a		[a]
+abi	Abidji		a		[ã]
+abi	Abidji		˦
+abi	Abidji		˨
+
 adj	Adioukrou		˨˦				adj_herault.pdf
-adj	Adioukrou		˦				
-adj	Adioukrou		˨				
-adj	Adioukrou		˧				
-adj	Adioukrou		<p>	distribution is restricted compared to other consonants			
-adj	Adioukrou		b				
-adj	Adioukrou		t				
-adj	Adioukrou		d				
-adj	Adioukrou		t̠ʃ				
-adj	Adioukrou		d̠ʒ				
-adj	Adioukrou		k				
-adj	Adioukrou		ɡ				
-adj	Adioukrou		kp		[kp]		
-adj	Adioukrou		kp		[kpʷ]		
-adj	Adioukrou		ɡb				
-adj	Adioukrou		m				
-adj	Adioukrou		n				
-adj	Adioukrou		ɲ				
-adj	Adioukrou		ŋ		[ŋ]		
-adj	Adioukrou		ŋ		[w̃]		
-adj	Adioukrou		f				
-adj	Adioukrou		s				
-adj	Adioukrou		j				
-adj	Adioukrou		h				
-adj	Adioukrou		w				
-adj	Adioukrou		l				
-adj	Adioukrou		r				
-adj	Adioukrou		i				
-adj	Adioukrou		e				
-adj	Adioukrou		ɛ				
-adj	Adioukrou		u				
-adj	Adioukrou		o				
-adj	Adioukrou		ɔ				
-adj	Adioukrou		a				
-							
+adj	Adioukrou		˦
+adj	Adioukrou		˨
+adj	Adioukrou		˧
+adj	Adioukrou		<p>	distribution is restricted compared to other consonants
+adj	Adioukrou		b
+adj	Adioukrou		t
+adj	Adioukrou		d
+adj	Adioukrou		t̠ʃ
+adj	Adioukrou		d̠ʒ
+adj	Adioukrou		k
+adj	Adioukrou		ɡ
+adj	Adioukrou		kp		[kp]
+adj	Adioukrou		kp		[kpʷ]
+adj	Adioukrou		ɡb
+adj	Adioukrou		m
+adj	Adioukrou		n
+adj	Adioukrou		ɲ
+adj	Adioukrou		ŋ		[ŋ]
+adj	Adioukrou		ŋ		[w̃]
+adj	Adioukrou		f
+adj	Adioukrou		s
+adj	Adioukrou		j
+adj	Adioukrou		h
+adj	Adioukrou		w
+adj	Adioukrou		l
+adj	Adioukrou		r
+adj	Adioukrou		i
+adj	Adioukrou		e
+adj	Adioukrou		ɛ
+adj	Adioukrou		u
+adj	Adioukrou		o
+adj	Adioukrou		ɔ
+adj	Adioukrou		a
+
 ahi	Aizi, Tiagba		p				ahi.pdf
-ahi	Aizi, Tiagba		t				
-ahi	Aizi, Tiagba		<c>	rare			
-ahi	Aizi, Tiagba		k		[k]		
-ahi	Aizi, Tiagba		k		[c]		
-ahi	Aizi, Tiagba		kp				
-ahi	Aizi, Tiagba		b				
-ahi	Aizi, Tiagba		d				
-ahi	Aizi, Tiagba		<ɟ>	rare			
-ahi	Aizi, Tiagba		ɡ				
-ahi	Aizi, Tiagba		ɡb				
-ahi	Aizi, Tiagba		ɓ				
-ahi	Aizi, Tiagba		f				
-ahi	Aizi, Tiagba		v				
-ahi	Aizi, Tiagba		s				
-ahi	Aizi, Tiagba		z				
-ahi	Aizi, Tiagba		ʃ				
-ahi	Aizi, Tiagba		ʒ				
-ahi	Aizi, Tiagba		m				
-ahi	Aizi, Tiagba		n				
-ahi	Aizi, Tiagba		j				
-ahi	Aizi, Tiagba		ŋ				
-ahi	Aizi, Tiagba		ɲ				
-ahi	Aizi, Tiagba		w		[w]		
-ahi	Aizi, Tiagba		w		[ɥ]		
-ahi	Aizi, Tiagba		l		[l]	initial and intervocalic	
-ahi	Aizi, Tiagba		l		[ɗ]	before [i,ɪ,j,ɥ]	
-ahi	Aizi, Tiagba		l		[r]		
-ahi	Aizi, Tiagba		i				
-ahi	Aizi, Tiagba		ɪ				
-ahi	Aizi, Tiagba		e				
-ahi	Aizi, Tiagba		ɛ				
-ahi	Aizi, Tiagba		a				
-ahi	Aizi, Tiagba		o				
-ahi	Aizi, Tiagba		ʊ				
-ahi	Aizi, Tiagba		o				
-ahi	Aizi, Tiagba		ɔ				
-							
+ahi	Aizi, Tiagba		t
+ahi	Aizi, Tiagba		<c>	rare
+ahi	Aizi, Tiagba		k		[k]
+ahi	Aizi, Tiagba		k		[c]
+ahi	Aizi, Tiagba		kp
+ahi	Aizi, Tiagba		b
+ahi	Aizi, Tiagba		d
+ahi	Aizi, Tiagba		<ɟ>	rare
+ahi	Aizi, Tiagba		ɡ
+ahi	Aizi, Tiagba		ɡb
+ahi	Aizi, Tiagba		ɓ
+ahi	Aizi, Tiagba		f
+ahi	Aizi, Tiagba		v
+ahi	Aizi, Tiagba		s
+ahi	Aizi, Tiagba		z
+ahi	Aizi, Tiagba		ʃ
+ahi	Aizi, Tiagba		ʒ
+ahi	Aizi, Tiagba		m
+ahi	Aizi, Tiagba		n
+ahi	Aizi, Tiagba		j
+ahi	Aizi, Tiagba		ŋ
+ahi	Aizi, Tiagba		ɲ
+ahi	Aizi, Tiagba		w		[w]
+ahi	Aizi, Tiagba		w		[ɥ]
+ahi	Aizi, Tiagba		l		[l]	initial and intervocalic
+ahi	Aizi, Tiagba		l		[ɗ]	before [i,ɪ,j,ɥ]
+ahi	Aizi, Tiagba		l		[r]
+ahi	Aizi, Tiagba		i
+ahi	Aizi, Tiagba		ɪ
+ahi	Aizi, Tiagba		e
+ahi	Aizi, Tiagba		ɛ
+ahi	Aizi, Tiagba		a
+ahi	Aizi, Tiagba		o
+ahi	Aizi, Tiagba		ʊ
+ahi	Aizi, Tiagba		o
+ahi	Aizi, Tiagba		ɔ
+
 ald	Alladian		i				ald_duponchel.pdf
-ald	Alladian		ɪ				
-ald	Alladian		e				
-ald	Alladian		ɛ				
-ald	Alladian		a				
-ald	Alladian		ɔ				
-ald	Alladian		o				
-ald	Alladian		u				
-ald	Alladian		ã				
-ald	Alladian		õ				
-ald	Alladian		ẽ				
-ald	Alladian		p				
-ald	Alladian		b				
-ald	Alladian		t				
-ald	Alladian		d				
-ald	Alladian		c				
-ald	Alladian		ɟ				
-ald	Alladian		k				
-ald	Alladian		ɡ				
-ald	Alladian		kp				
-ald	Alladian		ɡb				
-ald	Alladian		f				
-ald	Alladian		v				
-ald	Alladian		s				
-ald	Alladian		z				
-ald	Alladian		ʃ				
-ald	Alladian		ʒ				
-ald	Alladian		j				
-ald	Alladian		ɥ				
-ald	Alladian		w				
-ald	Alladian		m				
-ald	Alladian		n				
-ald	Alladian		ɲ				
-ald	Alladian		l		[l]		
-ald	Alladian		l		[r]		
-ald	Alladian		l		[ɾ]		
-ald	Alladian		˦				
-ald	Alladian		˨				
-							
+ald	Alladian		ɪ
+ald	Alladian		e
+ald	Alladian		ɛ
+ald	Alladian		a
+ald	Alladian		ɔ
+ald	Alladian		o
+ald	Alladian		u
+ald	Alladian		ã
+ald	Alladian		õ
+ald	Alladian		ẽ
+ald	Alladian		p
+ald	Alladian		b
+ald	Alladian		t
+ald	Alladian		d
+ald	Alladian		c
+ald	Alladian		ɟ
+ald	Alladian		k
+ald	Alladian		ɡ
+ald	Alladian		kp
+ald	Alladian		ɡb
+ald	Alladian		f
+ald	Alladian		v
+ald	Alladian		s
+ald	Alladian		z
+ald	Alladian		ʃ
+ald	Alladian		ʒ
+ald	Alladian		j
+ald	Alladian		ɥ
+ald	Alladian		w
+ald	Alladian		m
+ald	Alladian		n
+ald	Alladian		ɲ
+ald	Alladian		l		[l]
+ald	Alladian		l		[r]
+ald	Alladian		l		[ɾ]
+ald	Alladian		˦
+ald	Alladian		˨
+
 ahs	Tinɔr		i				ahs_tinor.pdf
-ahs	Tinɔr		ɪ				
-ahs	Tinɔr		e				
-ahs	Tinɔr		ɛ				
-ahs	Tinɔr		a				
-ahs	Tinɔr		ʊ				
-ahs	Tinɔr		u				
-ahs	Tinɔr		o				
-ahs	Tinɔr		ɔ				
-ahs	Tinɔr		<p>				
-ahs	Tinɔr		b				
-ahs	Tinɔr		m				
-ahs	Tinɔr		f				
-ahs	Tinɔr		t				
-ahs	Tinɔr		d				
-ahs	Tinɔr		n				
-ahs	Tinɔr		r				
-ahs	Tinɔr		<ɽ>				
-ahs	Tinɔr		s				
-ahs	Tinɔr		z				
-ahs	Tinɔr		ʃ				
-ahs	Tinɔr		c				
-ahs	Tinɔr		ɟ				
-ahs	Tinɔr		ɲ				
-ahs	Tinɔr		j				
-ahs	Tinɔr		k				
-ahs	Tinɔr		ɡ				
-ahs	Tinɔr		ŋ				
-ahs	Tinɔr		ɣ	never word-medial			
-ahs	Tinɔr		kp				
-ahs	Tinɔr		ɡb				
-ahs	Tinɔr		w				
-ahs	Tinɔr		h				
-ahs	Tinɔr		˦				
-ahs	Tinɔr		˨				
-ahs	Tinɔr		˧				
-							
+ahs	Tinɔr		ɪ
+ahs	Tinɔr		e
+ahs	Tinɔr		ɛ
+ahs	Tinɔr		a
+ahs	Tinɔr		ʊ
+ahs	Tinɔr		u
+ahs	Tinɔr		o
+ahs	Tinɔr		ɔ
+ahs	Tinɔr		<p>
+ahs	Tinɔr		b
+ahs	Tinɔr		m
+ahs	Tinɔr		f
+ahs	Tinɔr		t
+ahs	Tinɔr		d
+ahs	Tinɔr		n
+ahs	Tinɔr		r
+ahs	Tinɔr		<ɽ>
+ahs	Tinɔr		s
+ahs	Tinɔr		z
+ahs	Tinɔr		ʃ
+ahs	Tinɔr		c
+ahs	Tinɔr		ɟ
+ahs	Tinɔr		ɲ
+ahs	Tinɔr		j
+ahs	Tinɔr		k
+ahs	Tinɔr		ɡ
+ahs	Tinɔr		ŋ
+ahs	Tinɔr		ɣ	never word-medial
+ahs	Tinɔr		kp
+ahs	Tinɔr		ɡb
+ahs	Tinɔr		w
+ahs	Tinɔr		h
+ahs	Tinɔr		˦
+ahs	Tinɔr		˨
+ahs	Tinɔr		˧
+
 zdj	Shindazidja	Washili	˦				zdj_patin.pdf
-zdj	Shindazidja	Washili	˨				
-zdj	Shindazidja	Washili	i				
-zdj	Shindazidja	Washili	e				
-zdj	Shindazidja	Washili	a				
-zdj	Shindazidja	Washili	o				
-zdj	Shindazidja	Washili	u				
-zdj	Shindazidja	Washili	p				
-zdj	Shindazidja	Washili	<b>	ɡenerally in borrowinɡs			
-zdj	Shindazidja	Washili	t̪				
-zdj	Shindazidja	Washili	<d̪>	generally in borrowings			
-zdj	Shindazidja	Washili	ʈ				
-zdj	Shindazidja	Washili	ɖ				
-zdj	Shindazidja	Washili	k				
-zdj	Shindazidja	Washili	ɡ				
-zdj	Shindazidja	Washili	<ʔ>	marginal			
-zdj	Shindazidja	Washili	ts				
-zdj	Shindazidja	Washili	dz				
-zdj	Shindazidja	Washili	t̠ʃ				
-zdj	Shindazidja	Washili	d̠ʒ				
-zdj	Shindazidja	Washili	ɓ				
-zdj	Shindazidja	Washili	ɗ				
-zdj	Shindazidja	Washili	β				
-zdj	Shindazidja	Washili	f				
-zdj	Shindazidja	Washili	v				
-zdj	Shindazidja	Washili	s				
-zdj	Shindazidja	Washili	z				
-zdj	Shindazidja	Washili	ʃ				
-zdj	Shindazidja	Washili	<ʒ>	in French borrowings			
-zdj	Shindazidja	Washili	h				
-zdj	Shindazidja	Washili	m				
-zdj	Shindazidja	Washili	n				
-zdj	Shindazidja	Washili	ɲ				
-zdj	Shindazidja	Washili	w				
-zdj	Shindazidja	Washili	l				
-zdj	Shindazidja	Washili	j				
-zdj	Shindazidja	Washili	r				
-zdj	Shindazidja	Washili	mb				
-zdj	Shindazidja	Washili	mɓ				
-zdj	Shindazidja	Washili	nt				
-zdj	Shindazidja	Washili	nd				
-zdj	Shindazidja	Washili	nts				
-zdj	Shindazidja	Washili	ndz				
-zdj	Shindazidja	Washili	nɗ				
-zdj	Shindazidja	Washili	n̠t̠ʃ				
-zdj	Shindazidja	Washili	n̠d̠ʒ				
-zdj	Shindazidja	Washili	ŋk				
-zdj	Shindazidja	Washili	ŋɡ				
-							
+zdj	Shindazidja	Washili	˨
+zdj	Shindazidja	Washili	i
+zdj	Shindazidja	Washili	e
+zdj	Shindazidja	Washili	a
+zdj	Shindazidja	Washili	o
+zdj	Shindazidja	Washili	u
+zdj	Shindazidja	Washili	p
+zdj	Shindazidja	Washili	<b>	ɡenerally in borrowinɡs
+zdj	Shindazidja	Washili	t̪
+zdj	Shindazidja	Washili	<d̪>	generally in borrowings
+zdj	Shindazidja	Washili	ʈ
+zdj	Shindazidja	Washili	ɖ
+zdj	Shindazidja	Washili	k
+zdj	Shindazidja	Washili	ɡ
+zdj	Shindazidja	Washili	<ʔ>	marginal
+zdj	Shindazidja	Washili	ts
+zdj	Shindazidja	Washili	dz
+zdj	Shindazidja	Washili	t̠ʃ
+zdj	Shindazidja	Washili	d̠ʒ
+zdj	Shindazidja	Washili	ɓ
+zdj	Shindazidja	Washili	ɗ
+zdj	Shindazidja	Washili	β
+zdj	Shindazidja	Washili	f
+zdj	Shindazidja	Washili	v
+zdj	Shindazidja	Washili	s
+zdj	Shindazidja	Washili	z
+zdj	Shindazidja	Washili	ʃ
+zdj	Shindazidja	Washili	<ʒ>	in French borrowings
+zdj	Shindazidja	Washili	h
+zdj	Shindazidja	Washili	m
+zdj	Shindazidja	Washili	n
+zdj	Shindazidja	Washili	ɲ
+zdj	Shindazidja	Washili	w
+zdj	Shindazidja	Washili	l
+zdj	Shindazidja	Washili	j
+zdj	Shindazidja	Washili	r
+zdj	Shindazidja	Washili	mb
+zdj	Shindazidja	Washili	mɓ
+zdj	Shindazidja	Washili	nt
+zdj	Shindazidja	Washili	nd
+zdj	Shindazidja	Washili	nts
+zdj	Shindazidja	Washili	ndz
+zdj	Shindazidja	Washili	nɗ
+zdj	Shindazidja	Washili	n̠t̠ʃ
+zdj	Shindazidja	Washili	n̠d̠ʒ
+zdj	Shindazidja	Washili	ŋk
+zdj	Shindazidja	Washili	ŋɡ
+
 ibe	Akpes	Daja	i				akpes.pdf
-ibe	Akpes	Daja	e				
-ibe	Akpes	Daja	ɛ				
-ibe	Akpes	Daja	a				
-ibe	Akpes	Daja	u				
-ibe	Akpes	Daja	o				
-ibe	Akpes	Daja	ɔ				
-ibe	Akpes	Daja	ã				
-ibe	Akpes	Daja	ɔ̃				
-ibe	Akpes	Daja	ɛ̃				
-ibe	Akpes	Daja	˦				
-ibe	Akpes	Daja	˨				
-ibe	Akpes	Daja	˧				
-ibe	Akpes	Daja	b				
-ibe	Akpes	Daja	m				
-ibe	Akpes	Daja	f				
-ibe	Akpes	Daja	t				
-ibe	Akpes	Daja	d				
-ibe	Akpes	Daja	n				
-ibe	Akpes	Daja	s				
-ibe	Akpes	Daja	r				
-ibe	Akpes	Daja	l				
-ibe	Akpes	Daja	ts				
-ibe	Akpes	Daja	dz				
-ibe	Akpes	Daja	ʃ				
-ibe	Akpes	Daja	j				
-ibe	Akpes	Daja	k				
-ibe	Akpes	Daja	ɡ				
-ibe	Akpes	Daja	ŋ				
-ibe	Akpes	Daja	x				
-ibe	Akpes	Daja	kp				
-ibe	Akpes	Daja	ɡb				
-ibe	Akpes	Daja	w				
-ibe	Akpes	Daja	h				
-							
+ibe	Akpes	Daja	e
+ibe	Akpes	Daja	ɛ
+ibe	Akpes	Daja	a
+ibe	Akpes	Daja	u
+ibe	Akpes	Daja	o
+ibe	Akpes	Daja	ɔ
+ibe	Akpes	Daja	ã
+ibe	Akpes	Daja	ɔ̃
+ibe	Akpes	Daja	ɛ̃
+ibe	Akpes	Daja	˦
+ibe	Akpes	Daja	˨
+ibe	Akpes	Daja	˧
+ibe	Akpes	Daja	b
+ibe	Akpes	Daja	m
+ibe	Akpes	Daja	f
+ibe	Akpes	Daja	t
+ibe	Akpes	Daja	d
+ibe	Akpes	Daja	n
+ibe	Akpes	Daja	s
+ibe	Akpes	Daja	r
+ibe	Akpes	Daja	l
+ibe	Akpes	Daja	ts
+ibe	Akpes	Daja	dz
+ibe	Akpes	Daja	ʃ
+ibe	Akpes	Daja	j
+ibe	Akpes	Daja	k
+ibe	Akpes	Daja	ɡ
+ibe	Akpes	Daja	ŋ
+ibe	Akpes	Daja	x
+ibe	Akpes	Daja	kp
+ibe	Akpes	Daja	ɡb
+ibe	Akpes	Daja	w
+ibe	Akpes	Daja	h
+
 etx	Iten		i				etx.pdf
-etx	Iten		e				
-etx	Iten		ɛ				
-etx	Iten		a				
-etx	Iten		o				
-etx	Iten		u				
-etx	Iten		p				
-etx	Iten		b				
-etx	Iten		ɸ				
-etx	Iten		β				
-etx	Iten		pf				
-etx	Iten		m				
-etx	Iten		w				
-etx	Iten		f				
-etx	Iten		v				
-etx	Iten		ⱱ				
-etx	Iten		t				
-etx	Iten		d				
-etx	Iten		s				
-etx	Iten		z				
-etx	Iten		ts				
-etx	Iten		dz				
-etx	Iten		n				
-etx	Iten		l				
-etx	Iten		t̠ʃ				
-etx	Iten		d̠ʒ				
-etx	Iten		ʃ				
-etx	Iten		ʒ				
-etx	Iten		ɾ				
-etx	Iten		ɲ				
-etx	Iten		j				
-etx	Iten		k				
-etx	Iten		ɡ				
-etx	Iten		h				
-etx	Iten		ŋ				
-etx	Iten		kp				
-etx	Iten		ɡb				
-etx	Iten		bʲ				
-etx	Iten		ɡʲ				
-etx	Iten		ɡbʲ				
-etx	Iten		hʲ				
-etx	Iten		kʲ				
-etx	Iten		kpʲ				
-etx	Iten		lʲ				
-etx	Iten		nʲ				
-etx	Iten		ɾʲ				
-etx	Iten		pʲ				
-etx	Iten		ɸʲ				
-etx	Iten		tʲ				
-etx	Iten		t̠ʃʷ				
-etx	Iten		dʷ				
-etx	Iten		dzʷ				
-etx	Iten		ɡʷ				
-etx	Iten		hʷ				
-etx	Iten		d̠ʒʷ				
-etx	Iten		lʷ				
-etx	Iten		mʷ				
-etx	Iten		nʷ				
-etx	Iten		ɾʷ				
-etx	Iten		ʃʷ				
-etx	Iten		tʷ				
-etx	Iten		tsʷ				
-etx	Iten		jʷ				
-etx	Iten		dʲʷ				
-etx	Iten		ɡʲʷ				
-etx	Iten		hʲʷ				
-etx	Iten		lʲʷ				
-etx	Iten		nʲʷ				
-etx	Iten		ɾʲʷ				
-etx	Iten		˦				
-etx	Iten		˨				
-etx	Iten		˧				
-etx	Iten		˨˦				
-etx	Iten		˦˨				
-							
+etx	Iten		e
+etx	Iten		ɛ
+etx	Iten		a
+etx	Iten		o
+etx	Iten		u
+etx	Iten		p
+etx	Iten		b
+etx	Iten		ɸ
+etx	Iten		β
+etx	Iten		pf
+etx	Iten		m
+etx	Iten		w
+etx	Iten		f
+etx	Iten		v
+etx	Iten		ⱱ
+etx	Iten		t
+etx	Iten		d
+etx	Iten		s
+etx	Iten		z
+etx	Iten		ts
+etx	Iten		dz
+etx	Iten		n
+etx	Iten		l
+etx	Iten		t̠ʃ
+etx	Iten		d̠ʒ
+etx	Iten		ʃ
+etx	Iten		ʒ
+etx	Iten		ɾ
+etx	Iten		ɲ
+etx	Iten		j
+etx	Iten		k
+etx	Iten		ɡ
+etx	Iten		h
+etx	Iten		ŋ
+etx	Iten		kp
+etx	Iten		ɡb
+etx	Iten		bʲ
+etx	Iten		ɡʲ
+etx	Iten		ɡbʲ
+etx	Iten		hʲ
+etx	Iten		kʲ
+etx	Iten		kpʲ
+etx	Iten		lʲ
+etx	Iten		nʲ
+etx	Iten		ɾʲ
+etx	Iten		pʲ
+etx	Iten		ɸʲ
+etx	Iten		tʲ
+etx	Iten		t̠ʃʷ
+etx	Iten		dʷ
+etx	Iten		dzʷ
+etx	Iten		ɡʷ
+etx	Iten		hʷ
+etx	Iten		d̠ʒʷ
+etx	Iten		lʷ
+etx	Iten		mʷ
+etx	Iten		nʷ
+etx	Iten		ɾʷ
+etx	Iten		ʃʷ
+etx	Iten		tʷ
+etx	Iten		tsʷ
+etx	Iten		jʷ
+etx	Iten		dʲʷ
+etx	Iten		ɡʲʷ
+etx	Iten		hʲʷ
+etx	Iten		lʲʷ
+etx	Iten		nʲʷ
+etx	Iten		ɾʲʷ
+etx	Iten		˦
+etx	Iten		˨
+etx	Iten		˧
+etx	Iten		˨˦
+etx	Iten		˦˨
+
 nus	Nuer		p				fwrightmathesis.pdf
-nus	Nuer		b				
-nus	Nuer		m				
-nus	Nuer		w				
-nus	Nuer		θ				
-nus	Nuer		ð				
-nus	Nuer		ɱ				
-nus	Nuer		t				
-nus	Nuer		d				
-nus	Nuer		n				
-nus	Nuer		r				
-nus	Nuer		l				
-nus	Nuer		c				
-nus	Nuer		ɟ				
-nus	Nuer		ɲ				
-nus	Nuer		j				
-nus	Nuer		k				
-nus	Nuer		ɡ				
-nus	Nuer		ŋ				
-nus	Nuer		ɦ				
-nus	Nuer		i				
-nus	Nuer		i̤				
-nus	Nuer		ɛ				
-nus	Nuer		ɛ̤				
-nus	Nuer		a				
-nus	Nuer		e̤				
-nus	Nuer		a̤				
-nus	Nuer		ɔ				
-nus	Nuer		ɔ̤				
-nus	Nuer		o				
-nus	Nuer		o̤				
-nus	Nuer		ṳ				
-nus	Nuer		æ̤				
-nus	Nuer		ʊ̤				
-nus	Nuer		iː				
-nus	Nuer		i̤ː				
-nus	Nuer		ɛː				
-nus	Nuer		ɛ̤ː				
-nus	Nuer		aː				
-nus	Nuer		e̤ː				
-nus	Nuer		a̤ː				
-nus	Nuer		ɔː				
-nus	Nuer		ɔ̤ː				
-nus	Nuer		oː				
-nus	Nuer		o̤ː				
-nus	Nuer		ṳː				
-nus	Nuer		æ̤ː				
-nus	Nuer		ʊ̤ː				
-							
+nus	Nuer		b
+nus	Nuer		m
+nus	Nuer		w
+nus	Nuer		θ
+nus	Nuer		ð
+nus	Nuer		ɱ
+nus	Nuer		t
+nus	Nuer		d
+nus	Nuer		n
+nus	Nuer		r
+nus	Nuer		l
+nus	Nuer		c
+nus	Nuer		ɟ
+nus	Nuer		ɲ
+nus	Nuer		j
+nus	Nuer		k
+nus	Nuer		ɡ
+nus	Nuer		ŋ
+nus	Nuer		ɦ
+nus	Nuer		i
+nus	Nuer		i̤
+nus	Nuer		ɛ
+nus	Nuer		ɛ̤
+nus	Nuer		a
+nus	Nuer		e̤
+nus	Nuer		a̤
+nus	Nuer		ɔ
+nus	Nuer		ɔ̤
+nus	Nuer		o
+nus	Nuer		o̤
+nus	Nuer		ṳ
+nus	Nuer		æ̤
+nus	Nuer		ʊ̤
+nus	Nuer		iː
+nus	Nuer		i̤ː
+nus	Nuer		ɛː
+nus	Nuer		ɛ̤ː
+nus	Nuer		aː
+nus	Nuer		e̤ː
+nus	Nuer		a̤ː
+nus	Nuer		ɔː
+nus	Nuer		ɔ̤ː
+nus	Nuer		oː
+nus	Nuer		o̤ː
+nus	Nuer		ṳː
+nus	Nuer		æ̤ː
+nus	Nuer		ʊ̤ː
+
 gel	West Kainji		i				gel.pdf
-gel	West Kainji		e				
-gel	West Kainji		ɛ				
-gel	West Kainji		ɘ				
-gel	West Kainji		a				
-gel	West Kainji		u				
-gel	West Kainji		o				
-gel	West Kainji		ɔ				
-gel	West Kainji		iː				
-gel	West Kainji		eː				
-gel	West Kainji		ɛː				
-gel	West Kainji		ɘː				
-gel	West Kainji		aː				
-gel	West Kainji		uː				
-gel	West Kainji		oː				
-gel	West Kainji		ɔː				
-gel	West Kainji		p				
-gel	West Kainji		b				
-gel	West Kainji		pʲ				
-gel	West Kainji		bʲ				
-gel	West Kainji		t				
-gel	West Kainji		d				
-gel	West Kainji		k				
-gel	West Kainji		ɡ				
-gel	West Kainji		kʷ				
-gel	West Kainji		ɡʷ				
-gel	West Kainji		kʲ				
-gel	West Kainji		ɡʲ				
-gel	West Kainji		<ʔ>	limited distribution			
-gel	West Kainji		t̠ʃ				
-gel	West Kainji		d̠ʒ				
-gel	West Kainji		t̠ʃʷ				
-gel	West Kainji		d̠ʒʷ				
-gel	West Kainji		f				
-gel	West Kainji		v				
-gel	West Kainji		vʲ				
-gel	West Kainji		s				
-gel	West Kainji		z				
-gel	West Kainji		sʷ				
-gel	West Kainji		zʷ				
-gel	West Kainji		ʃ				
-gel	West Kainji		h				
-gel	West Kainji		hʲ				
-gel	West Kainji		m				
-gel	West Kainji		mʲ				
-gel	West Kainji		n		[n]		
-gel	West Kainji		n		[ŋ]	before plosives	
-gel	West Kainji		nʲ				
-gel	West Kainji		r		[r]		
-gel	West Kainji		rʷ				
-gel	West Kainji		rʲ				
-gel	West Kainji		j				
-gel	West Kainji		w				
-gel	West Kainji		r		[lː]		
-gel	West Kainji		˦				
-gel	West Kainji		˨				
-gel	West Kainji		˧				
-gel	West Kainji		˥˩				
-							
+gel	West Kainji		e
+gel	West Kainji		ɛ
+gel	West Kainji		ɘ
+gel	West Kainji		a
+gel	West Kainji		u
+gel	West Kainji		o
+gel	West Kainji		ɔ
+gel	West Kainji		iː
+gel	West Kainji		eː
+gel	West Kainji		ɛː
+gel	West Kainji		ɘː
+gel	West Kainji		aː
+gel	West Kainji		uː
+gel	West Kainji		oː
+gel	West Kainji		ɔː
+gel	West Kainji		p
+gel	West Kainji		b
+gel	West Kainji		pʲ
+gel	West Kainji		bʲ
+gel	West Kainji		t
+gel	West Kainji		d
+gel	West Kainji		k
+gel	West Kainji		ɡ
+gel	West Kainji		kʷ
+gel	West Kainji		ɡʷ
+gel	West Kainji		kʲ
+gel	West Kainji		ɡʲ
+gel	West Kainji		<ʔ>	limited distribution
+gel	West Kainji		t̠ʃ
+gel	West Kainji		d̠ʒ
+gel	West Kainji		t̠ʃʷ
+gel	West Kainji		d̠ʒʷ
+gel	West Kainji		f
+gel	West Kainji		v
+gel	West Kainji		vʲ
+gel	West Kainji		s
+gel	West Kainji		z
+gel	West Kainji		sʷ
+gel	West Kainji		zʷ
+gel	West Kainji		ʃ
+gel	West Kainji		h
+gel	West Kainji		hʲ
+gel	West Kainji		m
+gel	West Kainji		mʲ
+gel	West Kainji		n		[n]
+gel	West Kainji		n		[ŋ]	before plosives
+gel	West Kainji		nʲ
+gel	West Kainji		r		[r]
+gel	West Kainji		rʷ
+gel	West Kainji		rʲ
+gel	West Kainji		j
+gel	West Kainji		w
+gel	West Kainji		r		[lː]
+gel	West Kainji		˦
+gel	West Kainji		˨
+gel	West Kainji		˧
+gel	West Kainji		˥˩
+
 idu	Idu		i		[i]		idu.pdf
-idu	Idu		ɪ		[ɪ]		
-idu	Idu		e		[e]		
-idu	Idu		ɛ		[ɛ]		
-idu	Idu		a		[a]		
-idu	Idu		ɔ		[ɔ]		
-idu	Idu		o		[o]		
-idu	Idu		ʊ		[ʊ]		
-idu	Idu		u		[u]		
-idu	Idu		ĩ				
-idu	Idu		ẽ				
-idu	Idu		ɛ̃				
-idu	Idu		ã				
-idu	Idu		ɔ̃				
-idu	Idu		õ				
-idu	Idu		ũ				
-idu	Idu		i		[ĩ]		
-idu	Idu		ɪ		[ɪ̃]		
-idu	Idu		e		[ẽ]		
-idu	Idu		ɛ		[ɛ̃]		
-idu	Idu		a		[ã]		
-idu	Idu		ɔ		[ɔ̃]		
-idu	Idu		o		[õ]		
-idu	Idu		ʊ		[ʊ̃]		
-idu	Idu		u		[ũ]		
-idu	Idu		iː		[iː]		
-idu	Idu		eː		[eː]		
-idu	Idu		ɛː		[ɛː]		
-idu	Idu		aː		[aː]		
-idu	Idu		uː		[uː]		
-idu	Idu		oː		[oː]		
-idu	Idu		ɔː		[ɔː]		
-idu	Idu		iː		[ĩː]	word-final	
-idu	Idu		eː		[ẽː]	word-final	
-idu	Idu		ɛː		[ɛ̃ː]	word-final	
-idu	Idu		aː		[ãː]	word-final	
-idu	Idu		uː		[ũː]	word-final	
-idu	Idu		oː		[õː]	word-final	
-idu	Idu		ɔː		[ɔ̃ː]	word-final	
-idu	Idu		p				
-idu	Idu		b				
-idu	Idu		m				
-idu	Idu		pf				
-idu	Idu		bv				
-idu	Idu		f				
-idu	Idu		v				
-idu	Idu		t				
-idu	Idu		d				
-idu	Idu		n				
-idu	Idu		r		[ɾ]	root-initial	
-idu	Idu		r		[r]		
-idu	Idu		s				
-idu	Idu		z				
-idu	Idu		ts				
-idu	Idu		dz				
-idu	Idu		ʃ				
-idu	Idu		ʒ				
-idu	Idu		<l>	Hausa loanwords			
-idu	Idu		ɽ				
-idu	Idu		c				
-idu	Idu		ɟ				
-idu	Idu		j				
-idu	Idu		k				
-idu	Idu		ɡ				
-idu	Idu		ŋ				
-idu	Idu		x				
-idu	Idu		ɣ				
-idu	Idu		kp				
-idu	Idu		ɡb				
-idu	Idu		w				
-idu	Idu		<ɥ>	rare			
-idu	Idu		h				
-idu	Idu		xʷ				
-idu	Idu		<ŋʷ>	marginal			
-idu	Idu		<hʷ>	marginal			
-idu	Idu		<bvʷ>	marginal			
-idu	Idu		<ɡʲʷ>	marginal			
-idu	Idu		<d̠ʒʷ>	marginal			
-idu	Idu		<ɣʷ>	marginal			
-idu	Idu		<kʲ>	marginal			
-idu	Idu		<zʲ>	marginal			
-idu	Idu		<wʲ>	marginal			
-idu	Idu		ŋmɡb				
-idu	Idu		mpf				
-idu	Idu		ŋʷ				
-idu	Idu		ŋɡ				
-idu	Idu		nd				
-idu	Idu		ndz				
-idu	Idu		˦				
-idu	Idu		˨				
-idu	Idu		˧				
-idu	Idu		˨˦				
-idu	Idu		˦˨				
-							
+idu	Idu		ɪ		[ɪ]
+idu	Idu		e		[e]
+idu	Idu		ɛ		[ɛ]
+idu	Idu		a		[a]
+idu	Idu		ɔ		[ɔ]
+idu	Idu		o		[o]
+idu	Idu		ʊ		[ʊ]
+idu	Idu		u		[u]
+idu	Idu		ĩ
+idu	Idu		ẽ
+idu	Idu		ɛ̃
+idu	Idu		ã
+idu	Idu		ɔ̃
+idu	Idu		õ
+idu	Idu		ũ
+idu	Idu		i		[ĩ]
+idu	Idu		ɪ		[ɪ̃]
+idu	Idu		e		[ẽ]
+idu	Idu		ɛ		[ɛ̃]
+idu	Idu		a		[ã]
+idu	Idu		ɔ		[ɔ̃]
+idu	Idu		o		[õ]
+idu	Idu		ʊ		[ʊ̃]
+idu	Idu		u		[ũ]
+idu	Idu		iː		[iː]
+idu	Idu		eː		[eː]
+idu	Idu		ɛː		[ɛː]
+idu	Idu		aː		[aː]
+idu	Idu		uː		[uː]
+idu	Idu		oː		[oː]
+idu	Idu		ɔː		[ɔː]
+idu	Idu		iː		[ĩː]	word-final
+idu	Idu		eː		[ẽː]	word-final
+idu	Idu		ɛː		[ɛ̃ː]	word-final
+idu	Idu		aː		[ãː]	word-final
+idu	Idu		uː		[ũː]	word-final
+idu	Idu		oː		[õː]	word-final
+idu	Idu		ɔː		[ɔ̃ː]	word-final
+idu	Idu		p
+idu	Idu		b
+idu	Idu		m
+idu	Idu		pf
+idu	Idu		bv
+idu	Idu		f
+idu	Idu		v
+idu	Idu		t
+idu	Idu		d
+idu	Idu		n
+idu	Idu		r		[ɾ]	root-initial
+idu	Idu		r		[r]
+idu	Idu		s
+idu	Idu		z
+idu	Idu		ts
+idu	Idu		dz
+idu	Idu		ʃ
+idu	Idu		ʒ
+idu	Idu		<l>	Hausa loanwords
+idu	Idu		ɽ
+idu	Idu		c
+idu	Idu		ɟ
+idu	Idu		j
+idu	Idu		k
+idu	Idu		ɡ
+idu	Idu		ŋ
+idu	Idu		x
+idu	Idu		ɣ
+idu	Idu		kp
+idu	Idu		ɡb
+idu	Idu		w
+idu	Idu		<ɥ>	rare
+idu	Idu		h
+idu	Idu		xʷ
+idu	Idu		<ŋʷ>	marginal
+idu	Idu		<hʷ>	marginal
+idu	Idu		<bvʷ>	marginal
+idu	Idu		<ɡʲʷ>	marginal
+idu	Idu		<d̠ʒʷ>	marginal
+idu	Idu		<ɣʷ>	marginal
+idu	Idu		<kʲ>	marginal
+idu	Idu		<zʲ>	marginal
+idu	Idu		<wʲ>	marginal
+idu	Idu		ŋmɡb
+idu	Idu		mpf
+idu	Idu		ŋʷ
+idu	Idu		ŋɡ
+idu	Idu		nd
+idu	Idu		ndz
+idu	Idu		˦
+idu	Idu		˨
+idu	Idu		˧
+idu	Idu		˨˦
+idu	Idu		˦˨
+
 iri	Rigwe		i				iri.pdf
-iri	Rigwe		ĩ				
-iri	Rigwe		e				
-iri	Rigwe		ẽ				
-iri	Rigwe		ɛ				
-iri	Rigwe		ɛ̃				
-iri	Rigwe		a				
-iri	Rigwe		ã				
-iri	Rigwe		u				
-iri	Rigwe		ũ				
-iri	Rigwe		ɔ				
-iri	Rigwe		ɔ̃				
-iri	Rigwe		p				
-iri	Rigwe		pʲ				
-iri	Rigwe		b				
-iri	Rigwe		bʲ				
-iri	Rigwe		m				
-iri	Rigwe		mʲ				
-iri	Rigwe		mʷ				
-iri	Rigwe		ps				
-iri	Rigwe		ʙ				
-iri	Rigwe		ɱ				
-iri	Rigwe		f				
-iri	Rigwe		fʲ				
-iri	Rigwe		v				
-iri	Rigwe		vʲ				
-iri	Rigwe		ð				
-iri	Rigwe		ðʲ				
-iri	Rigwe		t				
-iri	Rigwe		d				
-iri	Rigwe		n				
-iri	Rigwe		s				
-iri	Rigwe		z				
-iri	Rigwe		ts				
-iri	Rigwe		tsʲ				
-iri	Rigwe		ɾ				
-iri	Rigwe		ɾʲ				
-iri	Rigwe		ɾʷ				
-iri	Rigwe		r				
-iri	Rigwe		rʷ				
-iri	Rigwe		rʲ				
-iri	Rigwe		ɬ				
-iri	Rigwe		ʃ				
-iri	Rigwe		ʃʷ				
-iri	Rigwe		ʒ				
-iri	Rigwe		ʒʷ				
-iri	Rigwe		t̠ʃ				
-iri	Rigwe		t̠ʃʷ				
-iri	Rigwe		d̠ʒ				
-iri	Rigwe		d̠ʒʷ				
-iri	Rigwe		c				
-iri	Rigwe		cʲ				
-iri	Rigwe		cʷ				
-iri	Rigwe		ɟ				
-iri	Rigwe		ɟʲ				
-iri	Rigwe		ɟʷ				
-iri	Rigwe		ɲ				
-iri	Rigwe		ɲʷ				
-iri	Rigwe		tɕ				
-iri	Rigwe		tɕʷ				
-iri	Rigwe		jʷ				
-iri	Rigwe		j				
-iri	Rigwe		j̥ʷ				
-iri	Rigwe		k				
-iri	Rigwe		kʷ				
-iri	Rigwe		ɡ				
-iri	Rigwe		ɡʷ				
-iri	Rigwe		ŋ				
-iri	Rigwe		ŋʷ				
-iri	Rigwe		ŋʲʷ				
-iri	Rigwe		kp				
-iri	Rigwe		ɡb				
-iri	Rigwe		ŋm				
-iri	Rigwe		ʍ				
-iri	Rigwe		ʍʲ				
-iri	Rigwe		w				
-iri	Rigwe		wʲ				
-iri	Rigwe		h				
-iri	Rigwe		hʲ				
-iri	Rigwe		ˀk				
-iri	Rigwe		ˀkp				
-iri	Rigwe		ˀɡb				
-iri	Rigwe		ˀɡʷ				
-iri	Rigwe		ˀs				
-iri	Rigwe		ˀc				
-iri	Rigwe		ˀʃʷ				
-iri	Rigwe		ˀʍ				
-iri	Rigwe		ˀʍʲ				
-iri	Rigwe		ˀj				
-iri	Rigwe		ˀb				
-iri	Rigwe		ɲː				
-iri	Rigwe		˦				
-iri	Rigwe		˨				
-iri	Rigwe		˧				
-iri	Rigwe		˩				
-							
+iri	Rigwe		ĩ
+iri	Rigwe		e
+iri	Rigwe		ẽ
+iri	Rigwe		ɛ
+iri	Rigwe		ɛ̃
+iri	Rigwe		a
+iri	Rigwe		ã
+iri	Rigwe		u
+iri	Rigwe		ũ
+iri	Rigwe		ɔ
+iri	Rigwe		ɔ̃
+iri	Rigwe		p
+iri	Rigwe		pʲ
+iri	Rigwe		b
+iri	Rigwe		bʲ
+iri	Rigwe		m
+iri	Rigwe		mʲ
+iri	Rigwe		mʷ
+iri	Rigwe		ps
+iri	Rigwe		ʙ
+iri	Rigwe		ɱ
+iri	Rigwe		f
+iri	Rigwe		fʲ
+iri	Rigwe		v
+iri	Rigwe		vʲ
+iri	Rigwe		ð
+iri	Rigwe		ðʲ
+iri	Rigwe		t
+iri	Rigwe		d
+iri	Rigwe		n
+iri	Rigwe		s
+iri	Rigwe		z
+iri	Rigwe		ts
+iri	Rigwe		tsʲ
+iri	Rigwe		ɾ
+iri	Rigwe		ɾʲ
+iri	Rigwe		ɾʷ
+iri	Rigwe		r
+iri	Rigwe		rʷ
+iri	Rigwe		rʲ
+iri	Rigwe		ɬ
+iri	Rigwe		ʃ
+iri	Rigwe		ʃʷ
+iri	Rigwe		ʒ
+iri	Rigwe		ʒʷ
+iri	Rigwe		t̠ʃ
+iri	Rigwe		t̠ʃʷ
+iri	Rigwe		d̠ʒ
+iri	Rigwe		d̠ʒʷ
+iri	Rigwe		c
+iri	Rigwe		cʲ
+iri	Rigwe		cʷ
+iri	Rigwe		ɟ
+iri	Rigwe		ɟʲ
+iri	Rigwe		ɟʷ
+iri	Rigwe		ɲ
+iri	Rigwe		ɲʷ
+iri	Rigwe		tɕ
+iri	Rigwe		tɕʷ
+iri	Rigwe		jʷ
+iri	Rigwe		j
+iri	Rigwe		j̥ʷ
+iri	Rigwe		k
+iri	Rigwe		kʷ
+iri	Rigwe		ɡ
+iri	Rigwe		ɡʷ
+iri	Rigwe		ŋ
+iri	Rigwe		ŋʷ
+iri	Rigwe		ŋʲʷ
+iri	Rigwe		kp
+iri	Rigwe		ɡb
+iri	Rigwe		ŋm
+iri	Rigwe		ʍ
+iri	Rigwe		ʍʲ
+iri	Rigwe		w
+iri	Rigwe		wʲ
+iri	Rigwe		h
+iri	Rigwe		hʲ
+iri	Rigwe		ˀk
+iri	Rigwe		ˀkp
+iri	Rigwe		ˀɡb
+iri	Rigwe		ˀɡʷ
+iri	Rigwe		ˀs
+iri	Rigwe		ˀc
+iri	Rigwe		ˀʃʷ
+iri	Rigwe		ˀʍ
+iri	Rigwe		ˀʍʲ
+iri	Rigwe		ˀj
+iri	Rigwe		ˀb
+iri	Rigwe		ɲː
+iri	Rigwe		˦
+iri	Rigwe		˨
+iri	Rigwe		˧
+iri	Rigwe		˩
+
 izr	Izere		p				izr.pdf
-izr	Izere		b				
-izr	Izere		<ɸ>	controversial			
-izr	Izere		f				
-izr	Izere		v				
-izr	Izere		t				
-izr	Izere		d				
-izr	Izere		n				
-izr	Izere		r				
-izr	Izere		s				
-izr	Izere		z				
-izr	Izere		ts				
-izr	Izere		l				
-izr	Izere		ʃ				
-izr	Izere		ʒ				
-izr	Izere		c				
-izr	Izere		ɟ				
-izr	Izere		ɲ				
-izr	Izere		j				
-izr	Izere		k				
-izr	Izere		ɡ				
-izr	Izere		ŋ				
-izr	Izere		kp				
-izr	Izere		ɡb				
-izr	Izere		ŋm				
-izr	Izere		w				
-izr	Izere		h				
-izr	Izere		i				
-izr	Izere		e				
-izr	Izere		ɛ				
-izr	Izere		a				
-izr	Izere		ɔ				
-izr	Izere		o				
-izr	Izere		u				
-izr	Izere		˦				
-izr	Izere		˨				
-izr	Izere		˧				
-izr	Izere		<˨˦>	loanwords			
-izr	Izere		<˦˨>	loanwords			
-							
+izr	Izere		b
+izr	Izere		<ɸ>	controversial
+izr	Izere		f
+izr	Izere		v
+izr	Izere		t
+izr	Izere		d
+izr	Izere		n
+izr	Izere		r
+izr	Izere		s
+izr	Izere		z
+izr	Izere		ts
+izr	Izere		l
+izr	Izere		ʃ
+izr	Izere		ʒ
+izr	Izere		c
+izr	Izere		ɟ
+izr	Izere		ɲ
+izr	Izere		j
+izr	Izere		k
+izr	Izere		ɡ
+izr	Izere		ŋ
+izr	Izere		kp
+izr	Izere		ɡb
+izr	Izere		ŋm
+izr	Izere		w
+izr	Izere		h
+izr	Izere		i
+izr	Izere		e
+izr	Izere		ɛ
+izr	Izere		a
+izr	Izere		ɔ
+izr	Izere		o
+izr	Izere		u
+izr	Izere		˦
+izr	Izere		˨
+izr	Izere		˧
+izr	Izere		<˨˦>	loanwords
+izr	Izere		<˦˨>	loanwords
+
 jer	Jere	Eboze	i				jer_eboze.pdf
-jer	Jere	Eboze	e				
-jer	Jere	Eboze	ɛ				
-jer	Jere	Eboze	ə				
-jer	Jere	Eboze	a				
-jer	Jere	Eboze	ɔ				
-jer	Jere	Eboze	o				
-jer	Jere	Eboze	u				
-jer	Jere	Eboze	iː				
-jer	Jere	Eboze	eː				
-jer	Jere	Eboze	ɛː				
-jer	Jere	Eboze	aː				
-jer	Jere	Eboze	əː				
-jer	Jere	Eboze	ɔː				
-jer	Jere	Eboze	oː				
-jer	Jere	Eboze	uː				
-jer	Jere	Eboze	p				
-jer	Jere	Eboze	b				
-jer	Jere	Eboze	m				
-jer	Jere	Eboze	f				
-jer	Jere	Eboze	v				
-jer	Jere	Eboze	t				
-jer	Jere	Eboze	d				
-jer	Jere	Eboze	n				
-jer	Jere	Eboze	r				
-jer	Jere	Eboze	s				
-jer	Jere	Eboze	z				
-jer	Jere	Eboze	l				
-jer	Jere	Eboze	ʃ				
-jer	Jere	Eboze	ʒ				
-jer	Jere	Eboze	t̠ʃ				
-jer	Jere	Eboze	d̠ʒ				
-jer	Jere	Eboze	ɲ				
-jer	Jere	Eboze	j				
-jer	Jere	Eboze	k				
-jer	Jere	Eboze	ɡ				
-jer	Jere	Eboze	ŋ				
-jer	Jere	Eboze	ɡb	alternates freely with [ɡʷ] and [ɡbʷ]			
-jer	Jere	Eboze	w				
-jer	Jere	Eboze	h				
-jer	Jere	Eboze	˦				
-jer	Jere	Eboze	˨				
-jer	Jere	Eboze	˧				
-jer	Jere	Eboze	˥				
-							
+jer	Jere	Eboze	e
+jer	Jere	Eboze	ɛ
+jer	Jere	Eboze	ə
+jer	Jere	Eboze	a
+jer	Jere	Eboze	ɔ
+jer	Jere	Eboze	o
+jer	Jere	Eboze	u
+jer	Jere	Eboze	iː
+jer	Jere	Eboze	eː
+jer	Jere	Eboze	ɛː
+jer	Jere	Eboze	aː
+jer	Jere	Eboze	əː
+jer	Jere	Eboze	ɔː
+jer	Jere	Eboze	oː
+jer	Jere	Eboze	uː
+jer	Jere	Eboze	p
+jer	Jere	Eboze	b
+jer	Jere	Eboze	m
+jer	Jere	Eboze	f
+jer	Jere	Eboze	v
+jer	Jere	Eboze	t
+jer	Jere	Eboze	d
+jer	Jere	Eboze	n
+jer	Jere	Eboze	r
+jer	Jere	Eboze	s
+jer	Jere	Eboze	z
+jer	Jere	Eboze	l
+jer	Jere	Eboze	ʃ
+jer	Jere	Eboze	ʒ
+jer	Jere	Eboze	t̠ʃ
+jer	Jere	Eboze	d̠ʒ
+jer	Jere	Eboze	ɲ
+jer	Jere	Eboze	j
+jer	Jere	Eboze	k
+jer	Jere	Eboze	ɡ
+jer	Jere	Eboze	ŋ
+jer	Jere	Eboze	ɡb	alternates freely with [ɡʷ] and [ɡbʷ]
+jer	Jere	Eboze	w
+jer	Jere	Eboze	h
+jer	Jere	Eboze	˦
+jer	Jere	Eboze	˨
+jer	Jere	Eboze	˧
+jer	Jere	Eboze	˥
+
 agb	Leggbo		p				agb_hyman.pdf
-agb	Leggbo		b				
-agb	Leggbo		v				
-agb	Leggbo		m				
-agb	Leggbo		t				
-agb	Leggbo		d				
-agb	Leggbo		z				
-agb	Leggbo		l				
-agb	Leggbo		n				
-agb	Leggbo		j				
-agb	Leggbo		k				
-agb	Leggbo		t̠ʃ				
-agb	Leggbo		ɡ				
-agb	Leggbo		ŋ				
-agb	Leggbo		kp				
-agb	Leggbo		ɡb				
-agb	Leggbo		w				
-agb	Leggbo		pː				
-agb	Leggbo		bː				
-agb	Leggbo		fː				
-agb	Leggbo		vː				
-agb	Leggbo		mː				
-agb	Leggbo		tː				
-agb	Leggbo		dː				
-agb	Leggbo		sː				
-agb	Leggbo		dzː				
-agb	Leggbo		nː				
-agb	Leggbo		t̠ʃː				
-agb	Leggbo		d̠ʒː				
-agb	Leggbo		lː				
-agb	Leggbo		ɲː				
-agb	Leggbo		kː				
-agb	Leggbo		ɡː				
-agb	Leggbo		jː				
-agb	Leggbo		ŋː				
-agb	Leggbo		kpː				
-agb	Leggbo		ɡbː				
-agb	Leggbo		wː				
-agb	Leggbo		i				
-agb	Leggbo		e				
-agb	Leggbo		ɛ				
-agb	Leggbo		a				
-agb	Leggbo		u				
-agb	Leggbo		o				
-agb	Leggbo		ɔ				
-agb	Leggbo		eː				
-agb	Leggbo		ɛː				
-agb	Leggbo		aː				
-agb	Leggbo		oː				
-agb	Leggbo		ɔː				
-agb	Leggbo		˦				
-agb	Leggbo		˨				
-agb	Leggbo		˧				
-							
+agb	Leggbo		b
+agb	Leggbo		v
+agb	Leggbo		m
+agb	Leggbo		t
+agb	Leggbo		d
+agb	Leggbo		z
+agb	Leggbo		l
+agb	Leggbo		n
+agb	Leggbo		j
+agb	Leggbo		k
+agb	Leggbo		t̠ʃ
+agb	Leggbo		ɡ
+agb	Leggbo		ŋ
+agb	Leggbo		kp
+agb	Leggbo		ɡb
+agb	Leggbo		w
+agb	Leggbo		pː
+agb	Leggbo		bː
+agb	Leggbo		fː
+agb	Leggbo		vː
+agb	Leggbo		mː
+agb	Leggbo		tː
+agb	Leggbo		dː
+agb	Leggbo		sː
+agb	Leggbo		dzː
+agb	Leggbo		nː
+agb	Leggbo		t̠ʃː
+agb	Leggbo		d̠ʒː
+agb	Leggbo		lː
+agb	Leggbo		ɲː
+agb	Leggbo		kː
+agb	Leggbo		ɡː
+agb	Leggbo		jː
+agb	Leggbo		ŋː
+agb	Leggbo		kpː
+agb	Leggbo		ɡbː
+agb	Leggbo		wː
+agb	Leggbo		i
+agb	Leggbo		e
+agb	Leggbo		ɛ
+agb	Leggbo		a
+agb	Leggbo		u
+agb	Leggbo		o
+agb	Leggbo		ɔ
+agb	Leggbo		eː
+agb	Leggbo		ɛː
+agb	Leggbo		aː
+agb	Leggbo		oː
+agb	Leggbo		ɔː
+agb	Leggbo		˦
+agb	Leggbo		˨
+agb	Leggbo		˧
+
 lgq	Logba		<p>	marginal			logba.pdf
-lgq	Logba		b				
-lgq	Logba		m				
-lgq	Logba		f				
-lgq	Logba		v				
-lgq	Logba		t		[t]		
-lgq	Logba		d		[d]		
-lgq	Logba		t		[ts]		
-lgq	Logba		d		[dz]		
-lgq	Logba		s		[s]		
-lgq	Logba		z		[z]		
-lgq	Logba		ts		[ts]		
-lgq	Logba		dz		[dz]		
-lgq	Logba		n		[n]		
-lgq	Logba		n		[ɲ]		
-lgq	Logba		l				
-lgq	Logba		<r>	rare			
-lgq	Logba		ɖ				
-lgq	Logba		s		[ʃ]	before [i]	
-lgq	Logba		z		[ʒ]	before [i]	
-lgq	Logba		ts		[t̠ʃ]		
-lgq	Logba		dz		[d̠ʒ]		
-lgq	Logba		ɲ				
-lgq	Logba		j				
-lgq	Logba		k				
-lgq	Logba		ɡ				
-lgq	Logba		<x>	limited distribution			
-lgq	Logba		ŋ				
-lgq	Logba		kp				
-lgq	Logba		ɡb				
-lgq	Logba		<ɦ>	limited distribution			
-lgq	Logba		w				
-lgq	Logba		i				
-lgq	Logba		e				
-lgq	Logba		ɛ				
-lgq	Logba		a				
-lgq	Logba		u				
-lgq	Logba		o				
-lgq	Logba		ɔ				
-lgq	Logba		<˨˦>	borrowed words			
-lgq	Logba		˦				
-lgq	Logba		˨				
-							
+lgq	Logba		b
+lgq	Logba		m
+lgq	Logba		f
+lgq	Logba		v
+lgq	Logba		t		[t]
+lgq	Logba		d		[d]
+lgq	Logba		t		[ts]
+lgq	Logba		d		[dz]
+lgq	Logba		s		[s]
+lgq	Logba		z		[z]
+lgq	Logba		ts		[ts]
+lgq	Logba		dz		[dz]
+lgq	Logba		n		[n]
+lgq	Logba		n		[ɲ]
+lgq	Logba		l
+lgq	Logba		<r>	rare
+lgq	Logba		ɖ
+lgq	Logba		s		[ʃ]	before [i]
+lgq	Logba		z		[ʒ]	before [i]
+lgq	Logba		ts		[t̠ʃ]
+lgq	Logba		dz		[d̠ʒ]
+lgq	Logba		ɲ
+lgq	Logba		j
+lgq	Logba		k
+lgq	Logba		ɡ
+lgq	Logba		<x>	limited distribution
+lgq	Logba		ŋ
+lgq	Logba		kp
+lgq	Logba		ɡb
+lgq	Logba		<ɦ>	limited distribution
+lgq	Logba		w
+lgq	Logba		i
+lgq	Logba		e
+lgq	Logba		ɛ
+lgq	Logba		a
+lgq	Logba		u
+lgq	Logba		o
+lgq	Logba		ɔ
+lgq	Logba		<˨˦>	borrowed words
+lgq	Logba		˦
+lgq	Logba		˨
+
 awn	Awngi		˦				awngi_2010.pdf
-awn	Awngi		˨				
-awn	Awngi		p		[p]		
-awn	Awngi		p		[pʰ]	variation	
-awn	Awngi		b		[b]		
-awn	Awngi		b		[β]	word-final	
-awn	Awngi		f				
-awn	Awngi		m				
-awn	Awngi		w				
-awn	Awngi		t		[t]		
-awn	Awngi		t		[tʰ]	variation	
-awn	Awngi		d				
-awn	Awngi		ts				
-awn	Awngi		dz				
-awn	Awngi		s				
-awn	Awngi		st				
-awn	Awngi		n				
-awn	Awngi		l				
-awn	Awngi		r		[r]		
-awn	Awngi		r		[ɾ]		
-awn	Awngi		r		[ɾ̥]		
-awn	Awngi		k				
-awn	Awngi		kʷ				
-awn	Awngi		ɡ				
-awn	Awngi		ɡʷ				
-awn	Awngi		t̠ʃ				
-awn	Awngi		d̠ʒ		[d̠ʒ]		
-awn	Awngi		d̠ʒ		[ʒ]	variation	
-awn	Awngi		ʃ				
-awn	Awngi		ʃt				
-awn	Awngi		ŋ				
-awn	Awngi		ŋʷ				
-awn	Awngi		j		[j]		
-awn	Awngi		j		[ʝ]	variation	
-awn	Awngi		q				
-awn	Awngi		qʷ				
-awn	Awngi		ʁ				
-awn	Awngi		ʁʷ				
-awn	Awngi		<h>	Amharic loans			
-awn	Awngi		i		[i]		
-awn	Awngi		i		[ɪ]		
-awn	Awngi		<ɨ>	epenthetic	[ɨ]		
-awn	Awngi		e		[e]		
-awn	Awngi		e		[æ]		
-awn	Awngi		e		[eː]		
-awn	Awngi		e		[ɛ]		
-awn	Awngi		a		[a]		
-awn	Awngi		u		[ʊ]		
-awn	Awngi		o		[o]		
-awn	Awngi		u		[uː]		
-awn	Awngi		o		[ɔ]		
-awn	Awngi		ɨ		[ɵ]		
-awn	Awngi		ɨ		[ʏ]		
-awn	Awngi		ɨ		[ə]		
-awn	Awngi		a		[ɑ]		
-awn	Awngi		˦˨				
-awn	Awngi		˦				
-awn	Awngi		˨				
-							
+awn	Awngi		˨
+awn	Awngi		p		[p]
+awn	Awngi		p		[pʰ]	variation
+awn	Awngi		b		[b]
+awn	Awngi		b		[β]	word-final
+awn	Awngi		f
+awn	Awngi		m
+awn	Awngi		w
+awn	Awngi		t		[t]
+awn	Awngi		t		[tʰ]	variation
+awn	Awngi		d
+awn	Awngi		ts
+awn	Awngi		dz
+awn	Awngi		s
+awn	Awngi		st
+awn	Awngi		n
+awn	Awngi		l
+awn	Awngi		r		[r]
+awn	Awngi		r		[ɾ]
+awn	Awngi		r		[ɾ̥]
+awn	Awngi		k
+awn	Awngi		kʷ
+awn	Awngi		ɡ
+awn	Awngi		ɡʷ
+awn	Awngi		t̠ʃ
+awn	Awngi		d̠ʒ		[d̠ʒ]
+awn	Awngi		d̠ʒ		[ʒ]	variation
+awn	Awngi		ʃ
+awn	Awngi		ʃt
+awn	Awngi		ŋ
+awn	Awngi		ŋʷ
+awn	Awngi		j		[j]
+awn	Awngi		j		[ʝ]	variation
+awn	Awngi		q
+awn	Awngi		qʷ
+awn	Awngi		ʁ
+awn	Awngi		ʁʷ
+awn	Awngi		<h>	Amharic loans
+awn	Awngi		i		[i]
+awn	Awngi		i		[ɪ]
+awn	Awngi		<ɨ>	epenthetic	[ɨ]
+awn	Awngi		e		[e]
+awn	Awngi		e		[æ]
+awn	Awngi		e		[eː]
+awn	Awngi		e		[ɛ]
+awn	Awngi		a		[a]
+awn	Awngi		u		[ʊ]
+awn	Awngi		o		[o]
+awn	Awngi		u		[uː]
+awn	Awngi		o		[ɔ]
+awn	Awngi		ɨ		[ɵ]
+awn	Awngi		ɨ		[ʏ]
+awn	Awngi		ɨ		[ə]
+awn	Awngi		a		[ɑ]
+awn	Awngi		˦˨
+awn	Awngi		˦
+awn	Awngi		˨
+
 glw	Glavda		b				Glavda_Morphology.pdf
-glw	Glavda		p				
-glw	Glavda		ɓ				
-glw	Glavda		f				
-glw	Glavda		v				
-glw	Glavda		m	removed <mb> (status unclear)			
-glw	Glavda		w				
-glw	Glavda		d	removed <nd> (status unclear)			
-glw	Glavda		t				
-glw	Glavda		ɗ				
-glw	Glavda		s				
-glw	Glavda		z				
-glw	Glavda		dz				
-glw	Glavda		ts	removed <mts> (status unclear)			
-glw	Glavda		l				
-glw	Glavda		r	removed <rʷ> (status unclear)			
-glw	Glavda		ɬ	removed <ɬʷ> (status unclear)			
-glw	Glavda		ɮ	removed <ŋɮ> (status unclear)			
-glw	Glavda		n				
-glw	Glavda		ʃ				
-glw	Glavda		ʒ				
-glw	Glavda		d̠ʒ				
-glw	Glavda		t̠ʃ				
-glw	Glavda		ɟ				
-glw	Glavda		c				
-glw	Glavda		ç				
-glw	Glavda		ʝ				
-glw	Glavda		ɲ				
-glw	Glavda		j				
-glw	Glavda		ɡ	removed <ɡʷ> (status unclear); removed <ŋɡ> (status unclear)			
-glw	Glavda		k	removed <kʷ> (status unclear)			
-glw	Glavda		x				
-glw	Glavda		ɣ	removed <ɣʷ> (status unclear)			
-glw	Glavda		ŋ	removed <ŋʷ> (status unclear)			
-glw	Glavda		ə	removed <o>  (status unclear); removed <oː> (status unclear)			
-glw	Glavda		e				
-glw	Glavda		a				
-glw	Glavda		u				
-glw	Glavda		iː				
-glw	Glavda		aː				
-glw	Glavda		uː				
-glw	Glavda		˦				
-glw	Glavda		˨				
-							
+glw	Glavda		p
+glw	Glavda		ɓ
+glw	Glavda		f
+glw	Glavda		v
+glw	Glavda		m	removed <mb> (status unclear)
+glw	Glavda		w
+glw	Glavda		d	removed <nd> (status unclear)
+glw	Glavda		t
+glw	Glavda		ɗ
+glw	Glavda		s
+glw	Glavda		z
+glw	Glavda		dz
+glw	Glavda		ts	removed <mts> (status unclear)
+glw	Glavda		l
+glw	Glavda		r	removed <rʷ> (status unclear)
+glw	Glavda		ɬ	removed <ɬʷ> (status unclear)
+glw	Glavda		ɮ	removed <ŋɮ> (status unclear)
+glw	Glavda		n
+glw	Glavda		ʃ
+glw	Glavda		ʒ
+glw	Glavda		d̠ʒ
+glw	Glavda		t̠ʃ
+glw	Glavda		ɟ
+glw	Glavda		c
+glw	Glavda		ç
+glw	Glavda		ʝ
+glw	Glavda		ɲ
+glw	Glavda		j
+glw	Glavda		ɡ	removed <ɡʷ> (status unclear); removed <ŋɡ> (status unclear)
+glw	Glavda		k	removed <kʷ> (status unclear)
+glw	Glavda		x
+glw	Glavda		ɣ	removed <ɣʷ> (status unclear)
+glw	Glavda		ŋ	removed <ŋʷ> (status unclear)
+glw	Glavda		ə	removed <o>  (status unclear); removed <oː> (status unclear)
+glw	Glavda		e
+glw	Glavda		a
+glw	Glavda		u
+glw	Glavda		iː
+glw	Glavda		aː
+glw	Glavda		uː
+glw	Glavda		˦
+glw	Glavda		˨
+
 ahn	Ahaan		i				uwu_ahan.pdf
-ahn	Ahaan		e				
-ahn	Ahaan		ɛ				
-ahn	Ahaan		a				
-ahn	Ahaan		ɔ				
-ahn	Ahaan		o				
-ahn	Ahaan		u				
-ahn	Ahaan		ĩ				
-ahn	Ahaan		ẽ				
-ahn	Ahaan		ɛ̃				
-ahn	Ahaan		ã				
-ahn	Ahaan		ɔ̃				
-ahn	Ahaan		õ				
-ahn	Ahaan		ũ				
-ahn	Ahaan		p				
-ahn	Ahaan		b				
-ahn	Ahaan		m				
-ahn	Ahaan		f				
-ahn	Ahaan		v				
-ahn	Ahaan		t				
-ahn	Ahaan		d				
-ahn	Ahaan		n				
-ahn	Ahaan		r				
-ahn	Ahaan		s				
-ahn	Ahaan		z				
-ahn	Ahaan		l				
-ahn	Ahaan		ʃ				
-ahn	Ahaan		ʒ				
-ahn	Ahaan		t̠ʃ				
-ahn	Ahaan		d̠ʒ				
-ahn	Ahaan		ɲ				
-ahn	Ahaan		j				
-ahn	Ahaan		k				
-ahn	Ahaan		ɡ				
-ahn	Ahaan		ŋ				
-ahn	Ahaan		kp				
-ahn	Ahaan		ɡb				
-ahn	Ahaan		w				
-ahn	Ahaan		h				
-ahn	Ahaan		jʷ				
-ahn	Ahaan		˦				
-ahn	Ahaan		˨				
-ahn	Ahaan		˧				
-							
+ahn	Ahaan		e
+ahn	Ahaan		ɛ
+ahn	Ahaan		a
+ahn	Ahaan		ɔ
+ahn	Ahaan		o
+ahn	Ahaan		u
+ahn	Ahaan		ĩ
+ahn	Ahaan		ẽ
+ahn	Ahaan		ɛ̃
+ahn	Ahaan		ã
+ahn	Ahaan		ɔ̃
+ahn	Ahaan		õ
+ahn	Ahaan		ũ
+ahn	Ahaan		p
+ahn	Ahaan		b
+ahn	Ahaan		m
+ahn	Ahaan		f
+ahn	Ahaan		v
+ahn	Ahaan		t
+ahn	Ahaan		d
+ahn	Ahaan		n
+ahn	Ahaan		r
+ahn	Ahaan		s
+ahn	Ahaan		z
+ahn	Ahaan		l
+ahn	Ahaan		ʃ
+ahn	Ahaan		ʒ
+ahn	Ahaan		t̠ʃ
+ahn	Ahaan		d̠ʒ
+ahn	Ahaan		ɲ
+ahn	Ahaan		j
+ahn	Ahaan		k
+ahn	Ahaan		ɡ
+ahn	Ahaan		ŋ
+ahn	Ahaan		kp
+ahn	Ahaan		ɡb
+ahn	Ahaan		w
+ahn	Ahaan		h
+ahn	Ahaan		jʷ
+ahn	Ahaan		˦
+ahn	Ahaan		˨
+ahn	Ahaan		˧
+
 aye	Uwu		i				uwu_ahan.pdf
-aye	Uwu		e				
-aye	Uwu		ɛ				
-aye	Uwu		a				
-aye	Uwu		ɔ				
-aye	Uwu		o				
-aye	Uwu		u				
-aye	Uwu		ĩ				
-aye	Uwu		ẽ				
-aye	Uwu		ɛ̃				
-aye	Uwu		ã				
-aye	Uwu		ɔ̃				
-aye	Uwu		õ				
-aye	Uwu		ũ				
-aye	Uwu		p				
-aye	Uwu		b				
-aye	Uwu		m				
-aye	Uwu		f				
-aye	Uwu		v				
-aye	Uwu		t				
-aye	Uwu		d				
-aye	Uwu		n				
-aye	Uwu		r				
-aye	Uwu		s				
-aye	Uwu		z				
-aye	Uwu		l				
-aye	Uwu		ʃ				
-aye	Uwu		ʒ				
-aye	Uwu		t̠ʃ				
-aye	Uwu		d̠ʒ				
-aye	Uwu		ɲ				
-aye	Uwu		j				
-aye	Uwu		k				
-aye	Uwu		ɡ				
-aye	Uwu		ŋ				
-aye	Uwu		kp				
-aye	Uwu		ɡb				
-aye	Uwu		w				
-aye	Uwu		h				
-aye	Uwu		jʷ				
-aye	Uwu		˦				
-aye	Uwu		˨				
-aye	Uwu		˧				
-							
+aye	Uwu		e
+aye	Uwu		ɛ
+aye	Uwu		a
+aye	Uwu		ɔ
+aye	Uwu		o
+aye	Uwu		u
+aye	Uwu		ĩ
+aye	Uwu		ẽ
+aye	Uwu		ɛ̃
+aye	Uwu		ã
+aye	Uwu		ɔ̃
+aye	Uwu		õ
+aye	Uwu		ũ
+aye	Uwu		p
+aye	Uwu		b
+aye	Uwu		m
+aye	Uwu		f
+aye	Uwu		v
+aye	Uwu		t
+aye	Uwu		d
+aye	Uwu		n
+aye	Uwu		r
+aye	Uwu		s
+aye	Uwu		z
+aye	Uwu		l
+aye	Uwu		ʃ
+aye	Uwu		ʒ
+aye	Uwu		t̠ʃ
+aye	Uwu		d̠ʒ
+aye	Uwu		ɲ
+aye	Uwu		j
+aye	Uwu		k
+aye	Uwu		ɡ
+aye	Uwu		ŋ
+aye	Uwu		kp
+aye	Uwu		ɡb
+aye	Uwu		w
+aye	Uwu		h
+aye	Uwu		jʷ
+aye	Uwu		˦
+aye	Uwu		˨
+aye	Uwu		˧
+
 rng	Ronga		b				ronga.pdf
-rng	Ronga		ɓ				
-rng	Ronga		p				
-rng	Ronga		pʰ				
-rng	Ronga		bv				
-rng	Ronga		pf				
-rng	Ronga		pfʰ				
-rng	Ronga		f				
-rng	Ronga		v				
-rng	Ronga		v̤				
-rng	Ronga		m				
-rng	Ronga		m̤				
-rng	Ronga		w				
-rng	Ronga		w̤				
-rng	Ronga		d				
-rng	Ronga		ɗ				
-rng	Ronga		t				
-rng	Ronga		tʰ				
-rng	Ronga		dz				
-rng	Ronga		ts				
-rng	Ronga		tsʰ				
-rng	Ronga		s				
-rng	Ronga		z				
-rng	Ronga		ɬ				
-rng	Ronga		l				
-rng	Ronga		n				
-rng	Ronga		n̤				
-rng	Ronga		r				
-rng	Ronga		ɖʐ	updated from dʐ			
-rng	Ronga		ʈʂ	updated from tʂ			
-rng	Ronga		ʈʂʰ	updated from tʂʰ			
-rng	Ronga		ʐ				
-rng	Ronga		ɡǂ				
-rng	Ronga		d̠ʒ				
-rng	Ronga		t̠ʃ				
-rng	Ronga		t̠ʃʰ				
-rng	Ronga		ʃ				
-rng	Ronga		ʒ				
-rng	Ronga		ɲ				
-rng	Ronga		j				
-rng	Ronga		ɡ				
-rng	Ronga		k				
-rng	Ronga		kʰ				
-rng	Ronga		ɦ				
-rng	Ronga		bzʷ				
-rng	Ronga		psʷ				
-rng	Ronga		psʷʰ				
-rng	Ronga		ɬʷ				
-rng	Ronga		tʷ				
-rng	Ronga		dlʷ				
-rng	Ronga		sʷ				
-rng	Ronga		lʷ				
-rng	Ronga		nʷ				
-rng	Ronga		n̤ʷ				
-rng	Ronga		ɖʐʷ	updated from dʐʷ			
-rng	Ronga		ʈʂʷ	updated from tʂʷ			
-rng	Ronga		ʐʷ				
-rng	Ronga		ʃʷ				
-rng	Ronga		ɲʷ				
-rng	Ronga		kʷ				
-rng	Ronga		kʷʰ				
-rng	Ronga		ɡʷ				
-rng	Ronga		ɡ̤ʷ				
-rng	Ronga		ŋʷ				
-rng	Ronga		i				
-rng	Ronga		e		[e]		
-rng	Ronga		e		[ɛ]		
-rng	Ronga		a				
-rng	Ronga		u				
-rng	Ronga		o		[o]		
-rng	Ronga		o		[ɔ]		
-							
+rng	Ronga		ɓ
+rng	Ronga		p
+rng	Ronga		pʰ
+rng	Ronga		bv
+rng	Ronga		pf
+rng	Ronga		pfʰ
+rng	Ronga		f
+rng	Ronga		v
+rng	Ronga		v̤
+rng	Ronga		m
+rng	Ronga		m̤
+rng	Ronga		w
+rng	Ronga		w̤
+rng	Ronga		d
+rng	Ronga		ɗ
+rng	Ronga		t
+rng	Ronga		tʰ
+rng	Ronga		dz
+rng	Ronga		ts
+rng	Ronga		tsʰ
+rng	Ronga		s
+rng	Ronga		z
+rng	Ronga		ɬ
+rng	Ronga		l
+rng	Ronga		n
+rng	Ronga		n̤
+rng	Ronga		r
+rng	Ronga		ɖʐ	updated from dʐ
+rng	Ronga		ʈʂ	updated from tʂ
+rng	Ronga		ʈʂʰ	updated from tʂʰ
+rng	Ronga		ʐ
+rng	Ronga		ɡǂ
+rng	Ronga		d̠ʒ
+rng	Ronga		t̠ʃ
+rng	Ronga		t̠ʃʰ
+rng	Ronga		ʃ
+rng	Ronga		ʒ
+rng	Ronga		ɲ
+rng	Ronga		j
+rng	Ronga		ɡ
+rng	Ronga		k
+rng	Ronga		kʰ
+rng	Ronga		ɦ
+rng	Ronga		bzʷ
+rng	Ronga		psʷ
+rng	Ronga		psʷʰ
+rng	Ronga		ɬʷ
+rng	Ronga		tʷ
+rng	Ronga		dlʷ
+rng	Ronga		sʷ
+rng	Ronga		lʷ
+rng	Ronga		nʷ
+rng	Ronga		n̤ʷ
+rng	Ronga		ɖʐʷ	updated from dʐʷ
+rng	Ronga		ʈʂʷ	updated from tʂʷ
+rng	Ronga		ʐʷ
+rng	Ronga		ʃʷ
+rng	Ronga		ɲʷ
+rng	Ronga		kʷ
+rng	Ronga		kʷʰ
+rng	Ronga		ɡʷ
+rng	Ronga		ɡ̤ʷ
+rng	Ronga		ŋʷ
+rng	Ronga		i
+rng	Ronga		e		[e]
+rng	Ronga		e		[ɛ]
+rng	Ronga		a
+rng	Ronga		u
+rng	Ronga		o		[o]
+rng	Ronga		o		[ɔ]
+
 wni	Comorian, Ndzwani		b				Comorian-inventories.pdf
-wni	Comorian, Ndzwani		p				
-wni	Comorian, Ndzwani		v				
-wni	Comorian, Ndzwani		f				
-wni	Comorian, Ndzwani		m				
-wni	Comorian, Ndzwani		mb				
-wni	Comorian, Ndzwani		w				
-wni	Comorian, Ndzwani		d				
-wni	Comorian, Ndzwani		ɖ				
-wni	Comorian, Ndzwani		t				
-wni	Comorian, Ndzwani		ʈ				
-wni	Comorian, Ndzwani		z				
-wni	Comorian, Ndzwani		s				
-wni	Comorian, Ndzwani		n				
-wni	Comorian, Ndzwani		ndr				
-wni	Comorian, Ndzwani		l				
-wni	Comorian, Ndzwani		r				
-wni	Comorian, Ndzwani		dz				
-wni	Comorian, Ndzwani		d̠ʒ				
-wni	Comorian, Ndzwani		ts				
-wni	Comorian, Ndzwani		t̠ʃ				
-wni	Comorian, Ndzwani		ʒ				
-wni	Comorian, Ndzwani		ʃ				
-wni	Comorian, Ndzwani		ɲ				
-wni	Comorian, Ndzwani		ndz				
-wni	Comorian, Ndzwani		n̠d̠ʒ				
-wni	Comorian, Ndzwani		j				
-wni	Comorian, Ndzwani		ɡ				
-wni	Comorian, Ndzwani		k				
-wni	Comorian, Ndzwani		h				
-wni	Comorian, Ndzwani		ŋɡ				
-wni	Comorian, Ndzwani		ʕ				
-wni	Comorian, Ndzwani		˦				
-wni	Comorian, Ndzwani		˨				
-wni	Comorian, Ndzwani		i				
-wni	Comorian, Ndzwani		e				
-wni	Comorian, Ndzwani		a				
-wni	Comorian, Ndzwani		o				
-wni	Comorian, Ndzwani		u				
-							
+wni	Comorian, Ndzwani		p
+wni	Comorian, Ndzwani		v
+wni	Comorian, Ndzwani		f
+wni	Comorian, Ndzwani		m
+wni	Comorian, Ndzwani		mb
+wni	Comorian, Ndzwani		w
+wni	Comorian, Ndzwani		d
+wni	Comorian, Ndzwani		ɖ
+wni	Comorian, Ndzwani		t
+wni	Comorian, Ndzwani		ʈ
+wni	Comorian, Ndzwani		z
+wni	Comorian, Ndzwani		s
+wni	Comorian, Ndzwani		n
+wni	Comorian, Ndzwani		ndr
+wni	Comorian, Ndzwani		l
+wni	Comorian, Ndzwani		r
+wni	Comorian, Ndzwani		dz
+wni	Comorian, Ndzwani		d̠ʒ
+wni	Comorian, Ndzwani		ts
+wni	Comorian, Ndzwani		t̠ʃ
+wni	Comorian, Ndzwani		ʒ
+wni	Comorian, Ndzwani		ʃ
+wni	Comorian, Ndzwani		ɲ
+wni	Comorian, Ndzwani		ndz
+wni	Comorian, Ndzwani		n̠d̠ʒ
+wni	Comorian, Ndzwani		j
+wni	Comorian, Ndzwani		ɡ
+wni	Comorian, Ndzwani		k
+wni	Comorian, Ndzwani		h
+wni	Comorian, Ndzwani		ŋɡ
+wni	Comorian, Ndzwani		ʕ
+wni	Comorian, Ndzwani		˦
+wni	Comorian, Ndzwani		˨
+wni	Comorian, Ndzwani		i
+wni	Comorian, Ndzwani		e
+wni	Comorian, Ndzwani		a
+wni	Comorian, Ndzwani		o
+wni	Comorian, Ndzwani		u
+
 biv	Birifor		p				biv.pdf
-biv	Birifor		b		[b]		
-biv	Birifor		b		[p̚]	utterance final	
-biv	Birifor		f				
-biv	Birifor		v				
-biv	Birifor		m				
-biv	Birifor		<bˀ>	rare			
-biv	Birifor		t				
-biv	Birifor		d		[d]		
-biv	Birifor		d		[ɾ]	utterance final	
-biv	Birifor		d		[r]	intervocalic	
-biv	Birifor		d		[ɾ̥]		
-biv	Birifor		s				
-biv	Birifor		n				
-biv	Birifor		l				
-biv	Birifor		<lˀ>	rare			
-biv	Birifor		t̠ʃ				
-biv	Birifor		d̠ʒ				
-biv	Birifor		ɲ				
-biv	Birifor		j				
-biv	Birifor		<jˀ>	rare			
-biv	Birifor		k				
-biv	Birifor		ɡ				
-biv	Birifor		w				
-biv	Birifor		<wˀ>	rare			
-biv	Birifor		kp				
-biv	Birifor		ɡb				
-biv	Birifor		<ŋm>	rare			
-biv	Birifor		h				
-biv	Birifor		i				
-biv	Birifor		ɪ				
-biv	Birifor		e				
-biv	Birifor		ɛ				
-biv	Birifor		a				
-biv	Birifor		u				
-biv	Birifor		ʊ				
-biv	Birifor		o				
-biv	Birifor		ɔ				
-biv	Birifor		iː				
-biv	Birifor		ɪː				
-biv	Birifor		eː				
-biv	Birifor		ɛː				
-biv	Birifor		aː				
-biv	Birifor		uː				
-biv	Birifor		ʊː				
-biv	Birifor		oː				
-biv	Birifor		ɔː				
-biv	Birifor		ĩ				
-biv	Birifor		ɪ̃				
-biv	Birifor		ẽ				
-biv	Birifor		ɛ̃				
-biv	Birifor		ã				
-biv	Birifor		ũ				
-biv	Birifor		ʊ̃				
-biv	Birifor		õ				
-biv	Birifor		ɔ̃				
-							
+biv	Birifor		b		[b]
+biv	Birifor		b		[p̚]	utterance final
+biv	Birifor		f
+biv	Birifor		v
+biv	Birifor		m
+biv	Birifor		<bˀ>	rare
+biv	Birifor		t
+biv	Birifor		d		[d]
+biv	Birifor		d		[ɾ]	utterance final
+biv	Birifor		d		[r]	intervocalic
+biv	Birifor		d		[ɾ̥]
+biv	Birifor		s
+biv	Birifor		n
+biv	Birifor		l
+biv	Birifor		<lˀ>	rare
+biv	Birifor		t̠ʃ
+biv	Birifor		d̠ʒ
+biv	Birifor		ɲ
+biv	Birifor		j
+biv	Birifor		<jˀ>	rare
+biv	Birifor		k
+biv	Birifor		ɡ
+biv	Birifor		w
+biv	Birifor		<wˀ>	rare
+biv	Birifor		kp
+biv	Birifor		ɡb
+biv	Birifor		<ŋm>	rare
+biv	Birifor		h
+biv	Birifor		i
+biv	Birifor		ɪ
+biv	Birifor		e
+biv	Birifor		ɛ
+biv	Birifor		a
+biv	Birifor		u
+biv	Birifor		ʊ
+biv	Birifor		o
+biv	Birifor		ɔ
+biv	Birifor		iː
+biv	Birifor		ɪː
+biv	Birifor		eː
+biv	Birifor		ɛː
+biv	Birifor		aː
+biv	Birifor		uː
+biv	Birifor		ʊː
+biv	Birifor		oː
+biv	Birifor		ɔː
+biv	Birifor		ĩ
+biv	Birifor		ɪ̃
+biv	Birifor		ẽ
+biv	Birifor		ɛ̃
+biv	Birifor		ã
+biv	Birifor		ũ
+biv	Birifor		ʊ̃
+biv	Birifor		õ
+biv	Birifor		ɔ̃
+
 cwt	Kwatay		b				cwt.pdf
-cwt	Kwatay		m				
-cwt	Kwatay		f				
-cwt	Kwatay		w				
-cwt	Kwatay		t̪				
-cwt	Kwatay		n				
-cwt	Kwatay		s				
-cwt	Kwatay		l̪				
-cwt	Kwatay		r		[r]	intervocalic	
-cwt	Kwatay		r		[d̪]	word-initial and post-nasal	
-cwt	Kwatay		ɟ				
-cwt	Kwatay		ɲ				
-cwt	Kwatay		j				
-cwt	Kwatay		k		[k]		
-cwt	Kwatay		k		[ɡ]	intervocalic	
-cwt	Kwatay		ŋ				
-cwt	Kwatay		h				
-cwt	Kwatay		i				
-cwt	Kwatay		iː				
-cwt	Kwatay		e				
-cwt	Kwatay		eː				
-cwt	Kwatay		a				
-cwt	Kwatay		aː				
-cwt	Kwatay		u				
-cwt	Kwatay		uː				
-cwt	Kwatay		o				
-cwt	Kwatay		oː				
-cwt	Kwatay		<p>	borrowed words only			
-cwt	Kwatay		<v>	borrowed words only			
-cwt	Kwatay		<z>	borrowed words only			
-cwt	Kwatay		<ʃ>	borrowed words only			
-cwt	Kwatay		<ʒ>	borrowed words only			
-cwt	Kwatay		˥				
-cwt	Kwatay		˦				
-cwt	Kwatay		˨				
-cwt	Kwatay		˧				
-							
+cwt	Kwatay		m
+cwt	Kwatay		f
+cwt	Kwatay		w
+cwt	Kwatay		t̪
+cwt	Kwatay		n
+cwt	Kwatay		s
+cwt	Kwatay		l̪
+cwt	Kwatay		r		[r]	intervocalic
+cwt	Kwatay		r		[d̪]	word-initial and post-nasal
+cwt	Kwatay		ɟ
+cwt	Kwatay		ɲ
+cwt	Kwatay		j
+cwt	Kwatay		k		[k]
+cwt	Kwatay		k		[ɡ]	intervocalic
+cwt	Kwatay		ŋ
+cwt	Kwatay		h
+cwt	Kwatay		i
+cwt	Kwatay		iː
+cwt	Kwatay		e
+cwt	Kwatay		eː
+cwt	Kwatay		a
+cwt	Kwatay		aː
+cwt	Kwatay		u
+cwt	Kwatay		uː
+cwt	Kwatay		o
+cwt	Kwatay		oː
+cwt	Kwatay		<p>	borrowed words only
+cwt	Kwatay		<v>	borrowed words only
+cwt	Kwatay		<z>	borrowed words only
+cwt	Kwatay		<ʃ>	borrowed words only
+cwt	Kwatay		<ʒ>	borrowed words only
+cwt	Kwatay		˥
+cwt	Kwatay		˦
+cwt	Kwatay		˨
+cwt	Kwatay		˧
+
 ati	Attie	Memni	l		[l]		ati.pdf
-ati	Attie	Memni	l		[n]	precedinɡ a nasal vowel	
-ati	Attie	Memni	j		[ɲ]	precedinɡ a nasal vowel	
-ati	Attie	Memni	j		[j]		
-ati	Attie	Memni	w		[w]	before non-hiɡh oral vowels	
-ati	Attie	Memni	w		[w̃]	precedinɡ back nasal vowels when in initial position	
-ati	Attie	Memni	w		[ŋ]	elsewhere in variation with [ŋw̃]	
-ati	Attie	Memni	w		[ŋw̃]	elsewhere in variation with [ŋ]	
-ati	Attie	Memni	m				
-ati	Attie	Memni	p				
-ati	Attie	Memni	b				
-ati	Attie	Memni	t				
-ati	Attie	Memni	d				
-ati	Attie	Memni	<c>	borrowed words			
-ati	Attie	Memni	<ɟ>	borrowed words			
-ati	Attie	Memni	k				
-ati	Attie	Memni	ɡ				
-ati	Attie	Memni	kp				
-ati	Attie	Memni	ɡb				
-ati	Attie	Memni	ts				
-ati	Attie	Memni	dz				
-ati	Attie	Memni	t̠ʃ				
-ati	Attie	Memni	d̠ʒ				
-ati	Attie	Memni	f				
-ati	Attie	Memni	<v>	limited distribution			
-ati	Attie	Memni	s				
-ati	Attie	Memni	ʃ				
-ati	Attie	Memni	h				
-ati	Attie	Memni	l		[l̃]	in complex onsets precedinɡ a nasal vowel	
-ati	Attie	Memni	r	never in initial position			
-ati	Attie	Memni	l		[r]	in complex onsets if C1 is dental or palatal	
-ati	Attie	Memni	j		[j̃]	in complex onsets precedinɡ a nasal vowel	
-ati	Attie	Memni	w		[ɥ]	before hiɡh vowels and palatal consonants	
-ati	Attie	Memni	i				
-ati	Attie	Memni	e				
-ati	Attie	Memni	ɛ				
-ati	Attie	Memni	ø				
-ati	Attie	Memni	œ				
-ati	Attie	Memni	a				
-ati	Attie	Memni	u				
-ati	Attie	Memni	o				
-ati	Attie	Memni	ɔ				
-ati	Attie	Memni	ĩ		[ĩ]		
-ati	Attie	Memni	ĩ		[ɪ̃]		
-ati	Attie	Memni	ɛ̃				
-ati	Attie	Memni	ã				
-ati	Attie	Memni	œ̃				
-ati	Attie	Memni	<ɔ̃>	rare			
-ati	Attie	Memni	ũ		[ɷ̃]		
-ati	Attie	Memni	˥				
-ati	Attie	Memni	˦				
-ati	Attie	Memni	˨				
-ati	Attie	Memni	˧				
-ati	Attie	Memni	˨˧				
-ati	Attie	Memni	˨˧				
-ati	Attie	Memni	˧˨				
-ati	Attie	Memni	˥˨	SHL (superhigh-low			
-ati	Attie	Memni	˥˧	SHM (superhigh-mid)			
-							
+ati	Attie	Memni	l		[n]	precedinɡ a nasal vowel
+ati	Attie	Memni	j		[ɲ]	precedinɡ a nasal vowel
+ati	Attie	Memni	j		[j]
+ati	Attie	Memni	w		[w]	before non-hiɡh oral vowels
+ati	Attie	Memni	w		[w̃]	precedinɡ back nasal vowels when in initial position
+ati	Attie	Memni	w		[ŋ]	elsewhere in variation with [ŋw̃]
+ati	Attie	Memni	w		[ŋw̃]	elsewhere in variation with [ŋ]
+ati	Attie	Memni	m
+ati	Attie	Memni	p
+ati	Attie	Memni	b
+ati	Attie	Memni	t
+ati	Attie	Memni	d
+ati	Attie	Memni	<c>	borrowed words
+ati	Attie	Memni	<ɟ>	borrowed words
+ati	Attie	Memni	k
+ati	Attie	Memni	ɡ
+ati	Attie	Memni	kp
+ati	Attie	Memni	ɡb
+ati	Attie	Memni	ts
+ati	Attie	Memni	dz
+ati	Attie	Memni	t̠ʃ
+ati	Attie	Memni	d̠ʒ
+ati	Attie	Memni	f
+ati	Attie	Memni	<v>	limited distribution
+ati	Attie	Memni	s
+ati	Attie	Memni	ʃ
+ati	Attie	Memni	h
+ati	Attie	Memni	l		[l̃]	in complex onsets precedinɡ a nasal vowel
+ati	Attie	Memni	r	never in initial position
+ati	Attie	Memni	l		[r]	in complex onsets if C1 is dental or palatal
+ati	Attie	Memni	j		[j̃]	in complex onsets precedinɡ a nasal vowel
+ati	Attie	Memni	w		[ɥ]	before hiɡh vowels and palatal consonants
+ati	Attie	Memni	i
+ati	Attie	Memni	e
+ati	Attie	Memni	ɛ
+ati	Attie	Memni	ø
+ati	Attie	Memni	œ
+ati	Attie	Memni	a
+ati	Attie	Memni	u
+ati	Attie	Memni	o
+ati	Attie	Memni	ɔ
+ati	Attie	Memni	ĩ		[ĩ]
+ati	Attie	Memni	ĩ		[ɪ̃]
+ati	Attie	Memni	ɛ̃
+ati	Attie	Memni	ã
+ati	Attie	Memni	œ̃
+ati	Attie	Memni	<ɔ̃>	rare
+ati	Attie	Memni	ũ		[ɷ̃]
+ati	Attie	Memni	˥
+ati	Attie	Memni	˦
+ati	Attie	Memni	˨
+ati	Attie	Memni	˧
+ati	Attie	Memni	˨˧
+ati	Attie	Memni	˨˧
+ati	Attie	Memni	˧˨
+ati	Attie	Memni	˥˨	SHL (superhigh-low
+ati	Attie	Memni	˥˧	SHM (superhigh-mid)
+
 aoa	Angolar		p				aoa.pdf
-aoa	Angolar		ɓ				
-aoa	Angolar		m				
-aoa	Angolar		f				
-aoa	Angolar		v				
-aoa	Angolar		t				
-aoa	Angolar		d				
-aoa	Angolar		s		[s]		
-aoa	Angolar		z		[z]		
-aoa	Angolar		s		[θ]	before [i]	
-aoa	Angolar		z		[ð]	before [i]	
-aoa	Angolar		t̠ʃ				
-aoa	Angolar		d̠ʒ				
-aoa	Angolar		n				
-aoa	Angolar		l				
-aoa	Angolar		r				
-aoa	Angolar		ʃ				
-aoa	Angolar		ʒ				
-aoa	Angolar		ɲ				
-aoa	Angolar		j				
-aoa	Angolar		k				
-aoa	Angolar		ɡ				
-aoa	Angolar		ŋ				
-aoa	Angolar		w				
-aoa	Angolar		i				
-aoa	Angolar		e				
-aoa	Angolar		ɛ				
-aoa	Angolar		a				
-aoa	Angolar		u				
-aoa	Angolar		o				
-aoa	Angolar		ɔ				
-aoa	Angolar		˦				
-aoa	Angolar		˨				
-aoa	Angolar		ĩ				
-aoa	Angolar		ẽ				
-aoa	Angolar		ã				
-aoa	Angolar		ũ				
-aoa	Angolar		õ				
-							
+aoa	Angolar		ɓ
+aoa	Angolar		m
+aoa	Angolar		f
+aoa	Angolar		v
+aoa	Angolar		t
+aoa	Angolar		d
+aoa	Angolar		s		[s]
+aoa	Angolar		z		[z]
+aoa	Angolar		s		[θ]	before [i]
+aoa	Angolar		z		[ð]	before [i]
+aoa	Angolar		t̠ʃ
+aoa	Angolar		d̠ʒ
+aoa	Angolar		n
+aoa	Angolar		l
+aoa	Angolar		r
+aoa	Angolar		ʃ
+aoa	Angolar		ʒ
+aoa	Angolar		ɲ
+aoa	Angolar		j
+aoa	Angolar		k
+aoa	Angolar		ɡ
+aoa	Angolar		ŋ
+aoa	Angolar		w
+aoa	Angolar		i
+aoa	Angolar		e
+aoa	Angolar		ɛ
+aoa	Angolar		a
+aoa	Angolar		u
+aoa	Angolar		o
+aoa	Angolar		ɔ
+aoa	Angolar		˦
+aoa	Angolar		˨
+aoa	Angolar		ĩ
+aoa	Angolar		ẽ
+aoa	Angolar		ã
+aoa	Angolar		ũ
+aoa	Angolar		õ
+
 hae	Oromo, Eastern	Harar	˦				hae.pdf
-hae	Oromo, Eastern	Harar	˨				
-hae	Oromo, Eastern	Harar	i		[i]		
-hae	Oromo, Eastern	Harar	e		[e]		
-hae	Oromo, Eastern	Harar	a		[a]		
-hae	Oromo, Eastern	Harar	o		[o]		
-hae	Oromo, Eastern	Harar	u		[u]		
-hae	Oromo, Eastern	Harar	iː				
-hae	Oromo, Eastern	Harar	eː				
-hae	Oromo, Eastern	Harar	aː				
-hae	Oromo, Eastern	Harar	oː				
-hae	Oromo, Eastern	Harar	uː				
-hae	Oromo, Eastern	Harar	i		[iˑ]	associated with hiɡh tone	
-hae	Oromo, Eastern	Harar	e		[eˑ]	associated with hiɡh tone	
-hae	Oromo, Eastern	Harar	a		[aˑ]	associated with hiɡh tone	
-hae	Oromo, Eastern	Harar	o		[oˑ]	associated with hiɡh tone	
-hae	Oromo, Eastern	Harar	u		[uˑ]	associated with hiɡh tone	
-hae	Oromo, Eastern	Harar	i		[iː]	word-final	
-hae	Oromo, Eastern	Harar	e		[eː]	word-final	
-hae	Oromo, Eastern	Harar	a		[aː]	word-final	
-hae	Oromo, Eastern	Harar	o		[oː]	word-final	
-hae	Oromo, Eastern	Harar	u		[uː]	word-final	
-hae	Oromo, Eastern	Harar	b				
-hae	Oromo, Eastern	Harar	pʼ	never word-initial			
-hae	Oromo, Eastern	Harar	f				
-hae	Oromo, Eastern	Harar	m				
-hae	Oromo, Eastern	Harar	w				
-hae	Oromo, Eastern	Harar	d̪				
-hae	Oromo, Eastern	Harar	t̪				
-hae	Oromo, Eastern	Harar	d				
-hae	Oromo, Eastern	Harar	tʼ				
-hae	Oromo, Eastern	Harar	s				
-hae	Oromo, Eastern	Harar	<z>	loans only			
-hae	Oromo, Eastern	Harar	n				
-hae	Oromo, Eastern	Harar	l				
-hae	Oromo, Eastern	Harar	r				
-hae	Oromo, Eastern	Harar	d̠ʒ				
-hae	Oromo, Eastern	Harar	<t̠ʃ>	never word-initial, rare			
-hae	Oromo, Eastern	Harar	t̠ʃʼ				
-hae	Oromo, Eastern	Harar	<ʃ>	rare			
-hae	Oromo, Eastern	Harar	<ɲ>	rare			
-hae	Oromo, Eastern	Harar	j				
-hae	Oromo, Eastern	Harar	ɡ				
-hae	Oromo, Eastern	Harar	kʼ				
-hae	Oromo, Eastern	Harar	ʔ				
-hae	Oromo, Eastern	Harar	x				
-hae	Oromo, Eastern	Harar	h				
-hae	Oromo, Eastern	Harar	bː				
-hae	Oromo, Eastern	Harar	pʼː				
-hae	Oromo, Eastern	Harar	fː				
-hae	Oromo, Eastern	Harar	mː				
-hae	Oromo, Eastern	Harar	d̪ː				
-hae	Oromo, Eastern	Harar	t̪ː				
-hae	Oromo, Eastern	Harar	dː				
-hae	Oromo, Eastern	Harar	tʼː				
-hae	Oromo, Eastern	Harar	sː				
-hae	Oromo, Eastern	Harar	zː				
-hae	Oromo, Eastern	Harar	nː				
-hae	Oromo, Eastern	Harar	lː				
-hae	Oromo, Eastern	Harar	rː				
-hae	Oromo, Eastern	Harar	d̠ʒː				
-hae	Oromo, Eastern	Harar	t̠ʃː				
-hae	Oromo, Eastern	Harar	t̠ʃʼː				
-hae	Oromo, Eastern	Harar	ʃː				
-hae	Oromo, Eastern	Harar	ɲː				
-hae	Oromo, Eastern	Harar	jː				
-hae	Oromo, Eastern	Harar	ɡː				
-hae	Oromo, Eastern	Harar	kː	has no singleton counterpart			
-hae	Oromo, Eastern	Harar	kʼː				
-hae	Oromo, Eastern	Harar	xː				
-							
+hae	Oromo, Eastern	Harar	˨
+hae	Oromo, Eastern	Harar	i		[i]
+hae	Oromo, Eastern	Harar	e		[e]
+hae	Oromo, Eastern	Harar	a		[a]
+hae	Oromo, Eastern	Harar	o		[o]
+hae	Oromo, Eastern	Harar	u		[u]
+hae	Oromo, Eastern	Harar	iː
+hae	Oromo, Eastern	Harar	eː
+hae	Oromo, Eastern	Harar	aː
+hae	Oromo, Eastern	Harar	oː
+hae	Oromo, Eastern	Harar	uː
+hae	Oromo, Eastern	Harar	i		[iˑ]	associated with hiɡh tone
+hae	Oromo, Eastern	Harar	e		[eˑ]	associated with hiɡh tone
+hae	Oromo, Eastern	Harar	a		[aˑ]	associated with hiɡh tone
+hae	Oromo, Eastern	Harar	o		[oˑ]	associated with hiɡh tone
+hae	Oromo, Eastern	Harar	u		[uˑ]	associated with hiɡh tone
+hae	Oromo, Eastern	Harar	i		[iː]	word-final
+hae	Oromo, Eastern	Harar	e		[eː]	word-final
+hae	Oromo, Eastern	Harar	a		[aː]	word-final
+hae	Oromo, Eastern	Harar	o		[oː]	word-final
+hae	Oromo, Eastern	Harar	u		[uː]	word-final
+hae	Oromo, Eastern	Harar	b
+hae	Oromo, Eastern	Harar	pʼ	never word-initial
+hae	Oromo, Eastern	Harar	f
+hae	Oromo, Eastern	Harar	m
+hae	Oromo, Eastern	Harar	w
+hae	Oromo, Eastern	Harar	d̪
+hae	Oromo, Eastern	Harar	t̪
+hae	Oromo, Eastern	Harar	d
+hae	Oromo, Eastern	Harar	tʼ
+hae	Oromo, Eastern	Harar	s
+hae	Oromo, Eastern	Harar	<z>	loans only
+hae	Oromo, Eastern	Harar	n
+hae	Oromo, Eastern	Harar	l
+hae	Oromo, Eastern	Harar	r
+hae	Oromo, Eastern	Harar	d̠ʒ
+hae	Oromo, Eastern	Harar	<t̠ʃ>	never word-initial, rare
+hae	Oromo, Eastern	Harar	t̠ʃʼ
+hae	Oromo, Eastern	Harar	<ʃ>	rare
+hae	Oromo, Eastern	Harar	<ɲ>	rare
+hae	Oromo, Eastern	Harar	j
+hae	Oromo, Eastern	Harar	ɡ
+hae	Oromo, Eastern	Harar	kʼ
+hae	Oromo, Eastern	Harar	ʔ
+hae	Oromo, Eastern	Harar	x
+hae	Oromo, Eastern	Harar	h
+hae	Oromo, Eastern	Harar	bː
+hae	Oromo, Eastern	Harar	pʼː
+hae	Oromo, Eastern	Harar	fː
+hae	Oromo, Eastern	Harar	mː
+hae	Oromo, Eastern	Harar	d̪ː
+hae	Oromo, Eastern	Harar	t̪ː
+hae	Oromo, Eastern	Harar	dː
+hae	Oromo, Eastern	Harar	tʼː
+hae	Oromo, Eastern	Harar	sː
+hae	Oromo, Eastern	Harar	zː
+hae	Oromo, Eastern	Harar	nː
+hae	Oromo, Eastern	Harar	lː
+hae	Oromo, Eastern	Harar	rː
+hae	Oromo, Eastern	Harar	d̠ʒː
+hae	Oromo, Eastern	Harar	t̠ʃː
+hae	Oromo, Eastern	Harar	t̠ʃʼː
+hae	Oromo, Eastern	Harar	ʃː
+hae	Oromo, Eastern	Harar	ɲː
+hae	Oromo, Eastern	Harar	jː
+hae	Oromo, Eastern	Harar	ɡː
+hae	Oromo, Eastern	Harar	kː	has no singleton counterpart
+hae	Oromo, Eastern	Harar	kʼː
+hae	Oromo, Eastern	Harar	xː
+
 pov	Kriyol		i		[i]		pov.pdf
-pov	Kriyol		u		[u]		
-pov	Kriyol		e		[e]		
-pov	Kriyol		o		[o]		
-pov	Kriyol		a		[a]		
-pov	Kriyol		i		[i̥]	variably devoiced in word-final position	
-pov	Kriyol		u		[u̥]	variably devoiced in word-final position	
-pov	Kriyol		e		[e̥]	variably devoiced in word-final position	
-pov	Kriyol		o		[o̥]	variably devoiced in word-final position	
-pov	Kriyol		a		[ḁ]	variably devoiced in word-final position	
-pov	Kriyol		m				
-pov	Kriyol		n				
-pov	Kriyol		ɲ				
-pov	Kriyol		ɡ				
-pov	Kriyol		b				
-pov	Kriyol		d				
-pov	Kriyol		ɟ				
-pov	Kriyol		<ŋ>	phonemic status unclear			
-pov	Kriyol		p				
-pov	Kriyol		t				
-pov	Kriyol		c				
-pov	Kriyol		k				
-pov	Kriyol		<v>	recent loans only			
-pov	Kriyol		<z>	recent loans only			
-pov	Kriyol		<ʒ>	recent loans only			
-pov	Kriyol		f				
-pov	Kriyol		s				
-pov	Kriyol		<ʃ>	recent loans only			
-pov	Kriyol		w				
-pov	Kriyol		ɾ				
-pov	Kriyol		j				
-pov	Kriyol		l				
-pov	Kriyol		<lʲ>	recent loans only			
-pov	Kriyol		i		[ĩ]	nasal environments	
-pov	Kriyol		u		[ũ]	nasal environments	
-pov	Kriyol		e		[ẽ]	nasal environments	
-pov	Kriyol		o		[õ]	nasal environments	
-pov	Kriyol		a		[ã]	nasal environments	
-							
+pov	Kriyol		u		[u]
+pov	Kriyol		e		[e]
+pov	Kriyol		o		[o]
+pov	Kriyol		a		[a]
+pov	Kriyol		i		[i̥]	variably devoiced in word-final position
+pov	Kriyol		u		[u̥]	variably devoiced in word-final position
+pov	Kriyol		e		[e̥]	variably devoiced in word-final position
+pov	Kriyol		o		[o̥]	variably devoiced in word-final position
+pov	Kriyol		a		[ḁ]	variably devoiced in word-final position
+pov	Kriyol		m
+pov	Kriyol		n
+pov	Kriyol		ɲ
+pov	Kriyol		ɡ
+pov	Kriyol		b
+pov	Kriyol		d
+pov	Kriyol		ɟ
+pov	Kriyol		<ŋ>	phonemic status unclear
+pov	Kriyol		p
+pov	Kriyol		t
+pov	Kriyol		c
+pov	Kriyol		k
+pov	Kriyol		<v>	recent loans only
+pov	Kriyol		<z>	recent loans only
+pov	Kriyol		<ʒ>	recent loans only
+pov	Kriyol		f
+pov	Kriyol		s
+pov	Kriyol		<ʃ>	recent loans only
+pov	Kriyol		w
+pov	Kriyol		ɾ
+pov	Kriyol		j
+pov	Kriyol		l
+pov	Kriyol		<lʲ>	recent loans only
+pov	Kriyol		i		[ĩ]	nasal environments
+pov	Kriyol		u		[ũ]	nasal environments
+pov	Kriyol		e		[ẽ]	nasal environments
+pov	Kriyol		o		[õ]	nasal environments
+pov	Kriyol		a		[ã]	nasal environments
+
 bss	Akoose	Nyasoso	p				manenguba.pdf
-bss	Akoose	Nyasoso	b				
-bss	Akoose	Nyasoso	m				
-bss	Akoose	Nyasoso	t				
-bss	Akoose	Nyasoso	d				
-bss	Akoose	Nyasoso	s				
-bss	Akoose	Nyasoso	z				
-bss	Akoose	Nyasoso	l				
-bss	Akoose	Nyasoso	n				
-bss	Akoose	Nyasoso	c				
-bss	Akoose	Nyasoso	ɟ				
-bss	Akoose	Nyasoso	j				
-bss	Akoose	Nyasoso	ɲ		[ɲ]		
-bss	Akoose	Nyasoso	k				
-bss	Akoose	Nyasoso	ɡ				
-bss	Akoose	Nyasoso	w				
-bss	Akoose	Nyasoso	h				
-bss	Akoose	Nyasoso	b				
-bss	Akoose	Nyasoso	d				
-bss	Akoose	Nyasoso	ɡ				
-bss	Akoose	Nyasoso	<ʔ>	marginal			
-bss	Akoose	Nyasoso	ɲ		[ŋ]		
-bss	Akoose	Nyasoso	i				
-bss	Akoose	Nyasoso	e				
-bss	Akoose	Nyasoso	ə				
-bss	Akoose	Nyasoso	ɛ				
-bss	Akoose	Nyasoso	ɑ				
-bss	Akoose	Nyasoso	o				
-bss	Akoose	Nyasoso	ɔ				
-bss	Akoose	Nyasoso	ø				
-bss	Akoose	Nyasoso	iː				
-bss	Akoose	Nyasoso	aː				
-bss	Akoose	Nyasoso	uː				
-bss	Akoose	Nyasoso	ɔː				
-bss	Akoose	Nyasoso	˦				
-bss	Akoose	Nyasoso	˨				
-							
-bqz	Bakaka (Mwaneka)	Mwaneka	p			manenguba.pdf	
-bqz	Bakaka (Mwaneka)	Mwaneka	b				
-bqz	Bakaka (Mwaneka)	Mwaneka	t				
-bqz	Bakaka (Mwaneka)	Mwaneka	d				
-bqz	Bakaka (Mwaneka)	Mwaneka	s				
-bqz	Bakaka (Mwaneka)	Mwaneka	z				
-bqz	Bakaka (Mwaneka)	Mwaneka	l				
-bqz	Bakaka (Mwaneka)	Mwaneka	n				
-bqz	Bakaka (Mwaneka)	Mwaneka	m				
-bqz	Bakaka (Mwaneka)	Mwaneka	j				
-bqz	Bakaka (Mwaneka)	Mwaneka	ʃ				
-bqz	Bakaka (Mwaneka)	Mwaneka	ɟ				
-bqz	Bakaka (Mwaneka)	Mwaneka	ɲ				
-bqz	Bakaka (Mwaneka)	Mwaneka	k				
-bqz	Bakaka (Mwaneka)	Mwaneka	ɡ				
-bqz	Bakaka (Mwaneka)	Mwaneka	w				
-bqz	Bakaka (Mwaneka)	Mwaneka	h				
-bqz	Bakaka (Mwaneka)	Mwaneka	ʔ				
-bqz	Bakaka (Mwaneka)	Mwaneka	ŋ				
-bqz	Bakaka (Mwaneka)	Mwaneka	i				
-bqz	Bakaka (Mwaneka)	Mwaneka	u				
-bqz	Bakaka (Mwaneka)	Mwaneka	ɔ				
-bqz	Bakaka (Mwaneka)	Mwaneka	e				
-bqz	Bakaka (Mwaneka)	Mwaneka	ɛ				
-bqz	Bakaka (Mwaneka)	Mwaneka	a				
-bqz	Bakaka (Mwaneka)	Mwaneka	o				
-bqz	Bakaka (Mwaneka)	Mwaneka	iː				
-bqz	Bakaka (Mwaneka)	Mwaneka	eː				
-bqz	Bakaka (Mwaneka)	Mwaneka	ɛː				
-bqz	Bakaka (Mwaneka)	Mwaneka	aː				
-bqz	Bakaka (Mwaneka)	Mwaneka	ɔː				
-bqz	Bakaka (Mwaneka)	Mwaneka	oː				
-bqz	Bakaka (Mwaneka)	Mwaneka	˦				
-bqz	Bakaka (Mwaneka)	Mwaneka	˨				
-							
+bss	Akoose	Nyasoso	b
+bss	Akoose	Nyasoso	m
+bss	Akoose	Nyasoso	t
+bss	Akoose	Nyasoso	d
+bss	Akoose	Nyasoso	s
+bss	Akoose	Nyasoso	z
+bss	Akoose	Nyasoso	l
+bss	Akoose	Nyasoso	n
+bss	Akoose	Nyasoso	c
+bss	Akoose	Nyasoso	ɟ
+bss	Akoose	Nyasoso	j
+bss	Akoose	Nyasoso	ɲ		[ɲ]
+bss	Akoose	Nyasoso	k
+bss	Akoose	Nyasoso	ɡ
+bss	Akoose	Nyasoso	w
+bss	Akoose	Nyasoso	h
+bss	Akoose	Nyasoso	b
+bss	Akoose	Nyasoso	d
+bss	Akoose	Nyasoso	ɡ
+bss	Akoose	Nyasoso	<ʔ>	marginal
+bss	Akoose	Nyasoso	ɲ		[ŋ]
+bss	Akoose	Nyasoso	i
+bss	Akoose	Nyasoso	e
+bss	Akoose	Nyasoso	ə
+bss	Akoose	Nyasoso	ɛ
+bss	Akoose	Nyasoso	ɑ
+bss	Akoose	Nyasoso	o
+bss	Akoose	Nyasoso	ɔ
+bss	Akoose	Nyasoso	ø
+bss	Akoose	Nyasoso	iː
+bss	Akoose	Nyasoso	aː
+bss	Akoose	Nyasoso	uː
+bss	Akoose	Nyasoso	ɔː
+bss	Akoose	Nyasoso	˦
+bss	Akoose	Nyasoso	˨
+
+bqz	Bakaka (Mwaneka)	Mwaneka	p			manenguba.pdf
+bqz	Bakaka (Mwaneka)	Mwaneka	b
+bqz	Bakaka (Mwaneka)	Mwaneka	t
+bqz	Bakaka (Mwaneka)	Mwaneka	d
+bqz	Bakaka (Mwaneka)	Mwaneka	s
+bqz	Bakaka (Mwaneka)	Mwaneka	z
+bqz	Bakaka (Mwaneka)	Mwaneka	l
+bqz	Bakaka (Mwaneka)	Mwaneka	n
+bqz	Bakaka (Mwaneka)	Mwaneka	m
+bqz	Bakaka (Mwaneka)	Mwaneka	j
+bqz	Bakaka (Mwaneka)	Mwaneka	ʃ
+bqz	Bakaka (Mwaneka)	Mwaneka	ɟ
+bqz	Bakaka (Mwaneka)	Mwaneka	ɲ
+bqz	Bakaka (Mwaneka)	Mwaneka	k
+bqz	Bakaka (Mwaneka)	Mwaneka	ɡ
+bqz	Bakaka (Mwaneka)	Mwaneka	w
+bqz	Bakaka (Mwaneka)	Mwaneka	h
+bqz	Bakaka (Mwaneka)	Mwaneka	ʔ
+bqz	Bakaka (Mwaneka)	Mwaneka	ŋ
+bqz	Bakaka (Mwaneka)	Mwaneka	i
+bqz	Bakaka (Mwaneka)	Mwaneka	u
+bqz	Bakaka (Mwaneka)	Mwaneka	ɔ
+bqz	Bakaka (Mwaneka)	Mwaneka	e
+bqz	Bakaka (Mwaneka)	Mwaneka	ɛ
+bqz	Bakaka (Mwaneka)	Mwaneka	a
+bqz	Bakaka (Mwaneka)	Mwaneka	o
+bqz	Bakaka (Mwaneka)	Mwaneka	iː
+bqz	Bakaka (Mwaneka)	Mwaneka	eː
+bqz	Bakaka (Mwaneka)	Mwaneka	ɛː
+bqz	Bakaka (Mwaneka)	Mwaneka	aː
+bqz	Bakaka (Mwaneka)	Mwaneka	ɔː
+bqz	Bakaka (Mwaneka)	Mwaneka	oː
+bqz	Bakaka (Mwaneka)	Mwaneka	˦
+bqz	Bakaka (Mwaneka)	Mwaneka	˨
+
 bqz	Bakaka (Babong)	Babong	p				manenguba.pdf
-bqz	Bakaka (Babong)	Babong	b				
-bqz	Bakaka (Babong)	Babong	f		[f]		
-bqz	Bakaka (Babong)	Babong	f		[v]		
-bqz	Bakaka (Babong)	Babong	m				
-bqz	Bakaka (Babong)	Babong	n				
-bqz	Bakaka (Babong)	Babong	ɟ				
-bqz	Bakaka (Babong)	Babong	j				
-bqz	Bakaka (Babong)	Babong	w				
-bqz	Bakaka (Babong)	Babong	t				
-bqz	Bakaka (Babong)	Babong	d				
-bqz	Bakaka (Babong)	Babong	s				
-bqz	Bakaka (Babong)	Babong	z				
-bqz	Bakaka (Babong)	Babong	ɡ				
-bqz	Bakaka (Babong)	Babong	h				
-bqz	Bakaka (Babong)	Babong	ŋ				
-bqz	Bakaka (Babong)	Babong	˦				
-bqz	Bakaka (Babong)	Babong	˨				
-bqz	Bakaka (Babong)	Babong	i				
-bqz	Bakaka (Babong)	Babong	e				
-bqz	Bakaka (Babong)	Babong	ɛ				
-bqz	Bakaka (Babong)	Babong	a				
-bqz	Bakaka (Babong)	Babong	ɔ				
-bqz	Bakaka (Babong)	Babong	o				
-bqz	Bakaka (Babong)	Babong	u				
-bqz	Bakaka (Babong)	Babong	iː				
-bqz	Bakaka (Babong)	Babong	eː				
-bqz	Bakaka (Babong)	Babong	ɛː				
-bqz	Bakaka (Babong)	Babong	aː				
-bqz	Bakaka (Babong)	Babong	ɔː				
-bqz	Bakaka (Babong)	Babong	oː				
-bqz	Bakaka (Babong)	Babong	uː				
-							
+bqz	Bakaka (Babong)	Babong	b
+bqz	Bakaka (Babong)	Babong	f		[f]
+bqz	Bakaka (Babong)	Babong	f		[v]
+bqz	Bakaka (Babong)	Babong	m
+bqz	Bakaka (Babong)	Babong	n
+bqz	Bakaka (Babong)	Babong	ɟ
+bqz	Bakaka (Babong)	Babong	j
+bqz	Bakaka (Babong)	Babong	w
+bqz	Bakaka (Babong)	Babong	t
+bqz	Bakaka (Babong)	Babong	d
+bqz	Bakaka (Babong)	Babong	s
+bqz	Bakaka (Babong)	Babong	z
+bqz	Bakaka (Babong)	Babong	ɡ
+bqz	Bakaka (Babong)	Babong	h
+bqz	Bakaka (Babong)	Babong	ŋ
+bqz	Bakaka (Babong)	Babong	˦
+bqz	Bakaka (Babong)	Babong	˨
+bqz	Bakaka (Babong)	Babong	i
+bqz	Bakaka (Babong)	Babong	e
+bqz	Bakaka (Babong)	Babong	ɛ
+bqz	Bakaka (Babong)	Babong	a
+bqz	Bakaka (Babong)	Babong	ɔ
+bqz	Bakaka (Babong)	Babong	o
+bqz	Bakaka (Babong)	Babong	u
+bqz	Bakaka (Babong)	Babong	iː
+bqz	Bakaka (Babong)	Babong	eː
+bqz	Bakaka (Babong)	Babong	ɛː
+bqz	Bakaka (Babong)	Babong	aː
+bqz	Bakaka (Babong)	Babong	ɔː
+bqz	Bakaka (Babong)	Babong	oː
+bqz	Bakaka (Babong)	Babong	uː
+
 bqz	Bakaka (Mkaa')	Mkaa'	i				manenguba.pdf
-bqz	Bakaka (Mkaa')	Mkaa'	e				
-bqz	Bakaka (Mkaa')	Mkaa'	ɛ				
-bqz	Bakaka (Mkaa')	Mkaa'	a				
-bqz	Bakaka (Mkaa')	Mkaa'	ɔ				
-bqz	Bakaka (Mkaa')	Mkaa'	o				
-bqz	Bakaka (Mkaa')	Mkaa'	u				
-bqz	Bakaka (Mkaa')	Mkaa'	iː				
-bqz	Bakaka (Mkaa')	Mkaa'	eː				
-bqz	Bakaka (Mkaa')	Mkaa'	ɛː				
-bqz	Bakaka (Mkaa')	Mkaa'	aː				
-bqz	Bakaka (Mkaa')	Mkaa'	ɔː				
-bqz	Bakaka (Mkaa')	Mkaa'	oː				
-bqz	Bakaka (Mkaa')	Mkaa'	uː				
-bqz	Bakaka (Mkaa')	Mkaa'	˦				
-bqz	Bakaka (Mkaa')	Mkaa'	˨				
-bqz	Bakaka (Mkaa')	Mkaa'	p				
-bqz	Bakaka (Mkaa')	Mkaa'	b				
-bqz	Bakaka (Mkaa')	Mkaa'	m				
-bqz	Bakaka (Mkaa')	Mkaa'	t				
-bqz	Bakaka (Mkaa')	Mkaa'	d				
-bqz	Bakaka (Mkaa')	Mkaa'	s				
-bqz	Bakaka (Mkaa')	Mkaa'	l				
-bqz	Bakaka (Mkaa')	Mkaa'	n				
-bqz	Bakaka (Mkaa')	Mkaa'	ɟ				
-bqz	Bakaka (Mkaa')	Mkaa'	j				
-bqz	Bakaka (Mkaa')	Mkaa'	ɲ				
-bqz	Bakaka (Mkaa')	Mkaa'	k				
-bqz	Bakaka (Mkaa')	Mkaa'	ɡ				
-bqz	Bakaka (Mkaa')	Mkaa'	w				
-bqz	Bakaka (Mkaa')	Mkaa'	h				
-bqz	Bakaka (Mkaa')	Mkaa'	ŋ				
-bqz	Bakaka (Mkaa')	Mkaa'	˦				
-bqz	Bakaka (Mkaa')	Mkaa'	˨				
-							
+bqz	Bakaka (Mkaa')	Mkaa'	e
+bqz	Bakaka (Mkaa')	Mkaa'	ɛ
+bqz	Bakaka (Mkaa')	Mkaa'	a
+bqz	Bakaka (Mkaa')	Mkaa'	ɔ
+bqz	Bakaka (Mkaa')	Mkaa'	o
+bqz	Bakaka (Mkaa')	Mkaa'	u
+bqz	Bakaka (Mkaa')	Mkaa'	iː
+bqz	Bakaka (Mkaa')	Mkaa'	eː
+bqz	Bakaka (Mkaa')	Mkaa'	ɛː
+bqz	Bakaka (Mkaa')	Mkaa'	aː
+bqz	Bakaka (Mkaa')	Mkaa'	ɔː
+bqz	Bakaka (Mkaa')	Mkaa'	oː
+bqz	Bakaka (Mkaa')	Mkaa'	uː
+bqz	Bakaka (Mkaa')	Mkaa'	˦
+bqz	Bakaka (Mkaa')	Mkaa'	˨
+bqz	Bakaka (Mkaa')	Mkaa'	p
+bqz	Bakaka (Mkaa')	Mkaa'	b
+bqz	Bakaka (Mkaa')	Mkaa'	m
+bqz	Bakaka (Mkaa')	Mkaa'	t
+bqz	Bakaka (Mkaa')	Mkaa'	d
+bqz	Bakaka (Mkaa')	Mkaa'	s
+bqz	Bakaka (Mkaa')	Mkaa'	l
+bqz	Bakaka (Mkaa')	Mkaa'	n
+bqz	Bakaka (Mkaa')	Mkaa'	ɟ
+bqz	Bakaka (Mkaa')	Mkaa'	j
+bqz	Bakaka (Mkaa')	Mkaa'	ɲ
+bqz	Bakaka (Mkaa')	Mkaa'	k
+bqz	Bakaka (Mkaa')	Mkaa'	ɡ
+bqz	Bakaka (Mkaa')	Mkaa'	w
+bqz	Bakaka (Mkaa')	Mkaa'	h
+bqz	Bakaka (Mkaa')	Mkaa'	ŋ
+bqz	Bakaka (Mkaa')	Mkaa'	˦
+bqz	Bakaka (Mkaa')	Mkaa'	˨
+
 mbo	Mbo (Ekanang)	Ekanang	p				manenguba.pdf
-mbo	Mbo (Ekanang)	Ekanang	b				
-mbo	Mbo (Ekanang)	Ekanang	m				
-mbo	Mbo (Ekanang)	Ekanang	t				
-mbo	Mbo (Ekanang)	Ekanang	d				
-mbo	Mbo (Ekanang)	Ekanang	s				
-mbo	Mbo (Ekanang)	Ekanang	z				
-mbo	Mbo (Ekanang)	Ekanang	l				
-mbo	Mbo (Ekanang)	Ekanang	n				
-mbo	Mbo (Ekanang)	Ekanang	ʃ				
-mbo	Mbo (Ekanang)	Ekanang	ʒ				
-mbo	Mbo (Ekanang)	Ekanang	ɟ				
-mbo	Mbo (Ekanang)	Ekanang	k				
-mbo	Mbo (Ekanang)	Ekanang	ɡ				
-mbo	Mbo (Ekanang)	Ekanang	h				
-mbo	Mbo (Ekanang)	Ekanang	w				
-mbo	Mbo (Ekanang)	Ekanang	ʔ				
-mbo	Mbo (Ekanang)	Ekanang	ɲ				
-mbo	Mbo (Ekanang)	Ekanang	ŋ				
-mbo	Mbo (Ekanang)	Ekanang	i				
-mbo	Mbo (Ekanang)	Ekanang	ə				
-mbo	Mbo (Ekanang)	Ekanang	e				
-mbo	Mbo (Ekanang)	Ekanang	ɛ				
-mbo	Mbo (Ekanang)	Ekanang	a				
-mbo	Mbo (Ekanang)	Ekanang	ɑ				
-mbo	Mbo (Ekanang)	Ekanang	ɔ				
-mbo	Mbo (Ekanang)	Ekanang	ø				
-mbo	Mbo (Ekanang)	Ekanang	u				
-mbo	Mbo (Ekanang)	Ekanang	ʊ				
-mbo	Mbo (Ekanang)	Ekanang	iː				
-mbo	Mbo (Ekanang)	Ekanang	eː				
-mbo	Mbo (Ekanang)	Ekanang	əː				
-mbo	Mbo (Ekanang)	Ekanang	uː				
-mbo	Mbo (Ekanang)	Ekanang	˦				
-mbo	Mbo (Ekanang)	Ekanang	˨				
-							
+mbo	Mbo (Ekanang)	Ekanang	b
+mbo	Mbo (Ekanang)	Ekanang	m
+mbo	Mbo (Ekanang)	Ekanang	t
+mbo	Mbo (Ekanang)	Ekanang	d
+mbo	Mbo (Ekanang)	Ekanang	s
+mbo	Mbo (Ekanang)	Ekanang	z
+mbo	Mbo (Ekanang)	Ekanang	l
+mbo	Mbo (Ekanang)	Ekanang	n
+mbo	Mbo (Ekanang)	Ekanang	ʃ
+mbo	Mbo (Ekanang)	Ekanang	ʒ
+mbo	Mbo (Ekanang)	Ekanang	ɟ
+mbo	Mbo (Ekanang)	Ekanang	k
+mbo	Mbo (Ekanang)	Ekanang	ɡ
+mbo	Mbo (Ekanang)	Ekanang	h
+mbo	Mbo (Ekanang)	Ekanang	w
+mbo	Mbo (Ekanang)	Ekanang	ʔ
+mbo	Mbo (Ekanang)	Ekanang	ɲ
+mbo	Mbo (Ekanang)	Ekanang	ŋ
+mbo	Mbo (Ekanang)	Ekanang	i
+mbo	Mbo (Ekanang)	Ekanang	ə
+mbo	Mbo (Ekanang)	Ekanang	e
+mbo	Mbo (Ekanang)	Ekanang	ɛ
+mbo	Mbo (Ekanang)	Ekanang	a
+mbo	Mbo (Ekanang)	Ekanang	ɑ
+mbo	Mbo (Ekanang)	Ekanang	ɔ
+mbo	Mbo (Ekanang)	Ekanang	ø
+mbo	Mbo (Ekanang)	Ekanang	u
+mbo	Mbo (Ekanang)	Ekanang	ʊ
+mbo	Mbo (Ekanang)	Ekanang	iː
+mbo	Mbo (Ekanang)	Ekanang	eː
+mbo	Mbo (Ekanang)	Ekanang	əː
+mbo	Mbo (Ekanang)	Ekanang	uː
+mbo	Mbo (Ekanang)	Ekanang	˦
+mbo	Mbo (Ekanang)	Ekanang	˨
+
 bsi	Bassossi	Mienge	p				manenguba.pdf
-bsi	Bassossi	Mienge	b		[b]		
-bsi	Bassossi	Mienge	b		[b̤]		
-bsi	Bassossi	Mienge	m				
-bsi	Bassossi	Mienge	t				
-bsi	Bassossi	Mienge	d				
-bsi	Bassossi	Mienge	s				
-bsi	Bassossi	Mienge	z				
-bsi	Bassossi	Mienge	l				
-bsi	Bassossi	Mienge	n				
-bsi	Bassossi	Mienge	ɟ				
-bsi	Bassossi	Mienge	j				
-bsi	Bassossi	Mienge	ɲ				
-bsi	Bassossi	Mienge	k				
-bsi	Bassossi	Mienge	ɡ				
-bsi	Bassossi	Mienge	w				
-bsi	Bassossi	Mienge	kp				
-bsi	Bassossi	Mienge	ɡb				
-bsi	Bassossi	Mienge	h				
-bsi	Bassossi	Mienge	ʔ				
-bsi	Bassossi	Mienge	ŋ				
-bsi	Bassossi	Mienge	i				
-bsi	Bassossi	Mienge	ə				
-bsi	Bassossi	Mienge	ɔ				
-bsi	Bassossi	Mienge	ɛ				
-bsi	Bassossi	Mienge	a				
-bsi	Bassossi	Mienge	ɑ				
-bsi	Bassossi	Mienge	ɔ				
-bsi	Bassossi	Mienge	o				
-bsi	Bassossi	Mienge	u				
-bsi	Bassossi	Mienge	iː				
-bsi	Bassossi	Mienge	əː				
-bsi	Bassossi	Mienge	ɔː				
-bsi	Bassossi	Mienge	uː				
-bsi	Bassossi	Mienge	˦				
-bsi	Bassossi	Mienge	˨				
-							
+bsi	Bassossi	Mienge	b		[b]
+bsi	Bassossi	Mienge	b		[b̤]
+bsi	Bassossi	Mienge	m
+bsi	Bassossi	Mienge	t
+bsi	Bassossi	Mienge	d
+bsi	Bassossi	Mienge	s
+bsi	Bassossi	Mienge	z
+bsi	Bassossi	Mienge	l
+bsi	Bassossi	Mienge	n
+bsi	Bassossi	Mienge	ɟ
+bsi	Bassossi	Mienge	j
+bsi	Bassossi	Mienge	ɲ
+bsi	Bassossi	Mienge	k
+bsi	Bassossi	Mienge	ɡ
+bsi	Bassossi	Mienge	w
+bsi	Bassossi	Mienge	kp
+bsi	Bassossi	Mienge	ɡb
+bsi	Bassossi	Mienge	h
+bsi	Bassossi	Mienge	ʔ
+bsi	Bassossi	Mienge	ŋ
+bsi	Bassossi	Mienge	i
+bsi	Bassossi	Mienge	ə
+bsi	Bassossi	Mienge	ɔ
+bsi	Bassossi	Mienge	ɛ
+bsi	Bassossi	Mienge	a
+bsi	Bassossi	Mienge	ɑ
+bsi	Bassossi	Mienge	ɔ
+bsi	Bassossi	Mienge	o
+bsi	Bassossi	Mienge	u
+bsi	Bassossi	Mienge	iː
+bsi	Bassossi	Mienge	əː
+bsi	Bassossi	Mienge	ɔː
+bsi	Bassossi	Mienge	uː
+bsi	Bassossi	Mienge	˦
+bsi	Bassossi	Mienge	˨
+
 mbo	Mbo (Ngwatta)	Ngwatta	p				manenguba.pdf
-mbo	Mbo (Ngwatta)	Ngwatta	b				
-mbo	Mbo (Ngwatta)	Ngwatta	f				
-mbo	Mbo (Ngwatta)	Ngwatta	m				
-mbo	Mbo (Ngwatta)	Ngwatta	t				
-mbo	Mbo (Ngwatta)	Ngwatta	d				
-mbo	Mbo (Ngwatta)	Ngwatta	s				
-mbo	Mbo (Ngwatta)	Ngwatta	z				
-mbo	Mbo (Ngwatta)	Ngwatta	l				
-mbo	Mbo (Ngwatta)	Ngwatta	n				
-mbo	Mbo (Ngwatta)	Ngwatta	ɟ				
-mbo	Mbo (Ngwatta)	Ngwatta	ʃ				
-mbo	Mbo (Ngwatta)	Ngwatta	ʒ				
-mbo	Mbo (Ngwatta)	Ngwatta	j				
-mbo	Mbo (Ngwatta)	Ngwatta	ɲ				
-mbo	Mbo (Ngwatta)	Ngwatta	k				
-mbo	Mbo (Ngwatta)	Ngwatta	ɡ				
-mbo	Mbo (Ngwatta)	Ngwatta	w				
-mbo	Mbo (Ngwatta)	Ngwatta	ʔ				
-mbo	Mbo (Ngwatta)	Ngwatta	jˀ				
-mbo	Mbo (Ngwatta)	Ngwatta	ŋ				
-mbo	Mbo (Ngwatta)	Ngwatta	ə				
-mbo	Mbo (Ngwatta)	Ngwatta	i				
-mbo	Mbo (Ngwatta)	Ngwatta	ɛ				
-mbo	Mbo (Ngwatta)	Ngwatta	e				
-mbo	Mbo (Ngwatta)	Ngwatta	a				
-mbo	Mbo (Ngwatta)	Ngwatta	ɔ				
-mbo	Mbo (Ngwatta)	Ngwatta	o				
-mbo	Mbo (Ngwatta)	Ngwatta	ø				
-mbo	Mbo (Ngwatta)	Ngwatta	u				
-mbo	Mbo (Ngwatta)	Ngwatta	iː				
-mbo	Mbo (Ngwatta)	Ngwatta	əː				
-mbo	Mbo (Ngwatta)	Ngwatta	ɛː				
-mbo	Mbo (Ngwatta)	Ngwatta	uː				
-mbo	Mbo (Ngwatta)	Ngwatta	˦				
-mbo	Mbo (Ngwatta)	Ngwatta	˨				
-							
+mbo	Mbo (Ngwatta)	Ngwatta	b
+mbo	Mbo (Ngwatta)	Ngwatta	f
+mbo	Mbo (Ngwatta)	Ngwatta	m
+mbo	Mbo (Ngwatta)	Ngwatta	t
+mbo	Mbo (Ngwatta)	Ngwatta	d
+mbo	Mbo (Ngwatta)	Ngwatta	s
+mbo	Mbo (Ngwatta)	Ngwatta	z
+mbo	Mbo (Ngwatta)	Ngwatta	l
+mbo	Mbo (Ngwatta)	Ngwatta	n
+mbo	Mbo (Ngwatta)	Ngwatta	ɟ
+mbo	Mbo (Ngwatta)	Ngwatta	ʃ
+mbo	Mbo (Ngwatta)	Ngwatta	ʒ
+mbo	Mbo (Ngwatta)	Ngwatta	j
+mbo	Mbo (Ngwatta)	Ngwatta	ɲ
+mbo	Mbo (Ngwatta)	Ngwatta	k
+mbo	Mbo (Ngwatta)	Ngwatta	ɡ
+mbo	Mbo (Ngwatta)	Ngwatta	w
+mbo	Mbo (Ngwatta)	Ngwatta	ʔ
+mbo	Mbo (Ngwatta)	Ngwatta	jˀ
+mbo	Mbo (Ngwatta)	Ngwatta	ŋ
+mbo	Mbo (Ngwatta)	Ngwatta	ə
+mbo	Mbo (Ngwatta)	Ngwatta	i
+mbo	Mbo (Ngwatta)	Ngwatta	ɛ
+mbo	Mbo (Ngwatta)	Ngwatta	e
+mbo	Mbo (Ngwatta)	Ngwatta	a
+mbo	Mbo (Ngwatta)	Ngwatta	ɔ
+mbo	Mbo (Ngwatta)	Ngwatta	o
+mbo	Mbo (Ngwatta)	Ngwatta	ø
+mbo	Mbo (Ngwatta)	Ngwatta	u
+mbo	Mbo (Ngwatta)	Ngwatta	iː
+mbo	Mbo (Ngwatta)	Ngwatta	əː
+mbo	Mbo (Ngwatta)	Ngwatta	ɛː
+mbo	Mbo (Ngwatta)	Ngwatta	uː
+mbo	Mbo (Ngwatta)	Ngwatta	˦
+mbo	Mbo (Ngwatta)	Ngwatta	˨
+
 lir	Liberian English		p				lir.pdf
-lir	Liberian English		b				
-lir	Liberian English		f				
-lir	Liberian English		v				
-lir	Liberian English		m				
-lir	Liberian English		w				
-lir	Liberian English		t				
-lir	Liberian English		d				
-lir	Liberian English		s				
-lir	Liberian English		z				
-lir	Liberian English		n				
-lir	Liberian English		l				
-lir	Liberian English		r				
-lir	Liberian English		ʃ				
-lir	Liberian English		ʒ				
-lir	Liberian English		t̠ʃ				
-lir	Liberian English		d̠ʒ				
-lir	Liberian English		ɲ				
-lir	Liberian English		j				
-lir	Liberian English		k				
-lir	Liberian English		ɡ				
-lir	Liberian English		ŋ				
-lir	Liberian English		<kp>	borrowings from African languages			
-lir	Liberian English		<ɡb>	borrowings from African languages			
-lir	Liberian English		i				
-lir	Liberian English		e				
-lir	Liberian English		ɛ				
-lir	Liberian English		a				
-lir	Liberian English		u				
-lir	Liberian English		o				
-lir	Liberian English		ɔ				
-lir	Liberian English		ĩ				
-lir	Liberian English		ɛ̃				
-lir	Liberian English		ã				
-lir	Liberian English		ũ				
-lir	Liberian English		ɔ̃				
-							
+lir	Liberian English		b
+lir	Liberian English		f
+lir	Liberian English		v
+lir	Liberian English		m
+lir	Liberian English		w
+lir	Liberian English		t
+lir	Liberian English		d
+lir	Liberian English		s
+lir	Liberian English		z
+lir	Liberian English		n
+lir	Liberian English		l
+lir	Liberian English		r
+lir	Liberian English		ʃ
+lir	Liberian English		ʒ
+lir	Liberian English		t̠ʃ
+lir	Liberian English		d̠ʒ
+lir	Liberian English		ɲ
+lir	Liberian English		j
+lir	Liberian English		k
+lir	Liberian English		ɡ
+lir	Liberian English		ŋ
+lir	Liberian English		<kp>	borrowings from African languages
+lir	Liberian English		<ɡb>	borrowings from African languages
+lir	Liberian English		i
+lir	Liberian English		e
+lir	Liberian English		ɛ
+lir	Liberian English		a
+lir	Liberian English		u
+lir	Liberian English		o
+lir	Liberian English		ɔ
+lir	Liberian English		ĩ
+lir	Liberian English		ɛ̃
+lir	Liberian English		ã
+lir	Liberian English		ũ
+lir	Liberian English		ɔ̃
+
 ggu	Gban		ɸ				ggu.pdf
-ggu	Gban		β				
-ggu	Gban		t	pre-alveolar			
-ggu	Gban		d	pre-alveolar			
-ggu	Gban		s	post-alveolar, but not [ʃ]			
-ggu	Gban		z	post-alveolar, but not [ʒ]			
-ggu	Gban		<c>	marɡinal			
-ggu	Gban		<ɟ>	marɡinal			
-ggu	Gban		k				
-ggu	Gban		ɡ				
-ggu	Gban		kp				
-ggu	Gban		ɡb				
-ggu	Gban		kʷ	marɡinal			
-ggu	Gban		ɡʷ	marɡinal			
-ggu	Gban		b				
-ggu	Gban		l		[l]	syllable-initial	
-ggu	Gban		m				
-ggu	Gban		n		[n]		
-ggu	Gban		n		[m]		
-ggu	Gban		n		[ŋ]		
-ggu	Gban		j		[j]	before oral vowels	
-ggu	Gban		j		[ɲj̃]	before nasal vowels	
-ggu	Gban		w		[w]	before oral vowels	
-ggu	Gban		w		[ŋw̃]	before nasal vowels	
-ggu	Gban		l		[ɺ]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen	
-ggu	Gban		l		[ɾ]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen	
-ggu	Gban		l		[r̃]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen	
-ggu	Gban		l		[ɲ]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen	
-ggu	Gban		i		[i]		
-ggu	Gban		i		[ĩ]		
-ggu	Gban		e		[ɛ̃]		
-ggu	Gban		e		[e]		
-ggu	Gban		ɛ		[ɛ]		
-ggu	Gban		ɛ		[ɛ̃]		
-ggu	Gban		a		[a]		
-ggu	Gban		a		[ã]		
-ggu	Gban		u		[u]		
-ggu	Gban		u		[ũ]		
-ggu	Gban		ɔ		[ɔ]		
-ggu	Gban		ɔ		[ɔ̃]		
-ggu	Gban		o		[o]		
-ggu	Gban		o		[ɔ̃]		
-ggu	Gban		ĩ				
-ggu	Gban		ɛ̃				
-ggu	Gban		ã				
-ggu	Gban		ɔ̃				
-ggu	Gban		ũ				
-ggu	Gban		˨˧				
-ggu	Gban		˧˨				
-ggu	Gban		˦				
-ggu	Gban		˨				
-							
+ggu	Gban		β
+ggu	Gban		t	pre-alveolar
+ggu	Gban		d	pre-alveolar
+ggu	Gban		s	post-alveolar, but not [ʃ]
+ggu	Gban		z	post-alveolar, but not [ʒ]
+ggu	Gban		<c>	marɡinal
+ggu	Gban		<ɟ>	marɡinal
+ggu	Gban		k
+ggu	Gban		ɡ
+ggu	Gban		kp
+ggu	Gban		ɡb
+ggu	Gban		kʷ	marɡinal
+ggu	Gban		ɡʷ	marɡinal
+ggu	Gban		b
+ggu	Gban		l		[l]	syllable-initial
+ggu	Gban		m
+ggu	Gban		n		[n]
+ggu	Gban		n		[m]
+ggu	Gban		n		[ŋ]
+ggu	Gban		j		[j]	before oral vowels
+ggu	Gban		j		[ɲj̃]	before nasal vowels
+ggu	Gban		w		[w]	before oral vowels
+ggu	Gban		w		[ŋw̃]	before nasal vowels
+ggu	Gban		l		[ɺ]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen
+ggu	Gban		l		[ɾ]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen
+ggu	Gban		l		[r̃]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen
+ggu	Gban		l		[ɲ]	the intended realization of this allophone is unclear, but based upon discussion and spectra, this symbol was chosen
+ggu	Gban		i		[i]
+ggu	Gban		i		[ĩ]
+ggu	Gban		e		[ɛ̃]
+ggu	Gban		e		[e]
+ggu	Gban		ɛ		[ɛ]
+ggu	Gban		ɛ		[ɛ̃]
+ggu	Gban		a		[a]
+ggu	Gban		a		[ã]
+ggu	Gban		u		[u]
+ggu	Gban		u		[ũ]
+ggu	Gban		ɔ		[ɔ]
+ggu	Gban		ɔ		[ɔ̃]
+ggu	Gban		o		[o]
+ggu	Gban		o		[ɔ̃]
+ggu	Gban		ĩ
+ggu	Gban		ɛ̃
+ggu	Gban		ã
+ggu	Gban		ɔ̃
+ggu	Gban		ũ
+ggu	Gban		˨˧
+ggu	Gban		˧˨
+ggu	Gban		˦
+ggu	Gban		˨
+
 eto	Eton		p				eto.pdf
-eto	Eton		b	optional lenition to [β]	[b]		
-eto	Eton		b		[bʷ]	before [o]	
-eto	Eton		v				
-eto	Eton		m		[m]		
-eto	Eton		m		[mʷ]	before [o]	
-eto	Eton		t	sliɡhtly affricated before [i]			
-eto	Eton		d	optional lenition to [r], sliɡhtly affricated before [i]			
-eto	Eton		s				
-eto	Eton		z	optional lenition to [ɦ] or null			
-eto	Eton		n				
-eto	Eton		l				
-eto	Eton		t̠ʃ				
-eto	Eton		d̠ʒ				
-eto	Eton		ɲ				
-eto	Eton		j				
-eto	Eton		k		[k]		
-eto	Eton		k		[kʷ]	before [o]	
-eto	Eton		ɡ	optional lenition to [ɰ]			
-eto	Eton		ŋ				
-eto	Eton		kp				
-eto	Eton		ɡb				
-eto	Eton		ŋm				
-eto	Eton		w		[w]		
-eto	Eton		i		[i]		
-eto	Eton		iː				
-eto	Eton		e		[e]		
-eto	Eton		eː				
-eto	Eton		ɛ		[ɛ]		
-eto	Eton		ɛː				
-eto	Eton		a		[a]		
-eto	Eton		aː				
-eto	Eton		ə				
-eto	Eton		u		[u]		
-eto	Eton		uː				
-eto	Eton		o		[o]		
-eto	Eton		oː				
-eto	Eton		ɔ		[ɔ]		
-eto	Eton		ɔː				
-eto	Eton		w		[ɥ]	before [i], after [ɲ]	
-eto	Eton		m		[ɱ]	before [v]	
-eto	Eton		ɛ		[ɜ]	before labial and velar consonants and before [j]	
-eto	Eton		a		[ɑ]	after [w]	
-eto	Eton		i		[ĩ]		
-eto	Eton		e		[ẽ]		
-eto	Eton		ɛ		[ɛ̃]		
-eto	Eton		a		[ã]		
-eto	Eton		u		[ũ]		
-eto	Eton		o		[õ]		
-eto	Eton		ɔ		[ɔ̃]		
-eto	Eton		˦				
-eto	Eton		˨				
-eto	Eton		˦	there is a second 'dissimilating' H tone			
-							
+eto	Eton		b	optional lenition to [β]	[b]
+eto	Eton		b		[bʷ]	before [o]
+eto	Eton		v
+eto	Eton		m		[m]
+eto	Eton		m		[mʷ]	before [o]
+eto	Eton		t	sliɡhtly affricated before [i]
+eto	Eton		d	optional lenition to [r], sliɡhtly affricated before [i]
+eto	Eton		s
+eto	Eton		z	optional lenition to [ɦ] or null
+eto	Eton		n
+eto	Eton		l
+eto	Eton		t̠ʃ
+eto	Eton		d̠ʒ
+eto	Eton		ɲ
+eto	Eton		j
+eto	Eton		k		[k]
+eto	Eton		k		[kʷ]	before [o]
+eto	Eton		ɡ	optional lenition to [ɰ]
+eto	Eton		ŋ
+eto	Eton		kp
+eto	Eton		ɡb
+eto	Eton		ŋm
+eto	Eton		w		[w]
+eto	Eton		i		[i]
+eto	Eton		iː
+eto	Eton		e		[e]
+eto	Eton		eː
+eto	Eton		ɛ		[ɛ]
+eto	Eton		ɛː
+eto	Eton		a		[a]
+eto	Eton		aː
+eto	Eton		ə
+eto	Eton		u		[u]
+eto	Eton		uː
+eto	Eton		o		[o]
+eto	Eton		oː
+eto	Eton		ɔ		[ɔ]
+eto	Eton		ɔː
+eto	Eton		w		[ɥ]	before [i], after [ɲ]
+eto	Eton		m		[ɱ]	before [v]
+eto	Eton		ɛ		[ɜ]	before labial and velar consonants and before [j]
+eto	Eton		a		[ɑ]	after [w]
+eto	Eton		i		[ĩ]
+eto	Eton		e		[ẽ]
+eto	Eton		ɛ		[ɛ̃]
+eto	Eton		a		[ã]
+eto	Eton		u		[ũ]
+eto	Eton		o		[õ]
+eto	Eton		ɔ		[ɔ̃]
+eto	Eton		˦
+eto	Eton		˨
+eto	Eton		˦	there is a second 'dissimilating' H tone
+
 rcf	Reunionnais		p				rcf.pdf
-rcf	Reunionnais		pː	word-final only			
-rcf	Reunionnais		b				
-rcf	Reunionnais		bː	word-final only			
-rcf	Reunionnais		f				
-rcf	Reunionnais		fː	word-final only			
-rcf	Reunionnais		v				
-rcf	Reunionnais		vː	word-final only			
-rcf	Reunionnais		t̺				
-rcf	Reunionnais		t̺ː	word-final only			
-rcf	Reunionnais		d̺				
-rcf	Reunionnais		d̺ː	word-final only			
-rcf	Reunionnais		s	predorso-alveolar			
-rcf	Reunionnais		s̺	apico-alveolar			
-rcf	Reunionnais		sː	predorso-alveolar			
-rcf	Reunionnais		z				
-rcf	Reunionnais		z̺	apico-alveolar			
-rcf	Reunionnais		k				
-rcf	Reunionnais		kː	word-final only			
-rcf	Reunionnais		ɡ				
-rcf	Reunionnais		ɡː	word-final only, variation with [ɡ̃ː]			
-rcf	Reunionnais		ʁ		[ʁ]		
-rcf	Reunionnais		ʁ		[ɣ]		
-rcf	Reunionnais		l̪				
-rcf	Reunionnais		lː	word-final only			
-rcf	Reunionnais		m				
-rcf	Reunionnais		mː	word-final only			
-rcf	Reunionnais		n				
-rcf	Reunionnais		nː				
-rcf	Reunionnais		j				
-rcf	Reunionnais		j̃				
-rcf	Reunionnais		i		[i]		
-rcf	Reunionnais		i		[ĩ]		
-rcf	Reunionnais		iː				
-rcf	Reunionnais		u				
-rcf	Reunionnais		uː				
-rcf	Reunionnais		e		[e]	initial position	
-rcf	Reunionnais		e		[e̞]		
-rcf	Reunionnais		o		[o]	initial position	
-rcf	Reunionnais		o		[o̞]		
-rcf	Reunionnais		a		[a]		
-rcf	Reunionnais		a		[ɑ]		
-rcf	Reunionnais		a		[aː]		
-rcf	Reunionnais		ï				
-rcf	Reunionnais		ë				
-rcf	Reunionnais		ẽ				
-rcf	Reunionnais		õ				
-rcf	Reunionnais		ã				
-							
+rcf	Reunionnais		pː	word-final only
+rcf	Reunionnais		b
+rcf	Reunionnais		bː	word-final only
+rcf	Reunionnais		f
+rcf	Reunionnais		fː	word-final only
+rcf	Reunionnais		v
+rcf	Reunionnais		vː	word-final only
+rcf	Reunionnais		t̺
+rcf	Reunionnais		t̺ː	word-final only
+rcf	Reunionnais		d̺
+rcf	Reunionnais		d̺ː	word-final only
+rcf	Reunionnais		s	predorso-alveolar
+rcf	Reunionnais		s̺	apico-alveolar
+rcf	Reunionnais		sː	predorso-alveolar
+rcf	Reunionnais		z
+rcf	Reunionnais		z̺	apico-alveolar
+rcf	Reunionnais		k
+rcf	Reunionnais		kː	word-final only
+rcf	Reunionnais		ɡ
+rcf	Reunionnais		ɡː	word-final only, variation with [ɡ̃ː]
+rcf	Reunionnais		ʁ		[ʁ]
+rcf	Reunionnais		ʁ		[ɣ]
+rcf	Reunionnais		l̪
+rcf	Reunionnais		lː	word-final only
+rcf	Reunionnais		m
+rcf	Reunionnais		mː	word-final only
+rcf	Reunionnais		n
+rcf	Reunionnais		nː
+rcf	Reunionnais		j
+rcf	Reunionnais		j̃
+rcf	Reunionnais		i		[i]
+rcf	Reunionnais		i		[ĩ]
+rcf	Reunionnais		iː
+rcf	Reunionnais		u
+rcf	Reunionnais		uː
+rcf	Reunionnais		e		[e]	initial position
+rcf	Reunionnais		e		[e̞]
+rcf	Reunionnais		o		[o]	initial position
+rcf	Reunionnais		o		[o̞]
+rcf	Reunionnais		a		[a]
+rcf	Reunionnais		a		[ɑ]
+rcf	Reunionnais		a		[aː]
+rcf	Reunionnais		ï
+rcf	Reunionnais		ë
+rcf	Reunionnais		ẽ
+rcf	Reunionnais		õ
+rcf	Reunionnais		ã
+
 mls	Masalit		<p>	rare			mls.pdf
-mls	Masalit		b				
-mls	Masalit		m				
-mls	Masalit		w				
-mls	Masalit		j				
-mls	Masalit		<v>	rare			
-mls	Masalit		<f>	rare			
-mls	Masalit		d̪|d	dental-alveolar			
-mls	Masalit		t̪|t	dental-alveolar			
-mls	Masalit		s̪|s	dental-alveolar			
-mls	Masalit		<z̪|z>	dental-alveolar, Arabic loans only			
-mls	Masalit		n̪|n	dental-alveolar			
-mls	Masalit		l̪|l	dental-alveolar			
-mls	Masalit		r̪|r	dental-alveolar			
-mls	Masalit		t̠ʃ				
-mls	Masalit		ʃ				
-mls	Masalit		d̠ʒ				
-mls	Masalit		ɲ				
-mls	Masalit		<ɥ>	rare			
-mls	Masalit		j				
-mls	Masalit		ɡ				
-mls	Masalit		k				
-mls	Masalit		<x>	Arabic loans only			
-mls	Masalit		ŋ				
-mls	Masalit		w				
-mls	Masalit		<ʔ>	non-phonemic			
-mls	Masalit		<h>	very rare			
-mls	Masalit		<kǀ>	rare			
-mls	Masalit		<kǃ>	rare			
-mls	Masalit		rː				
-mls	Masalit		lː				
-mls	Masalit		mː				
-mls	Masalit		kː				
-mls	Masalit		i				
-mls	Masalit		e				
-mls	Masalit		ɛ				
-mls	Masalit		a				
-mls	Masalit		u				
-mls	Masalit		o				
-mls	Masalit		ɔ				
-mls	Masalit		ɨ				
-mls	Masalit		ə				
-mls	Masalit		ʌ				
-mls	Masalit		˨˦				
-mls	Masalit		˦˨				
-mls	Masalit		˦				
-mls	Masalit		˨				
-							
+mls	Masalit		b
+mls	Masalit		m
+mls	Masalit		w
+mls	Masalit		j
+mls	Masalit		<v>	rare
+mls	Masalit		<f>	rare
+mls	Masalit		d̪|d	dental-alveolar
+mls	Masalit		t̪|t	dental-alveolar
+mls	Masalit		s̪|s	dental-alveolar
+mls	Masalit		<z̪|z>	dental-alveolar, Arabic loans only
+mls	Masalit		n̪|n	dental-alveolar
+mls	Masalit		l̪|l	dental-alveolar
+mls	Masalit		r̪|r	dental-alveolar
+mls	Masalit		t̠ʃ
+mls	Masalit		ʃ
+mls	Masalit		d̠ʒ
+mls	Masalit		ɲ
+mls	Masalit		<ɥ>	rare
+mls	Masalit		j
+mls	Masalit		ɡ
+mls	Masalit		k
+mls	Masalit		<x>	Arabic loans only
+mls	Masalit		ŋ
+mls	Masalit		w
+mls	Masalit		<ʔ>	non-phonemic
+mls	Masalit		<h>	very rare
+mls	Masalit		<kǀ>	rare
+mls	Masalit		<kǃ>	rare
+mls	Masalit		rː
+mls	Masalit		lː
+mls	Masalit		mː
+mls	Masalit		kː
+mls	Masalit		i
+mls	Masalit		e
+mls	Masalit		ɛ
+mls	Masalit		a
+mls	Masalit		u
+mls	Masalit		o
+mls	Masalit		ɔ
+mls	Masalit		ɨ
+mls	Masalit		ə
+mls	Masalit		ʌ
+mls	Masalit		˨˦
+mls	Masalit		˦˨
+mls	Masalit		˦
+mls	Masalit		˨
+
 cri	Saotomense		i				cri.pdf
-cri	Saotomense		ĩ				
-cri	Saotomense		e				
-cri	Saotomense		ẽ				
-cri	Saotomense		ɛ				
-cri	Saotomense		a				
-cri	Saotomense		ã				
-cri	Saotomense		u				
-cri	Saotomense		ũ				
-cri	Saotomense		o				
-cri	Saotomense		õ				
-cri	Saotomense		ə				
-cri	Saotomense		<ɪ̃>	marginal			
-cri	Saotomense		p				
-cri	Saotomense		t				
-cri	Saotomense		k				
-cri	Saotomense		ɓ				
-cri	Saotomense		ɗ				
-cri	Saotomense		ɡ				
-cri	Saotomense		f				
-cri	Saotomense		v				
-cri	Saotomense		z				
-cri	Saotomense		ʒ				
-cri	Saotomense		t̠ʃ				
-cri	Saotomense		d̠ʒ				
-cri	Saotomense		m				
-cri	Saotomense		n		[n]		
-cri	Saotomense		n		[ŋ]		
-cri	Saotomense		<ɲ>	marginal			
-cri	Saotomense		w				
-cri	Saotomense		l				
-cri	Saotomense		<ʎ>	marginal			
-cri	Saotomense		j				
-							
+cri	Saotomense		ĩ
+cri	Saotomense		e
+cri	Saotomense		ẽ
+cri	Saotomense		ɛ
+cri	Saotomense		a
+cri	Saotomense		ã
+cri	Saotomense		u
+cri	Saotomense		ũ
+cri	Saotomense		o
+cri	Saotomense		õ
+cri	Saotomense		ə
+cri	Saotomense		<ɪ̃>	marginal
+cri	Saotomense		p
+cri	Saotomense		t
+cri	Saotomense		k
+cri	Saotomense		ɓ
+cri	Saotomense		ɗ
+cri	Saotomense		ɡ
+cri	Saotomense		f
+cri	Saotomense		v
+cri	Saotomense		z
+cri	Saotomense		ʒ
+cri	Saotomense		t̠ʃ
+cri	Saotomense		d̠ʒ
+cri	Saotomense		m
+cri	Saotomense		n		[n]
+cri	Saotomense		n		[ŋ]
+cri	Saotomense		<ɲ>	marginal
+cri	Saotomense		w
+cri	Saotomense		l
+cri	Saotomense		<ʎ>	marginal
+cri	Saotomense		j
+
 tan	Tangale		i				tan.pdf
-tan	Tangale		ɪ				
-tan	Tangale		e				
-tan	Tangale		ɛ				
-tan	Tangale		a				
-tan	Tangale		u				
-tan	Tangale		ʊ				
-tan	Tangale		o				
-tan	Tangale		ɔ				
-tan	Tangale		p				
-tan	Tangale		b				
-tan	Tangale		ɓ				
-tan	Tangale		bʷ				
-tan	Tangale		ɓʷ				
-tan	Tangale		m				
-tan	Tangale		mb				
-tan	Tangale		w				
-tan	Tangale		d̪̚				
-tan	Tangale		t				
-tan	Tangale		d				
-tan	Tangale		ɗ				
-tan	Tangale		dʷ				
-tan	Tangale		ɗʷ				
-tan	Tangale		tʷ				
-tan	Tangale		s				
-tan	Tangale		z				
-tan	Tangale		sʷ				
-tan	Tangale		zʷ				
-tan	Tangale		n				
-tan	Tangale		nd				
-tan	Tangale		l				
-tan	Tangale		r				
-tan	Tangale		rʷ				
-tan	Tangale		d̠ʒ				
-tan	Tangale		ʃ				
-tan	Tangale		ʒ				
-tan	Tangale		ʃʷ				
-tan	Tangale		ʒʷ				
-tan	Tangale		n̠d̠ʒ				
-tan	Tangale		j				
-tan	Tangale		jʷ				
-tan	Tangale		k				
-tan	Tangale		ɡ				
-tan	Tangale		kʷ				
-tan	Tangale		ɡʷ				
-tan	Tangale		ŋɡ				
-tan	Tangale		ŋ				
-tan	Tangale		ʔ				
-tan	Tangale		h				
-tan	Tangale		iː				
-tan	Tangale		ɪː				
-tan	Tangale		eː				
-tan	Tangale		ɛː				
-tan	Tangale		aː				
-tan	Tangale		uː				
-tan	Tangale		ʊː				
-tan	Tangale		oː				
-tan	Tangale		ɔː				
-tan	Tangale		˦				
-tan	Tangale		˨				
-							
+tan	Tangale		ɪ
+tan	Tangale		e
+tan	Tangale		ɛ
+tan	Tangale		a
+tan	Tangale		u
+tan	Tangale		ʊ
+tan	Tangale		o
+tan	Tangale		ɔ
+tan	Tangale		p
+tan	Tangale		b
+tan	Tangale		ɓ
+tan	Tangale		bʷ
+tan	Tangale		ɓʷ
+tan	Tangale		m
+tan	Tangale		mb
+tan	Tangale		w
+tan	Tangale		d̪̚
+tan	Tangale		t
+tan	Tangale		d
+tan	Tangale		ɗ
+tan	Tangale		dʷ
+tan	Tangale		ɗʷ
+tan	Tangale		tʷ
+tan	Tangale		s
+tan	Tangale		z
+tan	Tangale		sʷ
+tan	Tangale		zʷ
+tan	Tangale		n
+tan	Tangale		nd
+tan	Tangale		l
+tan	Tangale		r
+tan	Tangale		rʷ
+tan	Tangale		d̠ʒ
+tan	Tangale		ʃ
+tan	Tangale		ʒ
+tan	Tangale		ʃʷ
+tan	Tangale		ʒʷ
+tan	Tangale		n̠d̠ʒ
+tan	Tangale		j
+tan	Tangale		jʷ
+tan	Tangale		k
+tan	Tangale		ɡ
+tan	Tangale		kʷ
+tan	Tangale		ɡʷ
+tan	Tangale		ŋɡ
+tan	Tangale		ŋ
+tan	Tangale		ʔ
+tan	Tangale		h
+tan	Tangale		iː
+tan	Tangale		ɪː
+tan	Tangale		eː
+tan	Tangale		ɛː
+tan	Tangale		aː
+tan	Tangale		uː
+tan	Tangale		ʊː
+tan	Tangale		oː
+tan	Tangale		ɔː
+tan	Tangale		˦
+tan	Tangale		˨
+
 suk	Sukuma		i				suk.pdf
-suk	Sukuma		iː				
-suk	Sukuma		e		[ɪ]		
-suk	Sukuma		eː		[ɪː]		
-suk	Sukuma		ɛ				
-suk	Sukuma		ɛː				
-suk	Sukuma		a				
-suk	Sukuma		aː				
-suk	Sukuma		o		[ʊ]		
-suk	Sukuma		oː		[ʊː]		
-suk	Sukuma		ɔ				
-suk	Sukuma		ɔː				
-suk	Sukuma		u				
-suk	Sukuma		uː				
-suk	Sukuma		˨˦				
-suk	Sukuma		˦˨				
-suk	Sukuma		˦				
-suk	Sukuma		˨				
-suk	Sukuma		˧				
-suk	Sukuma		pʰ				
-suk	Sukuma		β		[β]		
-suk	Sukuma		β		[b]	borrowinɡs	
-suk	Sukuma		f				
-suk	Sukuma		<v>	rare			
-suk	Sukuma		tʰ				
-suk	Sukuma		d				
-suk	Sukuma		s				
-suk	Sukuma		<z>	rare			
-suk	Sukuma		ʃ				
-suk	Sukuma		cʰ				
-suk	Sukuma		ɟ				
-suk	Sukuma		kʰ				
-suk	Sukuma		ɡ		[ɡ]		
-suk	Sukuma		ɡ		[ɣ]		
-suk	Sukuma		m				
-suk	Sukuma		m̤ʱ				
-suk	Sukuma		n				
-suk	Sukuma		n̤ʱ				
-suk	Sukuma		ɲ				
-suk	Sukuma		ɲ̤ʱ				
-suk	Sukuma		ŋ				
-suk	Sukuma		ŋ̤ʱ				
-suk	Sukuma		w				
-suk	Sukuma		l				
-suk	Sukuma		j				
-suk	Sukuma		h				
-suk	Sukuma		m̤pʰ				
-suk	Sukuma		mb				
-suk	Sukuma		ɱ̤f				
-suk	Sukuma		ɱv				
-suk	Sukuma		n̤tʰ				
-suk	Sukuma		nd				
-suk	Sukuma		n̤s				
-suk	Sukuma		nz				
-suk	Sukuma		n̠ʃ				
-suk	Sukuma		ɲ̤cʰ				
-suk	Sukuma		ɲɟ				
-suk	Sukuma		ŋ̤kʰ				
-suk	Sukuma		ŋɡ				
-							
+suk	Sukuma		iː
+suk	Sukuma		e		[ɪ]
+suk	Sukuma		eː		[ɪː]
+suk	Sukuma		ɛ
+suk	Sukuma		ɛː
+suk	Sukuma		a
+suk	Sukuma		aː
+suk	Sukuma		o		[ʊ]
+suk	Sukuma		oː		[ʊː]
+suk	Sukuma		ɔ
+suk	Sukuma		ɔː
+suk	Sukuma		u
+suk	Sukuma		uː
+suk	Sukuma		˨˦
+suk	Sukuma		˦˨
+suk	Sukuma		˦
+suk	Sukuma		˨
+suk	Sukuma		˧
+suk	Sukuma		pʰ
+suk	Sukuma		β		[β]
+suk	Sukuma		β		[b]	borrowinɡs
+suk	Sukuma		f
+suk	Sukuma		<v>	rare
+suk	Sukuma		tʰ
+suk	Sukuma		d
+suk	Sukuma		s
+suk	Sukuma		<z>	rare
+suk	Sukuma		ʃ
+suk	Sukuma		cʰ
+suk	Sukuma		ɟ
+suk	Sukuma		kʰ
+suk	Sukuma		ɡ		[ɡ]
+suk	Sukuma		ɡ		[ɣ]
+suk	Sukuma		m
+suk	Sukuma		m̤ʱ
+suk	Sukuma		n
+suk	Sukuma		n̤ʱ
+suk	Sukuma		ɲ
+suk	Sukuma		ɲ̤ʱ
+suk	Sukuma		ŋ
+suk	Sukuma		ŋ̤ʱ
+suk	Sukuma		w
+suk	Sukuma		l
+suk	Sukuma		j
+suk	Sukuma		h
+suk	Sukuma		m̤pʰ
+suk	Sukuma		mb
+suk	Sukuma		ɱ̤f
+suk	Sukuma		ɱv
+suk	Sukuma		n̤tʰ
+suk	Sukuma		nd
+suk	Sukuma		n̤s
+suk	Sukuma		nz
+suk	Sukuma		n̠ʃ
+suk	Sukuma		ɲ̤cʰ
+suk	Sukuma		ɲɟ
+suk	Sukuma		ŋ̤kʰ
+suk	Sukuma		ŋɡ
+
 mfe	Mauritian Creole	Ordinary'	p				mfe.pdf
-mfe	Mauritian Creole	Ordinary'	b				
-mfe	Mauritian Creole	Ordinary'	t̪		[t̰]		
-mfe	Mauritian Creole	Ordinary'	t̰		[θ]	word-final	
-mfe	Mauritian Creole	Ordinary'	t̰		[c]	before [i] and [j]	
-mfe	Mauritian Creole	Ordinary'	d̪		[d̪]		
-mfe	Mauritian Creole	Ordinary'	d̪		[ð]	word-final	
-mfe	Mauritian Creole	Ordinary'	d̪		[ɟ]	before [i] and [j]	
-mfe	Mauritian Creole	Ordinary'	k	optionally palatalized before [i] and [j]			
-mfe	Mauritian Creole	Ordinary'	ɡ	optionally palatalized before [i] and [j]			
-mfe	Mauritian Creole	Ordinary'	f				
-mfe	Mauritian Creole	Ordinary'	v				
-mfe	Mauritian Creole	Ordinary'	s				
-mfe	Mauritian Creole	Ordinary'	z				
-mfe	Mauritian Creole	Ordinary'	m				
-mfe	Mauritian Creole	Ordinary'	n				
-mfe	Mauritian Creole	Ordinary'	ŋ	only found word-finally			
-mfe	Mauritian Creole	Ordinary'	l				
-mfe	Mauritian Creole	Ordinary'	w		[ŭ]		
-mfe	Mauritian Creole	Ordinary'	w		[ŏ]	intervocalic	
-mfe	Mauritian Creole	Ordinary'	j̃				
-mfe	Mauritian Creole	Ordinary'	j		[ə̆]		
-mfe	Mauritian Creole	Ordinary'	j		[ɣ]	intervocalic	
-mfe	Mauritian Creole	Ordinary'	r				
-mfe	Mauritian Creole	Ordinary'	i		[i]		
-mfe	Mauritian Creole	Ordinary'	i		[ɪ]	in closed syllables	
-mfe	Mauritian Creole	Ordinary'	e		[e]		
-mfe	Mauritian Creole	Ordinary'	e		[ɛ]	in closed syllables	
-mfe	Mauritian Creole	Ordinary'	æ̃				
-mfe	Mauritian Creole	Ordinary'	a		[a]		
-mfe	Mauritian Creole	Ordinary'	a		[ɑ]	adjacent to [r] and [w]	
-mfe	Mauritian Creole	Ordinary'	ɑ				
-mfe	Mauritian Creole	Ordinary'	ɔ				
-mfe	Mauritian Creole	Ordinary'	o		[o]		
-mfe	Mauritian Creole	Ordinary'	o		[ɔ]	in closed syllables	
-mfe	Mauritian Creole	Ordinary'	u		[u]		
-mfe	Mauritian Creole	Ordinary'	u		[ʊ]	in closed syllables	
-mfe	Mauritian Creole	Ordinary'	<t̠ʃ>	marginal			
-mfe	Mauritian Creole	Ordinary'	<d̠ʒ>	marginal			
-mfe	Mauritian Creole	Ordinary'	<ə>	marginal			
-							
+mfe	Mauritian Creole	Ordinary'	b
+mfe	Mauritian Creole	Ordinary'	t̪		[t̰]
+mfe	Mauritian Creole	Ordinary'	t̰		[θ]	word-final
+mfe	Mauritian Creole	Ordinary'	t̰		[c]	before [i] and [j]
+mfe	Mauritian Creole	Ordinary'	d̪		[d̪]
+mfe	Mauritian Creole	Ordinary'	d̪		[ð]	word-final
+mfe	Mauritian Creole	Ordinary'	d̪		[ɟ]	before [i] and [j]
+mfe	Mauritian Creole	Ordinary'	k	optionally palatalized before [i] and [j]
+mfe	Mauritian Creole	Ordinary'	ɡ	optionally palatalized before [i] and [j]
+mfe	Mauritian Creole	Ordinary'	f
+mfe	Mauritian Creole	Ordinary'	v
+mfe	Mauritian Creole	Ordinary'	s
+mfe	Mauritian Creole	Ordinary'	z
+mfe	Mauritian Creole	Ordinary'	m
+mfe	Mauritian Creole	Ordinary'	n
+mfe	Mauritian Creole	Ordinary'	ŋ	only found word-finally
+mfe	Mauritian Creole	Ordinary'	l
+mfe	Mauritian Creole	Ordinary'	w		[ŭ]
+mfe	Mauritian Creole	Ordinary'	w		[ŏ]	intervocalic
+mfe	Mauritian Creole	Ordinary'	j̃
+mfe	Mauritian Creole	Ordinary'	j		[ə̆]
+mfe	Mauritian Creole	Ordinary'	j		[ɣ]	intervocalic
+mfe	Mauritian Creole	Ordinary'	r
+mfe	Mauritian Creole	Ordinary'	i		[i]
+mfe	Mauritian Creole	Ordinary'	i		[ɪ]	in closed syllables
+mfe	Mauritian Creole	Ordinary'	e		[e]
+mfe	Mauritian Creole	Ordinary'	e		[ɛ]	in closed syllables
+mfe	Mauritian Creole	Ordinary'	æ̃
+mfe	Mauritian Creole	Ordinary'	a		[a]
+mfe	Mauritian Creole	Ordinary'	a		[ɑ]	adjacent to [r] and [w]
+mfe	Mauritian Creole	Ordinary'	ɑ
+mfe	Mauritian Creole	Ordinary'	ɔ
+mfe	Mauritian Creole	Ordinary'	o		[o]
+mfe	Mauritian Creole	Ordinary'	o		[ɔ]	in closed syllables
+mfe	Mauritian Creole	Ordinary'	u		[u]
+mfe	Mauritian Creole	Ordinary'	u		[ʊ]	in closed syllables
+mfe	Mauritian Creole	Ordinary'	<t̠ʃ>	marginal
+mfe	Mauritian Creole	Ordinary'	<d̠ʒ>	marginal
+mfe	Mauritian Creole	Ordinary'	<ə>	marginal
+
 kri	Krio		t̪				krio_nylander.pdf
-kri	Krio		d̪				
-kri	Krio		n̪				
-kri	Krio		l̪				
-kri	Krio		p				
-kri	Krio		b				
-kri	Krio		m				
-kri	Krio		f				
-kri	Krio		v				
-kri	Krio		s				
-kri	Krio		z				
-kri	Krio		k				
-kri	Krio		ɡ				
-kri	Krio		kp				
-kri	Krio		ɡb				
-kri	Krio		w				
-kri	Krio		ʃ				
-kri	Krio		c				
-kri	Krio		ɟ				
-kri	Krio		j				
-kri	Krio		ʁ				
-kri	Krio		<θ>	loanwords			
-kri	Krio		<ʒ>	loanwords			
-kri	Krio		ɲ		[ɲ]	initial and intervocalic	
-kri	Krio		ɲ		[ŋ]	final, post velar, syllable final	
-kri	Krio		h				
-kri	Krio		i		[i]		
-kri	Krio		u		[u]		
-kri	Krio		e		[e]		
-kri	Krio		o		[o]		
-kri	Krio		ɛ		[ɛ]		
-kri	Krio		ɔ		[ɔ]		
-kri	Krio		a				
-kri	Krio		i		[ĩ]		
-kri	Krio		u		[ũ]		
-kri	Krio		e		[ẽ]		
-kri	Krio		o		[õ]		
-kri	Krio		ɛ		[ɛ̃]		
-kri	Krio		ɔ		[ɔ̃]		
-kri	Krio		˦				
-kri	Krio		˨				
-kri	Krio		˧				
-							
+kri	Krio		d̪
+kri	Krio		n̪
+kri	Krio		l̪
+kri	Krio		p
+kri	Krio		b
+kri	Krio		m
+kri	Krio		f
+kri	Krio		v
+kri	Krio		s
+kri	Krio		z
+kri	Krio		k
+kri	Krio		ɡ
+kri	Krio		kp
+kri	Krio		ɡb
+kri	Krio		w
+kri	Krio		ʃ
+kri	Krio		c
+kri	Krio		ɟ
+kri	Krio		j
+kri	Krio		ʁ
+kri	Krio		<θ>	loanwords
+kri	Krio		<ʒ>	loanwords
+kri	Krio		ɲ		[ɲ]	initial and intervocalic
+kri	Krio		ɲ		[ŋ]	final, post velar, syllable final
+kri	Krio		h
+kri	Krio		i		[i]
+kri	Krio		u		[u]
+kri	Krio		e		[e]
+kri	Krio		o		[o]
+kri	Krio		ɛ		[ɛ]
+kri	Krio		ɔ		[ɔ]
+kri	Krio		a
+kri	Krio		i		[ĩ]
+kri	Krio		u		[ũ]
+kri	Krio		e		[ẽ]
+kri	Krio		o		[õ]
+kri	Krio		ɛ		[ɛ̃]
+kri	Krio		ɔ		[ɔ̃]
+kri	Krio		˦
+kri	Krio		˨
+kri	Krio		˧
+
 ktu	Kituba	Kwilu	p				ktu.pdf
-ktu	Kituba	Kwilu	t				
-ktu	Kituba	Kwilu	k				
-ktu	Kituba	Kwilu	b				
-ktu	Kituba	Kwilu	d				
-ktu	Kituba	Kwilu	ɡ				
-ktu	Kituba	Kwilu	f				
-ktu	Kituba	Kwilu	s				
-ktu	Kituba	Kwilu	z				
-ktu	Kituba	Kwilu	v				
-ktu	Kituba	Kwilu	m				
-ktu	Kituba	Kwilu	n				
-ktu	Kituba	Kwilu	l				
-ktu	Kituba	Kwilu	j				
-ktu	Kituba	Kwilu	w				
-ktu	Kituba	Kwilu	i				
-ktu	Kituba	Kwilu	u				
-ktu	Kituba	Kwilu	e				
-ktu	Kituba	Kwilu	o				
-ktu	Kituba	Kwilu	a				
-ktu	Kituba	Kwilu	˦				
-ktu	Kituba	Kwilu	˨				
-							
+ktu	Kituba	Kwilu	t
+ktu	Kituba	Kwilu	k
+ktu	Kituba	Kwilu	b
+ktu	Kituba	Kwilu	d
+ktu	Kituba	Kwilu	ɡ
+ktu	Kituba	Kwilu	f
+ktu	Kituba	Kwilu	s
+ktu	Kituba	Kwilu	z
+ktu	Kituba	Kwilu	v
+ktu	Kituba	Kwilu	m
+ktu	Kituba	Kwilu	n
+ktu	Kituba	Kwilu	l
+ktu	Kituba	Kwilu	j
+ktu	Kituba	Kwilu	w
+ktu	Kituba	Kwilu	i
+ktu	Kituba	Kwilu	u
+ktu	Kituba	Kwilu	e
+ktu	Kituba	Kwilu	o
+ktu	Kituba	Kwilu	a
+ktu	Kituba	Kwilu	˦
+ktu	Kituba	Kwilu	˨
+
 aks	Akasilimi		p				akasilimi_baasaal_podi.pdf
-aks	Akasilimi		b				
-aks	Akasilimi		f				
-aks	Akasilimi		m				
-aks	Akasilimi		t				
-aks	Akasilimi		d	sometimes in variation with [r]			
-aks	Akasilimi		s				
-aks	Akasilimi		n				
-aks	Akasilimi		l				
-aks	Akasilimi		c				
-aks	Akasilimi		ɟ				
-aks	Akasilimi		j				
-aks	Akasilimi		ɲ				
-aks	Akasilimi		k				
-aks	Akasilimi		ɡ				
-aks	Akasilimi		ŋ				
-aks	Akasilimi		kp				
-aks	Akasilimi		ɡb				
-aks	Akasilimi		w				
-aks	Akasilimi		ŋmɡb				
-aks	Akasilimi		˦				
-aks	Akasilimi		˨				
-aks	Akasilimi		˧				
-aks	Akasilimi		i				
-aks	Akasilimi		iː				
-aks	Akasilimi		ɪ				
-aks	Akasilimi		ɪː				
-aks	Akasilimi		u				
-aks	Akasilimi		uː				
-aks	Akasilimi		ʊ				
-aks	Akasilimi		ʊː				
-aks	Akasilimi		e				
-aks	Akasilimi		eː				
-aks	Akasilimi		ɛ				
-aks	Akasilimi		ɛː				
-aks	Akasilimi		o				
-aks	Akasilimi		oː				
-aks	Akasilimi		ɔ				
-aks	Akasilimi		ɔː				
-aks	Akasilimi		a				
-aks	Akasilimi		aː				
-aks	Akasilimi		æ				
-aks	Akasilimi		ĩ				
-aks	Akasilimi		ɪ̃				
-aks	Akasilimi		ẽ				
-aks	Akasilimi		ɛ̃				
-aks	Akasilimi		ã				
-aks	Akasilimi		æ̃				
-aks	Akasilimi		ũ				
-aks	Akasilimi		ʊ̃				
-aks	Akasilimi		õ				
-aks	Akasilimi		ɔ̃				
-							
+aks	Akasilimi		b
+aks	Akasilimi		f
+aks	Akasilimi		m
+aks	Akasilimi		t
+aks	Akasilimi		d	sometimes in variation with [r]
+aks	Akasilimi		s
+aks	Akasilimi		n
+aks	Akasilimi		l
+aks	Akasilimi		c
+aks	Akasilimi		ɟ
+aks	Akasilimi		j
+aks	Akasilimi		ɲ
+aks	Akasilimi		k
+aks	Akasilimi		ɡ
+aks	Akasilimi		ŋ
+aks	Akasilimi		kp
+aks	Akasilimi		ɡb
+aks	Akasilimi		w
+aks	Akasilimi		ŋmɡb
+aks	Akasilimi		˦
+aks	Akasilimi		˨
+aks	Akasilimi		˧
+aks	Akasilimi		i
+aks	Akasilimi		iː
+aks	Akasilimi		ɪ
+aks	Akasilimi		ɪː
+aks	Akasilimi		u
+aks	Akasilimi		uː
+aks	Akasilimi		ʊ
+aks	Akasilimi		ʊː
+aks	Akasilimi		e
+aks	Akasilimi		eː
+aks	Akasilimi		ɛ
+aks	Akasilimi		ɛː
+aks	Akasilimi		o
+aks	Akasilimi		oː
+aks	Akasilimi		ɔ
+aks	Akasilimi		ɔː
+aks	Akasilimi		a
+aks	Akasilimi		aː
+aks	Akasilimi		æ
+aks	Akasilimi		ĩ
+aks	Akasilimi		ɪ̃
+aks	Akasilimi		ẽ
+aks	Akasilimi		ɛ̃
+aks	Akasilimi		ã
+aks	Akasilimi		æ̃
+aks	Akasilimi		ũ
+aks	Akasilimi		ʊ̃
+aks	Akasilimi		õ
+aks	Akasilimi		ɔ̃
+
 bag	Tuki		i				bag.pdf
-bag	Tuki		e		[e]		
-bag	Tuki		a				
-bag	Tuki		u				
-bag	Tuki		o				
-bag	Tuki		ɔ				
-bag	Tuki		e		[ɛ]		
-bag	Tuki		oː				
-bag	Tuki		ɔː				
-bag	Tuki		aː				
-bag	Tuki		<ə>	only in certain grammatical constructions			
-bag	Tuki		t̠ʃ	free variation with [ts]	[t̠ʃ]		
-bag	Tuki		t̠ʃ		[t̠ʃʷ]		
-bag	Tuki		d̠ʒ	free variation with [dz]	[d̠ʒ]		
-bag	Tuki		d̠ʒ		[d̠ʒʷ]		
-bag	Tuki		d̠ʒ		[d̠ʒʲ]		
-bag	Tuki		p		[p]		
-bag	Tuki		p		[pʷ]		
-bag	Tuki		p		[pʲ]		
-bag	Tuki		t		[t]		
-bag	Tuki		t		[tʷ]		
-bag	Tuki		t		[tʲ]		
-bag	Tuki		k		[k]		
-bag	Tuki		k		[kʷ]		
-bag	Tuki		k		[kʲ]		
-bag	Tuki		kp				
-bag	Tuki		b		[b]		
-bag	Tuki		b		[bʷ]		
-bag	Tuki		b		[bʲ]		
-bag	Tuki		d				
-bag	Tuki		ɡ		[ɡ]		
-bag	Tuki		ɡ		[ɡʷ]		
-bag	Tuki		ɡb		[ɡb]		
-bag	Tuki		ɡb		[ɡbʷ]		
-bag	Tuki		ɡb		[ɡbʲ]		
-bag	Tuki		s		[s]		
-bag	Tuki		s		[sʷ]		
-bag	Tuki		s		[sʲ]		
-bag	Tuki		h	free variation with [ɸ]	[h]		
-bag	Tuki		h		[hʷ]		
-bag	Tuki		h		[hʲ]		
-bag	Tuki		β	free variation with [v]	[β]		
-bag	Tuki		β		[βʲ]		
-bag	Tuki		r		[r]		
-bag	Tuki		r		[rʲ]		
-bag	Tuki		j				
-bag	Tuki		w				
-bag	Tuki		m		[m]		
-bag	Tuki		m		[mʷ]		
-bag	Tuki		m		[mʲ]		
-bag	Tuki		n		[n]		
-bag	Tuki		n		[nʷ]		
-bag	Tuki		n		[nʲ]		
-bag	Tuki		ɲ		[ɲ]		
-bag	Tuki		ɲ		[ɲʷ]		
-bag	Tuki		ŋ				
-bag	Tuki		mb		[mb]		
-bag	Tuki		mb		[mbʷ]		
-bag	Tuki		mb		[mbʲ]		
-bag	Tuki		nd		[nd]		
-bag	Tuki		nd		[ndʷ]		
-bag	Tuki		nd		[ndʲ]		
-bag	Tuki		ŋɡ		[ŋɡ]		
-bag	Tuki		ŋɡ		[ŋɡʷ]		
-bag	Tuki		ŋɡ		[ŋɡʲ]		
-bag	Tuki		n̠d̠ʒ				
-bag	Tuki		ŋmɡb				
-bag	Tuki		˨˦				
-bag	Tuki		˦˨				
-bag	Tuki		˦				
-bag	Tuki		˨				
-							
+bag	Tuki		e		[e]
+bag	Tuki		a
+bag	Tuki		u
+bag	Tuki		o
+bag	Tuki		ɔ
+bag	Tuki		e		[ɛ]
+bag	Tuki		oː
+bag	Tuki		ɔː
+bag	Tuki		aː
+bag	Tuki		<ə>	only in certain grammatical constructions
+bag	Tuki		t̠ʃ	free variation with [ts]	[t̠ʃ]
+bag	Tuki		t̠ʃ		[t̠ʃʷ]
+bag	Tuki		d̠ʒ	free variation with [dz]	[d̠ʒ]
+bag	Tuki		d̠ʒ		[d̠ʒʷ]
+bag	Tuki		d̠ʒ		[d̠ʒʲ]
+bag	Tuki		p		[p]
+bag	Tuki		p		[pʷ]
+bag	Tuki		p		[pʲ]
+bag	Tuki		t		[t]
+bag	Tuki		t		[tʷ]
+bag	Tuki		t		[tʲ]
+bag	Tuki		k		[k]
+bag	Tuki		k		[kʷ]
+bag	Tuki		k		[kʲ]
+bag	Tuki		kp
+bag	Tuki		b		[b]
+bag	Tuki		b		[bʷ]
+bag	Tuki		b		[bʲ]
+bag	Tuki		d
+bag	Tuki		ɡ		[ɡ]
+bag	Tuki		ɡ		[ɡʷ]
+bag	Tuki		ɡb		[ɡb]
+bag	Tuki		ɡb		[ɡbʷ]
+bag	Tuki		ɡb		[ɡbʲ]
+bag	Tuki		s		[s]
+bag	Tuki		s		[sʷ]
+bag	Tuki		s		[sʲ]
+bag	Tuki		h	free variation with [ɸ]	[h]
+bag	Tuki		h		[hʷ]
+bag	Tuki		h		[hʲ]
+bag	Tuki		β	free variation with [v]	[β]
+bag	Tuki		β		[βʲ]
+bag	Tuki		r		[r]
+bag	Tuki		r		[rʲ]
+bag	Tuki		j
+bag	Tuki		w
+bag	Tuki		m		[m]
+bag	Tuki		m		[mʷ]
+bag	Tuki		m		[mʲ]
+bag	Tuki		n		[n]
+bag	Tuki		n		[nʷ]
+bag	Tuki		n		[nʲ]
+bag	Tuki		ɲ		[ɲ]
+bag	Tuki		ɲ		[ɲʷ]
+bag	Tuki		ŋ
+bag	Tuki		mb		[mb]
+bag	Tuki		mb		[mbʷ]
+bag	Tuki		mb		[mbʲ]
+bag	Tuki		nd		[nd]
+bag	Tuki		nd		[ndʷ]
+bag	Tuki		nd		[ndʲ]
+bag	Tuki		ŋɡ		[ŋɡ]
+bag	Tuki		ŋɡ		[ŋɡʷ]
+bag	Tuki		ŋɡ		[ŋɡʲ]
+bag	Tuki		n̠d̠ʒ
+bag	Tuki		ŋmɡb
+bag	Tuki		˨˦
+bag	Tuki		˦˨
+bag	Tuki		˦
+bag	Tuki		˨
+
 bkc	Baka		b				BakaOrthography.pdf
-bkc	Baka		ɓ				
-bkc	Baka		d				
-bkc	Baka		ɗ				
-bkc	Baka		ɡ				
-bkc	Baka		ɡb				
-bkc	Baka		h				
-bkc	Baka		d̠ʒ				
-bkc	Baka		k				
-bkc	Baka		kp				
-bkc	Baka		l				
-bkc	Baka		m				
-bkc	Baka		mb				
-bkc	Baka		n				
-bkc	Baka		nd				
-bkc	Baka		ŋɡ				
-bkc	Baka		ŋmɡb				
-bkc	Baka		n̠d̠ʒ				
-bkc	Baka		ɲ				
-bkc	Baka		ɸ				
-bkc	Baka		s				
-bkc	Baka		t				
-bkc	Baka		w				
-bkc	Baka		j				
-bkc	Baka		ʔ				
-bkc	Baka		a				
-bkc	Baka		e				
-bkc	Baka		ɛ				
-bkc	Baka		i				
-bkc	Baka		o				
-bkc	Baka		ɔ				
-bkc	Baka		u				
-bkc	Baka		˦				
-bkc	Baka		˨				
-bkc	Baka		˧				
-							
+bkc	Baka		ɓ
+bkc	Baka		d
+bkc	Baka		ɗ
+bkc	Baka		ɡ
+bkc	Baka		ɡb
+bkc	Baka		h
+bkc	Baka		d̠ʒ
+bkc	Baka		k
+bkc	Baka		kp
+bkc	Baka		l
+bkc	Baka		m
+bkc	Baka		mb
+bkc	Baka		n
+bkc	Baka		nd
+bkc	Baka		ŋɡ
+bkc	Baka		ŋmɡb
+bkc	Baka		n̠d̠ʒ
+bkc	Baka		ɲ
+bkc	Baka		ɸ
+bkc	Baka		s
+bkc	Baka		t
+bkc	Baka		w
+bkc	Baka		j
+bkc	Baka		ʔ
+bkc	Baka		a
+bkc	Baka		e
+bkc	Baka		ɛ
+bkc	Baka		i
+bkc	Baka		o
+bkc	Baka		ɔ
+bkc	Baka		u
+bkc	Baka		˦
+bkc	Baka		˨
+bkc	Baka		˧
+
 bmv	Bum		b		[b]		bmv.pdf
-bmv	Bum		b		[p]	syllable-final	
-bmv	Bum		t				
-bmv	Bum		d				
-bmv	Bum		tʲ				
-bmv	Bum		dʲ				
-bmv	Bum		k				
-bmv	Bum		ɡ				
-bmv	Bum		kp				
-bmv	Bum		ɡb				
-bmv	Bum		t̠ʃ				
-bmv	Bum		d̠ʒ				
-bmv	Bum		t̠ʃʲ				
-bmv	Bum		d̠ʒʲ				
-bmv	Bum		ʃʲ				
-bmv	Bum		f				
-bmv	Bum		s				
-bmv	Bum		ʃ				
-bmv	Bum		h				
-bmv	Bum		ɣ				
-bmv	Bum		m				
-bmv	Bum		n				
-bmv	Bum		ɲ		[ɲ]		
-bmv	Bum		ɲ		[ŋ]	syllable-final	
-bmv	Bum		l				
-bmv	Bum		w		[w]	elsewhere	
-bmv	Bum		w		[ɰ]	after labials	
-bmv	Bum		w		[ɥ]	after non-labials and before hiɡh front vowels	
-bmv	Bum		j	free variation with [ʒ]			
-bmv	Bum		bʷ		[bʷ]		
-bmv	Bum		bʷ		[bɰ]		
-bmv	Bum		tʷ		[tɥ]		
-bmv	Bum		kʷ				
-bmv	Bum		ɡʷ				
-bmv	Bum		fʷ		[fɰ]		
-bmv	Bum		t̠ʃʷ		[t̠ʃʷ]		
-bmv	Bum		t̠ʃʷ		[t̠ʃɥ]		
-bmv	Bum		d̠ʒʷ				
-bmv	Bum		ʃʷ				
-bmv	Bum		jʷ	free variation with [ʒʷ]	[jʷ]		
-bmv	Bum		jʷ	free variation with [ʒɥ]	[jɥ]		
-bmv	Bum		mʷ		[mɰ]		
-bmv	Bum		nʷ		[nɥ]		
-bmv	Bum		lʷ		[lɥ]		
-bmv	Bum		i				
-bmv	Bum		ɛ				
-bmv	Bum		ɨ				
-bmv	Bum		ə				
-bmv	Bum		a				
-bmv	Bum		u				
-bmv	Bum		ɔ				
-bmv	Bum		˦˨				
-bmv	Bum		˦				
-bmv	Bum		˨				
-							
+bmv	Bum		b		[p]	syllable-final
+bmv	Bum		t
+bmv	Bum		d
+bmv	Bum		tʲ
+bmv	Bum		dʲ
+bmv	Bum		k
+bmv	Bum		ɡ
+bmv	Bum		kp
+bmv	Bum		ɡb
+bmv	Bum		t̠ʃ
+bmv	Bum		d̠ʒ
+bmv	Bum		t̠ʃʲ
+bmv	Bum		d̠ʒʲ
+bmv	Bum		ʃʲ
+bmv	Bum		f
+bmv	Bum		s
+bmv	Bum		ʃ
+bmv	Bum		h
+bmv	Bum		ɣ
+bmv	Bum		m
+bmv	Bum		n
+bmv	Bum		ɲ		[ɲ]
+bmv	Bum		ɲ		[ŋ]	syllable-final
+bmv	Bum		l
+bmv	Bum		w		[w]	elsewhere
+bmv	Bum		w		[ɰ]	after labials
+bmv	Bum		w		[ɥ]	after non-labials and before hiɡh front vowels
+bmv	Bum		j	free variation with [ʒ]
+bmv	Bum		bʷ		[bʷ]
+bmv	Bum		bʷ		[bɰ]
+bmv	Bum		tʷ		[tɥ]
+bmv	Bum		kʷ
+bmv	Bum		ɡʷ
+bmv	Bum		fʷ		[fɰ]
+bmv	Bum		t̠ʃʷ		[t̠ʃʷ]
+bmv	Bum		t̠ʃʷ		[t̠ʃɥ]
+bmv	Bum		d̠ʒʷ
+bmv	Bum		ʃʷ
+bmv	Bum		jʷ	free variation with [ʒʷ]	[jʷ]
+bmv	Bum		jʷ	free variation with [ʒɥ]	[jɥ]
+bmv	Bum		mʷ		[mɰ]
+bmv	Bum		nʷ		[nɥ]
+bmv	Bum		lʷ		[lɥ]
+bmv	Bum		i
+bmv	Bum		ɛ
+bmv	Bum		ɨ
+bmv	Bum		ə
+bmv	Bum		a
+bmv	Bum		u
+bmv	Bum		ɔ
+bmv	Bum		˦˨
+bmv	Bum		˦
+bmv	Bum		˨
+
 dbq	Daba		p				dbq_lienhard.pdf
-dbq	Daba		b				
-dbq	Daba		ɓ		[ɓ]		
-dbq	Daba		ɓ		[ɓ̚]	word-final	
-dbq	Daba		f				
-dbq	Daba		v				
-dbq	Daba		mb				
-dbq	Daba		m				
-dbq	Daba		ⱱ				
-dbq	Daba		t				
-dbq	Daba		d				
-dbq	Daba		ɗ		[ɗ]		
-dbq	Daba		ɗ		[ɗ̚]	word-final	
-dbq	Daba		ɬ				
-dbq	Daba		ɮ				
-dbq	Daba		nd				
-dbq	Daba		n				
-dbq	Daba		l				
-dbq	Daba		r				
-dbq	Daba		t̠ʃ				
-dbq	Daba		d̠ʒ				
-dbq	Daba		s				
-dbq	Daba		z				
-dbq	Daba		n̠d̠ʒ				
-dbq	Daba		j				
-dbq	Daba		k				
-dbq	Daba		ɡ				
-dbq	Daba		ʔ	ok			
-dbq	Daba		x				
-dbq	Daba		ŋɡ				
-dbq	Daba		kp				
-dbq	Daba		ɡb				
-dbq	Daba		ŋɡmb				
-dbq	Daba		kʷ		[kʷ]		
-dbq	Daba		kʷ		[k]	word-final	
-dbq	Daba		ɡʷ				
-dbq	Daba		ʔʷ	ok			
-dbq	Daba		ŋɡʷ				
-dbq	Daba		w				
-dbq	Daba		i		[i]		
-dbq	Daba		i		[y]		
-dbq	Daba		ɛ		[ɛ]		
-dbq	Daba		ɛ		[œ]		
-dbq	Daba		ɨ				
-dbq	Daba		a				
-dbq	Daba		u				
-dbq	Daba		ɔ				
-dbq	Daba		˦˨				
-dbq	Daba		˦				
-dbq	Daba		˨				
-dbq	Daba		˧				
-							
+dbq	Daba		b
+dbq	Daba		ɓ		[ɓ]
+dbq	Daba		ɓ		[ɓ̚]	word-final
+dbq	Daba		f
+dbq	Daba		v
+dbq	Daba		mb
+dbq	Daba		m
+dbq	Daba		ⱱ
+dbq	Daba		t
+dbq	Daba		d
+dbq	Daba		ɗ		[ɗ]
+dbq	Daba		ɗ		[ɗ̚]	word-final
+dbq	Daba		ɬ
+dbq	Daba		ɮ
+dbq	Daba		nd
+dbq	Daba		n
+dbq	Daba		l
+dbq	Daba		r
+dbq	Daba		t̠ʃ
+dbq	Daba		d̠ʒ
+dbq	Daba		s
+dbq	Daba		z
+dbq	Daba		n̠d̠ʒ
+dbq	Daba		j
+dbq	Daba		k
+dbq	Daba		ɡ
+dbq	Daba		ʔ	ok
+dbq	Daba		x
+dbq	Daba		ŋɡ
+dbq	Daba		kp
+dbq	Daba		ɡb
+dbq	Daba		ŋɡmb
+dbq	Daba		kʷ		[kʷ]
+dbq	Daba		kʷ		[k]	word-final
+dbq	Daba		ɡʷ
+dbq	Daba		ʔʷ	ok
+dbq	Daba		ŋɡʷ
+dbq	Daba		w
+dbq	Daba		i		[i]
+dbq	Daba		i		[y]
+dbq	Daba		ɛ		[ɛ]
+dbq	Daba		ɛ		[œ]
+dbq	Daba		ɨ
+dbq	Daba		a
+dbq	Daba		u
+dbq	Daba		ɔ
+dbq	Daba		˦˨
+dbq	Daba		˦
+dbq	Daba		˨
+dbq	Daba		˧
+
 gou	Gavar		b				gou.pdf
-gou	Gavar		ɓ				
-gou	Gavar		t̠ʃ				
-gou	Gavar		d				
-gou	Gavar		dz				
-gou	Gavar		ɗ				
-gou	Gavar		f				
-gou	Gavar		ɡ				
-gou	Gavar		ɡb				
-gou	Gavar		ɣ				
-gou	Gavar		ɣʷ				
-gou	Gavar		ɡʷ				
-gou	Gavar		x		[x]		
-gou	Gavar		x		[h]	intervocalic	
-gou	Gavar		xʷ		[xʷ]		
-gou	Gavar		xʷ		[hʷ]	intervocalic	
-gou	Gavar		d̠ʒ				
-gou	Gavar		k				
-gou	Gavar		kp				
-gou	Gavar		kʷ				
-gou	Gavar		l				
-gou	Gavar		m				
-gou	Gavar		mb				
-gou	Gavar		ŋmɡb				
-gou	Gavar		n		[n]		
-gou	Gavar		n		[ŋ]		
-gou	Gavar		nd				
-gou	Gavar		ndz				
-gou	Gavar		n̠d̠ʒ				
-gou	Gavar		ŋ				
-gou	Gavar		ŋɡ				
-gou	Gavar		ŋɡʷ				
-gou	Gavar		ŋʷ				
-gou	Gavar		p				
-gou	Gavar		pt				
-gou	Gavar		r		[r]		
-gou	Gavar		r		[ɾ]	intervocalic	
-gou	Gavar		s				
-gou	Gavar		ʃ				
-gou	Gavar		ɬ				
-gou	Gavar		t				
-gou	Gavar		ts				
-gou	Gavar		v				
-gou	Gavar		ⱱ				
-gou	Gavar		w				
-gou	Gavar		j				
-gou	Gavar		z				
-gou	Gavar		ʒ				
-gou	Gavar		ɮ				
-gou	Gavar		ʔ	ok			
-gou	Gavar		ʔʷ	ok			
-gou	Gavar		ɑ		[a]		
-gou	Gavar		ɑ		[o]	variation with [ɔ]	
-gou	Gavar		e		[ɛ]	variation with [e]	
-gou	Gavar		e		[œ]		
-gou	Gavar		ə		[ə]		
-gou	Gavar		ə		[ø]		
-gou	Gavar		u		[ʊ]	variation with [u]	
-gou	Gavar		i		[ɪ]	variation with [i]	
-gou	Gavar		i		[ʏ]		
-gou	Gavar		˦				
-gou	Gavar		˨				
-gou	Gavar		˧				
-							
+gou	Gavar		ɓ
+gou	Gavar		t̠ʃ
+gou	Gavar		d
+gou	Gavar		dz
+gou	Gavar		ɗ
+gou	Gavar		f
+gou	Gavar		ɡ
+gou	Gavar		ɡb
+gou	Gavar		ɣ
+gou	Gavar		ɣʷ
+gou	Gavar		ɡʷ
+gou	Gavar		x		[x]
+gou	Gavar		x		[h]	intervocalic
+gou	Gavar		xʷ		[xʷ]
+gou	Gavar		xʷ		[hʷ]	intervocalic
+gou	Gavar		d̠ʒ
+gou	Gavar		k
+gou	Gavar		kp
+gou	Gavar		kʷ
+gou	Gavar		l
+gou	Gavar		m
+gou	Gavar		mb
+gou	Gavar		ŋmɡb
+gou	Gavar		n		[n]
+gou	Gavar		n		[ŋ]
+gou	Gavar		nd
+gou	Gavar		ndz
+gou	Gavar		n̠d̠ʒ
+gou	Gavar		ŋ
+gou	Gavar		ŋɡ
+gou	Gavar		ŋɡʷ
+gou	Gavar		ŋʷ
+gou	Gavar		p
+gou	Gavar		pt
+gou	Gavar		r		[r]
+gou	Gavar		r		[ɾ]	intervocalic
+gou	Gavar		s
+gou	Gavar		ʃ
+gou	Gavar		ɬ
+gou	Gavar		t
+gou	Gavar		ts
+gou	Gavar		v
+gou	Gavar		ⱱ
+gou	Gavar		w
+gou	Gavar		j
+gou	Gavar		z
+gou	Gavar		ʒ
+gou	Gavar		ɮ
+gou	Gavar		ʔ	ok
+gou	Gavar		ʔʷ	ok
+gou	Gavar		ɑ		[a]
+gou	Gavar		ɑ		[o]	variation with [ɔ]
+gou	Gavar		e		[ɛ]	variation with [e]
+gou	Gavar		e		[œ]
+gou	Gavar		ə		[ə]
+gou	Gavar		ə		[ø]
+gou	Gavar		u		[ʊ]	variation with [u]
+gou	Gavar		i		[ɪ]	variation with [i]
+gou	Gavar		i		[ʏ]
+gou	Gavar		˦
+gou	Gavar		˨
+gou	Gavar		˧
+
 gde	Gu'de		p		[p]		gde_menetrey.pdf
-gde	Gu'de		p		[pʷ]		
-gde	Gu'de		p		[pʲ]		
-gde	Gu'de		b				
-gde	Gu'de		ɓ		[ɓ]		
-gde	Gu'de		ɓ		[ɓʷ]		
-gde	Gu'de		t				
-gde	Gu'de		d				
-gde	Gu'de		ɗ				
-gde	Gu'de		k		[k]		
-gde	Gu'de		k		[kʲ]		
-gde	Gu'de		ɡ		[ɡ]		
-gde	Gu'de		ʔ		[ʔ]		
-gde	Gu'de		ɡ		[ɡʷ]		
-gde	Gu'de		ʔ		[ʔʷ]		
-gde	Gu'de		mb				
-gde	Gu'de		nd				
-gde	Gu'de		ŋɡ		[ŋɡ]		
-gde	Gu'de		ŋɡ		[ŋɡʷ]		
-gde	Gu'de		ndz		[ndz]		
-gde	Gu'de		ndz		[n̠d̠ʒ]		
-gde	Gu'de		ŋɣ				
-gde	Gu'de		m		[m]		
-gde	Gu'de		m		[mʷ]		
-gde	Gu'de		n		[n]		
-gde	Gu'de		n		[ɲ]		
-gde	Gu'de		ŋ				
-gde	Gu'de		f		[f]		
-gde	Gu'de		f		[fʲ]		
-gde	Gu'de		v				
-gde	Gu'de		s		[s]		
-gde	Gu'de		s		[ʃ]		
-gde	Gu'de		z		[z]		
-gde	Gu'de		z		[ʒ]		
-gde	Gu'de		x		[x]		
-gde	Gu'de		x		[xʷ]		
-gde	Gu'de		x		[xʲ]		
-gde	Gu'de		ɣ				
-gde	Gu'de		ts		[t̠ʃ]		
-gde	Gu'de		dz		[dz]		
-gde	Gu'de		ts		[ts]		
-gde	Gu'de		dz		[d̠ʒ]		
-gde	Gu'de		ɾ				
-gde	Gu'de		l				
-gde	Gu'de		ɬ		[ɬ]		
-gde	Gu'de		ɬ		[ɬʲ]		
-gde	Gu'de		<ⱱ>	marginal, ideophones only			
-gde	Gu'de		ə		[u]		
-gde	Gu'de		a		[ɔ]		
-gde	Gu'de		əː		[uː]		
-gde	Gu'de		aː		[aː]		
-gde	Gu'de		ə		[i]		
-gde	Gu'de		a		[ja]		
-gde	Gu'de		a		[wa]		
-gde	Gu'de		əː		[iː]		
-gde	Gu'de		aː		[yaː]		
-gde	Gu'de		əː		[eː]		
-gde	Gu'de		aː		[ɔː]		
-gde	Gu'de		˦				
-gde	Gu'de		˨				
-gde	Gu'de		ɱv		[ɱvʷ]		
-							
+gde	Gu'de		p		[pʷ]
+gde	Gu'de		p		[pʲ]
+gde	Gu'de		b
+gde	Gu'de		ɓ		[ɓ]
+gde	Gu'de		ɓ		[ɓʷ]
+gde	Gu'de		t
+gde	Gu'de		d
+gde	Gu'de		ɗ
+gde	Gu'de		k		[k]
+gde	Gu'de		k		[kʲ]
+gde	Gu'de		ɡ		[ɡ]
+gde	Gu'de		ʔ		[ʔ]
+gde	Gu'de		ɡ		[ɡʷ]
+gde	Gu'de		ʔ		[ʔʷ]
+gde	Gu'de		mb
+gde	Gu'de		nd
+gde	Gu'de		ŋɡ		[ŋɡ]
+gde	Gu'de		ŋɡ		[ŋɡʷ]
+gde	Gu'de		ndz		[ndz]
+gde	Gu'de		ndz		[n̠d̠ʒ]
+gde	Gu'de		ŋɣ
+gde	Gu'de		m		[m]
+gde	Gu'de		m		[mʷ]
+gde	Gu'de		n		[n]
+gde	Gu'de		n		[ɲ]
+gde	Gu'de		ŋ
+gde	Gu'de		f		[f]
+gde	Gu'de		f		[fʲ]
+gde	Gu'de		v
+gde	Gu'de		s		[s]
+gde	Gu'de		s		[ʃ]
+gde	Gu'de		z		[z]
+gde	Gu'de		z		[ʒ]
+gde	Gu'de		x		[x]
+gde	Gu'de		x		[xʷ]
+gde	Gu'de		x		[xʲ]
+gde	Gu'de		ɣ
+gde	Gu'de		ts		[t̠ʃ]
+gde	Gu'de		dz		[dz]
+gde	Gu'de		ts		[ts]
+gde	Gu'de		dz		[d̠ʒ]
+gde	Gu'de		ɾ
+gde	Gu'de		l
+gde	Gu'de		ɬ		[ɬ]
+gde	Gu'de		ɬ		[ɬʲ]
+gde	Gu'de		<ⱱ>	marginal, ideophones only
+gde	Gu'de		ə		[u]
+gde	Gu'de		a		[ɔ]
+gde	Gu'de		əː		[uː]
+gde	Gu'de		aː		[aː]
+gde	Gu'de		ə		[i]
+gde	Gu'de		a		[ja]
+gde	Gu'de		a		[wa]
+gde	Gu'de		əː		[iː]
+gde	Gu'de		aː		[yaː]
+gde	Gu'de		əː		[eː]
+gde	Gu'de		aː		[ɔː]
+gde	Gu'de		˦
+gde	Gu'de		˨
+gde	Gu'de		ɱv		[ɱvʷ]
+
 lno	Lango		p	alternatives with [ɸ] in some constructions			lno.pdf
-lno	Lango		b				
-lno	Lango		m				
-lno	Lango		t	alternatives with [ɾ̥] in some constructions			
-lno	Lango		d				
-lno	Lango		n				
-lno	Lango		ɾ				
-lno	Lango		l				
-lno	Lango		tɕ	alternatives with [ɕ] and [s] in some constructions			
-lno	Lango		dʑ				
-lno	Lango		ɲ				
-lno	Lango		j				
-lno	Lango		k	alternatives with [k] in some constructions			
-lno	Lango		ɡ				
-lno	Lango		ŋ	never intervocalic			
-lno	Lango		w				
-lno	Lango		i		[i]		
-lno	Lango		ɪ		[ɪ]		
-lno	Lango		e		[e]		
-lno	Lango		ɛ		[ɛ]		
-lno	Lango		ə		[ə]		
-lno	Lango		a		[a]		
-lno	Lango		u		[u]		
-lno	Lango		ʊ		[ʊ]		
-lno	Lango		o		[o]		
-lno	Lango		ɔ		[ɔ]		
-lno	Lango		i		[iː]		
-lno	Lango		ɪ		[ɪː]		
-lno	Lango		e		[eː]		
-lno	Lango		ɛ		[ɛː]		
-lno	Lango		ə		[əː]		
-lno	Lango		a		[aː]		
-lno	Lango		u		[uː]		
-lno	Lango		ʊ		[ʊː]		
-lno	Lango		o		[oː]		
-lno	Lango		ɔ		[ɔː]		
-lno	Lango		i		[ĩ]		
-lno	Lango		ɪ		[ɪ̃]		
-lno	Lango		e		[ẽ]		
-lno	Lango		ɛ		[ɛ̃]		
-lno	Lango		ə		[ə̃]		
-lno	Lango		a		[ã]		
-lno	Lango		u		[ũ]		
-lno	Lango		ʊ		[ʊ̃]		
-lno	Lango		o		[õ]		
-lno	Lango		ɔ		[ɔ̃]		
-lno	Lango		↓˦				
-lno	Lango		˨˦				
-lno	Lango		˦˨				
-lno	Lango		˦				
-lno	Lango		˨				
-lno	Lango		˦↓˦	high downstepped high			
-							
+lno	Lango		b
+lno	Lango		m
+lno	Lango		t	alternatives with [ɾ̥] in some constructions
+lno	Lango		d
+lno	Lango		n
+lno	Lango		ɾ
+lno	Lango		l
+lno	Lango		tɕ	alternatives with [ɕ] and [s] in some constructions
+lno	Lango		dʑ
+lno	Lango		ɲ
+lno	Lango		j
+lno	Lango		k	alternatives with [k] in some constructions
+lno	Lango		ɡ
+lno	Lango		ŋ	never intervocalic
+lno	Lango		w
+lno	Lango		i		[i]
+lno	Lango		ɪ		[ɪ]
+lno	Lango		e		[e]
+lno	Lango		ɛ		[ɛ]
+lno	Lango		ə		[ə]
+lno	Lango		a		[a]
+lno	Lango		u		[u]
+lno	Lango		ʊ		[ʊ]
+lno	Lango		o		[o]
+lno	Lango		ɔ		[ɔ]
+lno	Lango		i		[iː]
+lno	Lango		ɪ		[ɪː]
+lno	Lango		e		[eː]
+lno	Lango		ɛ		[ɛː]
+lno	Lango		ə		[əː]
+lno	Lango		a		[aː]
+lno	Lango		u		[uː]
+lno	Lango		ʊ		[ʊː]
+lno	Lango		o		[oː]
+lno	Lango		ɔ		[ɔː]
+lno	Lango		i		[ĩ]
+lno	Lango		ɪ		[ɪ̃]
+lno	Lango		e		[ẽ]
+lno	Lango		ɛ		[ɛ̃]
+lno	Lango		ə		[ə̃]
+lno	Lango		a		[ã]
+lno	Lango		u		[ũ]
+lno	Lango		ʊ		[ʊ̃]
+lno	Lango		o		[õ]
+lno	Lango		ɔ		[ɔ̃]
+lno	Lango		↓˦
+lno	Lango		˨˦
+lno	Lango		˦˨
+lno	Lango		˦
+lno	Lango		˨
+lno	Lango		˦↓˦	high downstepped high
+
 ahl	Igo		p				igo_gblem_ahl.pdf
-ahl	Igo		b				
-ahl	Igo		m				
-ahl	Igo		w				
-ahl	Igo		f				
-ahl	Igo		v				
-ahl	Igo		t				
-ahl	Igo		d				
-ahl	Igo		ɖ				
-ahl	Igo		n				
-ahl	Igo		l				
-ahl	Igo		s				
-ahl	Igo		z				
-ahl	Igo		c				
-ahl	Igo		ɟ				
-ahl	Igo		ɲ				
-ahl	Igo		j				
-ahl	Igo		k				
-ahl	Igo		ɡ				
-ahl	Igo		ŋ				
-ahl	Igo		h				
-ahl	Igo		kp				
-ahl	Igo		ɡb				
-ahl	Igo		i				
-ahl	Igo		e				
-ahl	Igo		ɛ				
-ahl	Igo		a				
-ahl	Igo		u				
-ahl	Igo		o				
-ahl	Igo		ɔ				
-ahl	Igo		˦				
-ahl	Igo		˨				
-ahl	Igo		˧				
-							
+ahl	Igo		b
+ahl	Igo		m
+ahl	Igo		w
+ahl	Igo		f
+ahl	Igo		v
+ahl	Igo		t
+ahl	Igo		d
+ahl	Igo		ɖ
+ahl	Igo		n
+ahl	Igo		l
+ahl	Igo		s
+ahl	Igo		z
+ahl	Igo		c
+ahl	Igo		ɟ
+ahl	Igo		ɲ
+ahl	Igo		j
+ahl	Igo		k
+ahl	Igo		ɡ
+ahl	Igo		ŋ
+ahl	Igo		h
+ahl	Igo		kp
+ahl	Igo		ɡb
+ahl	Igo		i
+ahl	Igo		e
+ahl	Igo		ɛ
+ahl	Igo		a
+ahl	Igo		u
+ahl	Igo		o
+ahl	Igo		ɔ
+ahl	Igo		˦
+ahl	Igo		˨
+ahl	Igo		˧
+
 kkj	Kako		i				kako_ernst1992_o.pdf
-kkj	Kako		e				
-kkj	Kako		ɛ				
-kkj	Kako		a				
-kkj	Kako		o				
-kkj	Kako		u				
-kkj	Kako		ɔ				
-kkj	Kako		ĩ				
-kkj	Kako		ɛ̃				
-kkj	Kako		ã				
-kkj	Kako		ɔ̃				
-kkj	Kako		ũ				
-kkj	Kako		b				
-kkj	Kako		d				
-kkj	Kako		f				
-kkj	Kako		ɡ				
-kkj	Kako		k				
-kkj	Kako		l				
-kkj	Kako		m				
-kkj	Kako		n				
-kkj	Kako		p				
-kkj	Kako		r				
-kkj	Kako		s				
-kkj	Kako		t				
-kkj	Kako		v				
-kkj	Kako		w				
-kkj	Kako		j				
-kkj	Kako		kʷ				
-kkj	Kako		ɡʷ				
-kkj	Kako		ɲ				
-kkj	Kako		d̠ʒ				
-kkj	Kako		t̠ʃ				
-kkj	Kako		h				
-kkj	Kako		ŋ				
-kkj	Kako		ɓ				
-kkj	Kako		ɗ				
-kkj	Kako		ʄ				
-kkj	Kako		kp				
-kkj	Kako		ɡb				
-kkj	Kako		mb				
-kkj	Kako		nd				
-kkj	Kako		n̠d̠ʒ				
-kkj	Kako		ŋɡ				
-kkj	Kako		ŋɡʷ				
-kkj	Kako		ŋmɡb				
-kkj	Kako		˦				
-kkj	Kako		˨				
-							
+kkj	Kako		e
+kkj	Kako		ɛ
+kkj	Kako		a
+kkj	Kako		o
+kkj	Kako		u
+kkj	Kako		ɔ
+kkj	Kako		ĩ
+kkj	Kako		ɛ̃
+kkj	Kako		ã
+kkj	Kako		ɔ̃
+kkj	Kako		ũ
+kkj	Kako		b
+kkj	Kako		d
+kkj	Kako		f
+kkj	Kako		ɡ
+kkj	Kako		k
+kkj	Kako		l
+kkj	Kako		m
+kkj	Kako		n
+kkj	Kako		p
+kkj	Kako		r
+kkj	Kako		s
+kkj	Kako		t
+kkj	Kako		v
+kkj	Kako		w
+kkj	Kako		j
+kkj	Kako		kʷ
+kkj	Kako		ɡʷ
+kkj	Kako		ɲ
+kkj	Kako		d̠ʒ
+kkj	Kako		t̠ʃ
+kkj	Kako		h
+kkj	Kako		ŋ
+kkj	Kako		ɓ
+kkj	Kako		ɗ
+kkj	Kako		ʄ
+kkj	Kako		kp
+kkj	Kako		ɡb
+kkj	Kako		mb
+kkj	Kako		nd
+kkj	Kako		n̠d̠ʒ
+kkj	Kako		ŋɡ
+kkj	Kako		ŋɡʷ
+kkj	Kako		ŋmɡb
+kkj	Kako		˦
+kkj	Kako		˨
+
 knp	Kwanja	Sundani	p		[pʰ]		knp.pdf
-knp	Kwanja	Sundani	p		[pʷ]		
-knp	Kwanja	Sundani	t		[tʰ]		
-knp	Kwanja	Sundani	t		[t̚]		
-knp	Kwanja	Sundani	t		[tʷ]		
-knp	Kwanja	Sundani	k		[kʰ]		
-knp	Kwanja	Sundani	k		[k̚]		
-knp	Kwanja	Sundani	k		[kʷ]		
-knp	Kwanja	Sundani	b		[b]		
-knp	Kwanja	Sundani	b		[p̚]		
-knp	Kwanja	Sundani	b		[mb]		
-knp	Kwanja	Sundani	b		[mbʷ]		
-knp	Kwanja	Sundani	d		[d]		
-knp	Kwanja	Sundani	d		[nd]		
-knp	Kwanja	Sundani	d		[ndʷ]		
-knp	Kwanja	Sundani	d		[dʷ]		
-knp	Kwanja	Sundani	ɡ		[ɡ]		
-knp	Kwanja	Sundani	ɡ		[ŋɡ]		
-knp	Kwanja	Sundani	ɡ		[ɡʷ]		
-knp	Kwanja	Sundani	ɡ		[ŋɡʷ]		
-knp	Kwanja	Sundani	kp		[kp]		
-knp	Kwanja	Sundani	kp		[kpʷ]		
-knp	Kwanja	Sundani	ɡb		[ɡbʷ]		
-knp	Kwanja	Sundani	ɡb		[ɡb]		
-knp	Kwanja	Sundani	ɡb		[ŋmɡb]		
-knp	Kwanja	Sundani	ɡb		[ŋmɡbʷ]		
-knp	Kwanja	Sundani	f		[f]		
-knp	Kwanja	Sundani	f		[fʷ]		
-knp	Kwanja	Sundani	s		[sʷ]		
-knp	Kwanja	Sundani	s		[s]		
-knp	Kwanja	Sundani	s		[ʃ]		
-knp	Kwanja	Sundani	<v>	rare	[ɱvʷ]		
-knp	Kwanja	Sundani	d̠ʒ		[d̠ʒ]		
-knp	Kwanja	Sundani	d̠ʒ		[n̠d̠ʒ]		
-knp	Kwanja	Sundani	d̠ʒ		[n̠d̠ʒʷ]		
-knp	Kwanja	Sundani	t̠ʃ		[t̠ʃ]		
-knp	Kwanja	Sundani	t̠ʃ		[t̠ʃʷ]		
-knp	Kwanja	Sundani	d̠ʒ		[d̠ʒʷ]		
-knp	Kwanja	Sundani	m		[m]		
-knp	Kwanja	Sundani	m		[mʷ]		
-knp	Kwanja	Sundani	n		[n]		
-knp	Kwanja	Sundani	n		[nʷ]		
-knp	Kwanja	Sundani	ɲ				
-knp	Kwanja	Sundani	ŋ				
-knp	Kwanja	Sundani	l		[l]		
-knp	Kwanja	Sundani	l		[ɾ]		
-knp	Kwanja	Sundani	l		[ɹ̚]		
-knp	Kwanja	Sundani	l		[lʷ]		
-knp	Kwanja	Sundani	h		[h]		
-knp	Kwanja	Sundani	h		[hʷ]		
-knp	Kwanja	Sundani	w		[w]		
-knp	Kwanja	Sundani	j		[j]		
-knp	Kwanja	Sundani	j		[jʷ]		
-knp	Kwanja	Sundani	w		[wː]		
-knp	Kwanja	Sundani	i				
-knp	Kwanja	Sundani	y				
-knp	Kwanja	Sundani	ɨ				
-knp	Kwanja	Sundani	u				
-knp	Kwanja	Sundani	e				
-knp	Kwanja	Sundani	ə				
-knp	Kwanja	Sundani	o				
-knp	Kwanja	Sundani	ɛ				
-knp	Kwanja	Sundani	ɔ				
-knp	Kwanja	Sundani	a				
-knp	Kwanja	Sundani	iː				
-knp	Kwanja	Sundani	aː				
-knp	Kwanja	Sundani	eː				
-knp	Kwanja	Sundani	ɨː				
-knp	Kwanja	Sundani	əː				
-knp	Kwanja	Sundani	uː				
-knp	Kwanja	Sundani	oː				
-knp	Kwanja	Sundani	ɔː				
-knp	Kwanja	Sundani	˥				
-knp	Kwanja	Sundani	˩				
-knp	Kwanja	Sundani	˦				
-knp	Kwanja	Sundani	˨				
-							
+knp	Kwanja	Sundani	p		[pʷ]
+knp	Kwanja	Sundani	t		[tʰ]
+knp	Kwanja	Sundani	t		[t̚]
+knp	Kwanja	Sundani	t		[tʷ]
+knp	Kwanja	Sundani	k		[kʰ]
+knp	Kwanja	Sundani	k		[k̚]
+knp	Kwanja	Sundani	k		[kʷ]
+knp	Kwanja	Sundani	b		[b]
+knp	Kwanja	Sundani	b		[p̚]
+knp	Kwanja	Sundani	b		[mb]
+knp	Kwanja	Sundani	b		[mbʷ]
+knp	Kwanja	Sundani	d		[d]
+knp	Kwanja	Sundani	d		[nd]
+knp	Kwanja	Sundani	d		[ndʷ]
+knp	Kwanja	Sundani	d		[dʷ]
+knp	Kwanja	Sundani	ɡ		[ɡ]
+knp	Kwanja	Sundani	ɡ		[ŋɡ]
+knp	Kwanja	Sundani	ɡ		[ɡʷ]
+knp	Kwanja	Sundani	ɡ		[ŋɡʷ]
+knp	Kwanja	Sundani	kp		[kp]
+knp	Kwanja	Sundani	kp		[kpʷ]
+knp	Kwanja	Sundani	ɡb		[ɡbʷ]
+knp	Kwanja	Sundani	ɡb		[ɡb]
+knp	Kwanja	Sundani	ɡb		[ŋmɡb]
+knp	Kwanja	Sundani	ɡb		[ŋmɡbʷ]
+knp	Kwanja	Sundani	f		[f]
+knp	Kwanja	Sundani	f		[fʷ]
+knp	Kwanja	Sundani	s		[sʷ]
+knp	Kwanja	Sundani	s		[s]
+knp	Kwanja	Sundani	s		[ʃ]
+knp	Kwanja	Sundani	<v>	rare	[ɱvʷ]
+knp	Kwanja	Sundani	d̠ʒ		[d̠ʒ]
+knp	Kwanja	Sundani	d̠ʒ		[n̠d̠ʒ]
+knp	Kwanja	Sundani	d̠ʒ		[n̠d̠ʒʷ]
+knp	Kwanja	Sundani	t̠ʃ		[t̠ʃ]
+knp	Kwanja	Sundani	t̠ʃ		[t̠ʃʷ]
+knp	Kwanja	Sundani	d̠ʒ		[d̠ʒʷ]
+knp	Kwanja	Sundani	m		[m]
+knp	Kwanja	Sundani	m		[mʷ]
+knp	Kwanja	Sundani	n		[n]
+knp	Kwanja	Sundani	n		[nʷ]
+knp	Kwanja	Sundani	ɲ
+knp	Kwanja	Sundani	ŋ
+knp	Kwanja	Sundani	l		[l]
+knp	Kwanja	Sundani	l		[ɾ]
+knp	Kwanja	Sundani	l		[ɹ̚]
+knp	Kwanja	Sundani	l		[lʷ]
+knp	Kwanja	Sundani	h		[h]
+knp	Kwanja	Sundani	h		[hʷ]
+knp	Kwanja	Sundani	w		[w]
+knp	Kwanja	Sundani	j		[j]
+knp	Kwanja	Sundani	j		[jʷ]
+knp	Kwanja	Sundani	w		[wː]
+knp	Kwanja	Sundani	i
+knp	Kwanja	Sundani	y
+knp	Kwanja	Sundani	ɨ
+knp	Kwanja	Sundani	u
+knp	Kwanja	Sundani	e
+knp	Kwanja	Sundani	ə
+knp	Kwanja	Sundani	o
+knp	Kwanja	Sundani	ɛ
+knp	Kwanja	Sundani	ɔ
+knp	Kwanja	Sundani	a
+knp	Kwanja	Sundani	iː
+knp	Kwanja	Sundani	aː
+knp	Kwanja	Sundani	eː
+knp	Kwanja	Sundani	ɨː
+knp	Kwanja	Sundani	əː
+knp	Kwanja	Sundani	uː
+knp	Kwanja	Sundani	oː
+knp	Kwanja	Sundani	ɔː
+knp	Kwanja	Sundani	˥
+knp	Kwanja	Sundani	˩
+knp	Kwanja	Sundani	˦
+knp	Kwanja	Sundani	˨
+
 mcu	Mambila	Atta	i		[i]		Mambila_CAM.pdf
-mcu	Mambila	Atta	i		[ɪ]		
-mcu	Mambila	Atta	i		[ĩ]		
-mcu	Mambila	Atta	i		[ə]		
-mcu	Mambila	Atta	e		[e]		
-mcu	Mambila	Atta	e		[ẽ]		
-mcu	Mambila	Atta	e		[ɛ]		
-mcu	Mambila	Atta	e		[ɛ̃]		
-mcu	Mambila	Atta	a		[a]		
-mcu	Mambila	Atta	a		[ã]		
-mcu	Mambila	Atta	o		[o]		
-mcu	Mambila	Atta	o		[õ]		
-mcu	Mambila	Atta	u		[u]		
-mcu	Mambila	Atta	u		[w]		
-mcu	Mambila	Atta	u		[ʊ]		
-mcu	Mambila	Atta	u		[y]		
-mcu	Mambila	Atta	u		[ʊ̃]		
-mcu	Mambila	Atta	iː				
-mcu	Mambila	Atta	eː				
-mcu	Mambila	Atta	aː				
-mcu	Mambila	Atta	oː				
-mcu	Mambila	Atta	uː				
-mcu	Mambila	Atta	bv				
-mcu	Mambila	Atta	t̠ʃ				
-mcu	Mambila	Atta	d̠ʒ				
-mcu	Mambila	Atta	h		[hʲ]		
-mcu	Mambila	Atta	h		[hʷ]		
-mcu	Mambila	Atta	ŋ		[ŋʷ]		
-mcu	Mambila	Atta	p				
-mcu	Mambila	Atta	b				
-mcu	Mambila	Atta	m				
-mcu	Mambila	Atta	w				
-mcu	Mambila	Atta	f				
-mcu	Mambila	Atta	v				
-mcu	Mambila	Atta	t				
-mcu	Mambila	Atta	d		[d]		
-mcu	Mambila	Atta	d		[r]		
-mcu	Mambila	Atta	s		[s]		
-mcu	Mambila	Atta	s		[ʃ]		
-mcu	Mambila	Atta	n				
-mcu	Mambila	Atta	l		[l]		
-mcu	Mambila	Atta	l		[lʰ]		
-mcu	Mambila	Atta	l		[ɾ]		
-mcu	Mambila	Atta	t̠ʃ				
-mcu	Mambila	Atta	d̠ʒ		[d̠ʒ]		
-mcu	Mambila	Atta	d̠ʒ		[ʒ]		
-mcu	Mambila	Atta	ɲ				
-mcu	Mambila	Atta	j				
-mcu	Mambila	Atta	k		[k]		
-mcu	Mambila	Atta	k		[x]		
-mcu	Mambila	Atta	ɡ		[ɡ]		
-mcu	Mambila	Atta	ɡ		[ɣ]		
-mcu	Mambila	Atta	ŋ		[ŋ]		
-mcu	Mambila	Atta	h		[h]		
-mcu	Mambila	Atta	ɔ		[ɔ]		
-mcu	Mambila	Atta	ɔ		[ɔ̃]		
-mcu	Mambila	Atta	˥				
-mcu	Mambila	Atta	˩				
-mcu	Mambila	Atta	˦				
-mcu	Mambila	Atta	˨				
-							
+mcu	Mambila	Atta	i		[ɪ]
+mcu	Mambila	Atta	i		[ĩ]
+mcu	Mambila	Atta	i		[ə]
+mcu	Mambila	Atta	e		[e]
+mcu	Mambila	Atta	e		[ẽ]
+mcu	Mambila	Atta	e		[ɛ]
+mcu	Mambila	Atta	e		[ɛ̃]
+mcu	Mambila	Atta	a		[a]
+mcu	Mambila	Atta	a		[ã]
+mcu	Mambila	Atta	o		[o]
+mcu	Mambila	Atta	o		[õ]
+mcu	Mambila	Atta	u		[u]
+mcu	Mambila	Atta	u		[w]
+mcu	Mambila	Atta	u		[ʊ]
+mcu	Mambila	Atta	u		[y]
+mcu	Mambila	Atta	u		[ʊ̃]
+mcu	Mambila	Atta	iː
+mcu	Mambila	Atta	eː
+mcu	Mambila	Atta	aː
+mcu	Mambila	Atta	oː
+mcu	Mambila	Atta	uː
+mcu	Mambila	Atta	bv
+mcu	Mambila	Atta	t̠ʃ
+mcu	Mambila	Atta	d̠ʒ
+mcu	Mambila	Atta	h		[hʲ]
+mcu	Mambila	Atta	h		[hʷ]
+mcu	Mambila	Atta	ŋ		[ŋʷ]
+mcu	Mambila	Atta	p
+mcu	Mambila	Atta	b
+mcu	Mambila	Atta	m
+mcu	Mambila	Atta	w
+mcu	Mambila	Atta	f
+mcu	Mambila	Atta	v
+mcu	Mambila	Atta	t
+mcu	Mambila	Atta	d		[d]
+mcu	Mambila	Atta	d		[r]
+mcu	Mambila	Atta	s		[s]
+mcu	Mambila	Atta	s		[ʃ]
+mcu	Mambila	Atta	n
+mcu	Mambila	Atta	l		[l]
+mcu	Mambila	Atta	l		[lʰ]
+mcu	Mambila	Atta	l		[ɾ]
+mcu	Mambila	Atta	t̠ʃ
+mcu	Mambila	Atta	d̠ʒ		[d̠ʒ]
+mcu	Mambila	Atta	d̠ʒ		[ʒ]
+mcu	Mambila	Atta	ɲ
+mcu	Mambila	Atta	j
+mcu	Mambila	Atta	k		[k]
+mcu	Mambila	Atta	k		[x]
+mcu	Mambila	Atta	ɡ		[ɡ]
+mcu	Mambila	Atta	ɡ		[ɣ]
+mcu	Mambila	Atta	ŋ		[ŋ]
+mcu	Mambila	Atta	h		[h]
+mcu	Mambila	Atta	ɔ		[ɔ]
+mcu	Mambila	Atta	ɔ		[ɔ̃]
+mcu	Mambila	Atta	˥
+mcu	Mambila	Atta	˩
+mcu	Mambila	Atta	˦
+mcu	Mambila	Atta	˨
+
 meq	Mere		p				meq.pdf
-meq	Mere		b				
-meq	Mere		ɓ				
-meq	Mere		f				
-meq	Mere		v				
-meq	Mere		m				
-meq	Mere		mb				
-meq	Mere		w				
-meq	Mere		t				
-meq	Mere		d				
-meq	Mere		ɗ				
-meq	Mere		ɬ				
-meq	Mere		ɮ				
-meq	Mere		n				
-meq	Mere		ŋ				
-meq	Mere		nd				
-meq	Mere		l				
-meq	Mere		r				
-meq	Mere		ts		[ts]		
-meq	Mere		ts		[t̠ʃ]		
-meq	Mere		dz		[dz]		
-meq	Mere		dz		[d̠ʒ]		
-meq	Mere		s		[s]		
-meq	Mere		s		[ʃ]		
-meq	Mere		z		[z]		
-meq	Mere		z		[ʒ]		
-meq	Mere		ndz		[ndz]		
-meq	Mere		ndz		[nʒ]		
-meq	Mere		j				
-meq	Mere		k				
-meq	Mere		ɡ				
-meq	Mere		h		[h]		
-meq	Mere		h		[x]		
-meq	Mere		ŋɡ				
-meq	Mere		ʔ				
-meq	Mere		kʷ				
-meq	Mere		ɡʷ				
-meq	Mere		hʷ				
-meq	Mere		ŋɡʷ				
-meq	Mere		a				
-meq	Mere		ə				
-meq	Mere		ɛ				
-meq	Mere		i				
-meq	Mere		ɔ				
-meq	Mere		u				
-meq	Mere		y				
-meq	Mere		œ				
-meq	Mere		˦				
-meq	Mere		˨				
-meq	Mere		˧				
-							
+meq	Mere		b
+meq	Mere		ɓ
+meq	Mere		f
+meq	Mere		v
+meq	Mere		m
+meq	Mere		mb
+meq	Mere		w
+meq	Mere		t
+meq	Mere		d
+meq	Mere		ɗ
+meq	Mere		ɬ
+meq	Mere		ɮ
+meq	Mere		n
+meq	Mere		ŋ
+meq	Mere		nd
+meq	Mere		l
+meq	Mere		r
+meq	Mere		ts		[ts]
+meq	Mere		ts		[t̠ʃ]
+meq	Mere		dz		[dz]
+meq	Mere		dz		[d̠ʒ]
+meq	Mere		s		[s]
+meq	Mere		s		[ʃ]
+meq	Mere		z		[z]
+meq	Mere		z		[ʒ]
+meq	Mere		ndz		[ndz]
+meq	Mere		ndz		[nʒ]
+meq	Mere		j
+meq	Mere		k
+meq	Mere		ɡ
+meq	Mere		h		[h]
+meq	Mere		h		[x]
+meq	Mere		ŋɡ
+meq	Mere		ʔ
+meq	Mere		kʷ
+meq	Mere		ɡʷ
+meq	Mere		hʷ
+meq	Mere		ŋɡʷ
+meq	Mere		a
+meq	Mere		ə
+meq	Mere		ɛ
+meq	Mere		i
+meq	Mere		ɔ
+meq	Mere		u
+meq	Mere		y
+meq	Mere		œ
+meq	Mere		˦
+meq	Mere		˨
+meq	Mere		˧
+
 mfi	Mandara		˦				mfi.pdf
-mfi	Mandara		˨				
-mfi	Mandara		p				
-mfi	Mandara		b				
-mfi	Mandara		ɓ				
-mfi	Mandara		mb				
-mfi	Mandara		t				
-mfi	Mandara		d				
-mfi	Mandara		ɗ				
-mfi	Mandara		nd				
-mfi	Mandara		f				
-mfi	Mandara		v				
-mfi	Mandara		w				
-mfi	Mandara		h				
-mfi	Mandara		hʷ				
-mfi	Mandara		m				
-mfi	Mandara		n				
-mfi	Mandara		ŋ				
-mfi	Mandara		ŋʷ				
-mfi	Mandara		ɬʲ				
-mfi	Mandara		ɮʲ				
-mfi	Mandara		ɬ				
-mfi	Mandara		ɮ				
-mfi	Mandara		l				
-mfi	Mandara		r				
-mfi	Mandara		s				
-mfi	Mandara		z				
-mfi	Mandara		ʃ				
-mfi	Mandara		ʒ				
-mfi	Mandara		ts				
-mfi	Mandara		dz				
-mfi	Mandara		ndz				
-mfi	Mandara		t̠ʃ				
-mfi	Mandara		d̠ʒ				
-mfi	Mandara		n̠d̠ʒ				
-mfi	Mandara		ɳ				
-mfi	Mandara		j				
-mfi	Mandara		k				
-mfi	Mandara		ɡ				
-mfi	Mandara		ŋɡ				
-mfi	Mandara		kʲ				
-mfi	Mandara		ɡʲ				
-mfi	Mandara		ŋɡʲ				
-mfi	Mandara		kʷ				
-mfi	Mandara		ɡʷ				
-mfi	Mandara		ŋɡʷ				
-mfi	Mandara		ŋʷ				
-mfi	Mandara		ʄ				
-mfi	Mandara		iː				
-mfi	Mandara		e		[ə]		
-mfi	Mandara		e		[ɪ]		
-mfi	Mandara		e		[ʊ]		
-mfi	Mandara		e		[ɨ]		
-mfi	Mandara		e		[e]		
-mfi	Mandara		a		[a]		
-mfi	Mandara		a		[ɛ]		
-mfi	Mandara		a		[o]		
-mfi	Mandara		a		[ɔ]		
-mfi	Mandara		aː				
-mfi	Mandara		uː				
-							
+mfi	Mandara		˨
+mfi	Mandara		p
+mfi	Mandara		b
+mfi	Mandara		ɓ
+mfi	Mandara		mb
+mfi	Mandara		t
+mfi	Mandara		d
+mfi	Mandara		ɗ
+mfi	Mandara		nd
+mfi	Mandara		f
+mfi	Mandara		v
+mfi	Mandara		w
+mfi	Mandara		h
+mfi	Mandara		hʷ
+mfi	Mandara		m
+mfi	Mandara		n
+mfi	Mandara		ŋ
+mfi	Mandara		ŋʷ
+mfi	Mandara		ɬʲ
+mfi	Mandara		ɮʲ
+mfi	Mandara		ɬ
+mfi	Mandara		ɮ
+mfi	Mandara		l
+mfi	Mandara		r
+mfi	Mandara		s
+mfi	Mandara		z
+mfi	Mandara		ʃ
+mfi	Mandara		ʒ
+mfi	Mandara		ts
+mfi	Mandara		dz
+mfi	Mandara		ndz
+mfi	Mandara		t̠ʃ
+mfi	Mandara		d̠ʒ
+mfi	Mandara		n̠d̠ʒ
+mfi	Mandara		ɳ
+mfi	Mandara		j
+mfi	Mandara		k
+mfi	Mandara		ɡ
+mfi	Mandara		ŋɡ
+mfi	Mandara		kʲ
+mfi	Mandara		ɡʲ
+mfi	Mandara		ŋɡʲ
+mfi	Mandara		kʷ
+mfi	Mandara		ɡʷ
+mfi	Mandara		ŋɡʷ
+mfi	Mandara		ŋʷ
+mfi	Mandara		ʄ
+mfi	Mandara		iː
+mfi	Mandara		e		[ə]
+mfi	Mandara		e		[ɪ]
+mfi	Mandara		e		[ʊ]
+mfi	Mandara		e		[ɨ]
+mfi	Mandara		e		[e]
+mfi	Mandara		a		[a]
+mfi	Mandara		a		[ɛ]
+mfi	Mandara		a		[o]
+mfi	Mandara		a		[ɔ]
+mfi	Mandara		aː
+mfi	Mandara		uː
+
 coh	Chonyi		i		[i]		mijikenda.pdf
-coh	Chonyi		e		[e]		
-coh	Chonyi		a		[a]		
-coh	Chonyi		o		[o]		
-coh	Chonyi		u		[u]		
-coh	Chonyi		i		[ĩ]		
-coh	Chonyi		e		[ẽ]		
-coh	Chonyi		a		[ã]		
-coh	Chonyi		o		[õ]		
-coh	Chonyi		u		[ũ]		
-coh	Chonyi		p		[p]		
-coh	Chonyi		p		[pʰ]		
-coh	Chonyi		b		[b]		
-coh	Chonyi		b		[mb]		
-coh	Chonyi		mb				
-coh	Chonyi		t̪		[t̪]		
-coh	Chonyi		t̪		[t̪ʰ]		
-coh	Chonyi		d̪		[d̪]		
-coh	Chonyi		d̪		[n̪d̪]		
-coh	Chonyi		n̪d̪				
-coh	Chonyi		t		[t]		
-coh	Chonyi		t		[tʰ]		
-coh	Chonyi		d		[d]		
-coh	Chonyi		d		[nd]		
-coh	Chonyi		nd				
-coh	Chonyi		ts		[ts]		
-coh	Chonyi		ts		[tsʰ]		
-coh	Chonyi		dz		[dz]		
-coh	Chonyi		dz		[ndz]		
-coh	Chonyi		ndz				
-coh	Chonyi		t̠ʃ		[t̠ʃ]		
-coh	Chonyi		t̠ʃ		[t̠ʃʰ]		
-coh	Chonyi		d̠ʒ		[d̠ʒ]		
-coh	Chonyi		d̠ʒ		[n̠d̠ʒ]		
-coh	Chonyi		n̠d̠ʒ				
-coh	Chonyi		k		[k]		
-coh	Chonyi		k		[kʰ]		
-coh	Chonyi		ɡ		[ɡ]		
-coh	Chonyi		ɡ		[ŋɡ]		
-coh	Chonyi		ŋɡ				
-coh	Chonyi		kp		[kp]		
-coh	Chonyi		kp		[kpʰ]		
-coh	Chonyi		ɡb		[ɡb]		
-coh	Chonyi		ɡb		[ŋmɡb]		
-coh	Chonyi		ŋmɡb				
-coh	Chonyi		ʔ				
-coh	Chonyi		f				
-coh	Chonyi		s				
-coh	Chonyi		ʃ				
-coh	Chonyi		h				
-coh	Chonyi		β	possibly [ʋ]			
-coh	Chonyi		v				
-coh	Chonyi		ð				
-coh	Chonyi		z				
-coh	Chonyi		ɦ				
-coh	Chonyi		m				
-coh	Chonyi		n				
-coh	Chonyi		ɲ				
-coh	Chonyi		ŋ				
-coh	Chonyi		ŋm				
-coh	Chonyi		l				
-coh	Chonyi		r				
-coh	Chonyi		j				
-coh	Chonyi		w				
-coh	Chonyi		˦				
-coh	Chonyi		˨	underlyinɡly toneless, phonetically L			
-							
+coh	Chonyi		e		[e]
+coh	Chonyi		a		[a]
+coh	Chonyi		o		[o]
+coh	Chonyi		u		[u]
+coh	Chonyi		i		[ĩ]
+coh	Chonyi		e		[ẽ]
+coh	Chonyi		a		[ã]
+coh	Chonyi		o		[õ]
+coh	Chonyi		u		[ũ]
+coh	Chonyi		p		[p]
+coh	Chonyi		p		[pʰ]
+coh	Chonyi		b		[b]
+coh	Chonyi		b		[mb]
+coh	Chonyi		mb
+coh	Chonyi		t̪		[t̪]
+coh	Chonyi		t̪		[t̪ʰ]
+coh	Chonyi		d̪		[d̪]
+coh	Chonyi		d̪		[n̪d̪]
+coh	Chonyi		n̪d̪
+coh	Chonyi		t		[t]
+coh	Chonyi		t		[tʰ]
+coh	Chonyi		d		[d]
+coh	Chonyi		d		[nd]
+coh	Chonyi		nd
+coh	Chonyi		ts		[ts]
+coh	Chonyi		ts		[tsʰ]
+coh	Chonyi		dz		[dz]
+coh	Chonyi		dz		[ndz]
+coh	Chonyi		ndz
+coh	Chonyi		t̠ʃ		[t̠ʃ]
+coh	Chonyi		t̠ʃ		[t̠ʃʰ]
+coh	Chonyi		d̠ʒ		[d̠ʒ]
+coh	Chonyi		d̠ʒ		[n̠d̠ʒ]
+coh	Chonyi		n̠d̠ʒ
+coh	Chonyi		k		[k]
+coh	Chonyi		k		[kʰ]
+coh	Chonyi		ɡ		[ɡ]
+coh	Chonyi		ɡ		[ŋɡ]
+coh	Chonyi		ŋɡ
+coh	Chonyi		kp		[kp]
+coh	Chonyi		kp		[kpʰ]
+coh	Chonyi		ɡb		[ɡb]
+coh	Chonyi		ɡb		[ŋmɡb]
+coh	Chonyi		ŋmɡb
+coh	Chonyi		ʔ
+coh	Chonyi		f
+coh	Chonyi		s
+coh	Chonyi		ʃ
+coh	Chonyi		h
+coh	Chonyi		β	possibly [ʋ]
+coh	Chonyi		v
+coh	Chonyi		ð
+coh	Chonyi		z
+coh	Chonyi		ɦ
+coh	Chonyi		m
+coh	Chonyi		n
+coh	Chonyi		ɲ
+coh	Chonyi		ŋ
+coh	Chonyi		ŋm
+coh	Chonyi		l
+coh	Chonyi		r
+coh	Chonyi		j
+coh	Chonyi		w
+coh	Chonyi		˦
+coh	Chonyi		˨	underlyinɡly toneless, phonetically L
+
 dig	Digo		i		[i]		mijikenda.pdf
-dig	Digo		e		[e]		
-dig	Digo		a		[a]		
-dig	Digo		o		[o]		
-dig	Digo		u		[u]		
-dig	Digo		i		[ĩ]		
-dig	Digo		e		[ẽ]		
-dig	Digo		a		[ã]		
-dig	Digo		o		[õ]		
-dig	Digo		u		[ũ]		
-dig	Digo		p	distinction lost with aspirated counterpart			
-dig	Digo		b		[b]		
-dig	Digo		b		[mb]		
-dig	Digo		mb				
-dig	Digo		t̪	distinction lost with aspirated counterpart			
-dig	Digo		d̪		[d̪]		
-dig	Digo		d̪		[n̪d̪]		
-dig	Digo		n̪d̪				
-dig	Digo		t	distinction lost with aspirated counterpart			
-dig	Digo		d		[d]		
-dig	Digo		d		[nd]		
-dig	Digo		nd				
-dig	Digo		ts	distinction lost with aspirated counterpart			
-dig	Digo		dz		[dz]		
-dig	Digo		dz		[ndz]		
-dig	Digo		ndz				
-dig	Digo		t̠ʃ	distinction lost with aspirated counterpart			
-dig	Digo		d̠ʒ		[d̠ʒ]		
-dig	Digo		d̠ʒ		[n̠d̠ʒ]		
-dig	Digo		n̠d̠ʒ				
-dig	Digo		k	distinction lost with aspirated counterpart			
-dig	Digo		ɡ		[ɡ]		
-dig	Digo		ɡ		[ŋɡ]		
-dig	Digo		ŋɡ				
-dig	Digo		kp	distinction lost with aspirated counterpart			
-dig	Digo		ɡb		[ɡb]		
-dig	Digo		ɡb		[ŋmɡb]		
-dig	Digo		ŋmɡb				
-dig	Digo		ʔ				
-dig	Digo		f				
-dig	Digo		s				
-dig	Digo		ʃ				
-dig	Digo		h				
-dig	Digo		β	possibly [ʋ]			
-dig	Digo		v				
-dig	Digo		ð				
-dig	Digo		z				
-dig	Digo		ɦ				
-dig	Digo		m				
-dig	Digo		n				
-dig	Digo		ɲ				
-dig	Digo		ŋ				
-dig	Digo		ŋm				
-dig	Digo		l				
-dig	Digo		r				
-dig	Digo		j				
-dig	Digo		w				
-dig	Digo		˦				
-dig	Digo		˨	underlyinɡly toneless, phonetically L			
-dig	Digo		ʒ				
-							
+dig	Digo		e		[e]
+dig	Digo		a		[a]
+dig	Digo		o		[o]
+dig	Digo		u		[u]
+dig	Digo		i		[ĩ]
+dig	Digo		e		[ẽ]
+dig	Digo		a		[ã]
+dig	Digo		o		[õ]
+dig	Digo		u		[ũ]
+dig	Digo		p	distinction lost with aspirated counterpart
+dig	Digo		b		[b]
+dig	Digo		b		[mb]
+dig	Digo		mb
+dig	Digo		t̪	distinction lost with aspirated counterpart
+dig	Digo		d̪		[d̪]
+dig	Digo		d̪		[n̪d̪]
+dig	Digo		n̪d̪
+dig	Digo		t	distinction lost with aspirated counterpart
+dig	Digo		d		[d]
+dig	Digo		d		[nd]
+dig	Digo		nd
+dig	Digo		ts	distinction lost with aspirated counterpart
+dig	Digo		dz		[dz]
+dig	Digo		dz		[ndz]
+dig	Digo		ndz
+dig	Digo		t̠ʃ	distinction lost with aspirated counterpart
+dig	Digo		d̠ʒ		[d̠ʒ]
+dig	Digo		d̠ʒ		[n̠d̠ʒ]
+dig	Digo		n̠d̠ʒ
+dig	Digo		k	distinction lost with aspirated counterpart
+dig	Digo		ɡ		[ɡ]
+dig	Digo		ɡ		[ŋɡ]
+dig	Digo		ŋɡ
+dig	Digo		kp	distinction lost with aspirated counterpart
+dig	Digo		ɡb		[ɡb]
+dig	Digo		ɡb		[ŋmɡb]
+dig	Digo		ŋmɡb
+dig	Digo		ʔ
+dig	Digo		f
+dig	Digo		s
+dig	Digo		ʃ
+dig	Digo		h
+dig	Digo		β	possibly [ʋ]
+dig	Digo		v
+dig	Digo		ð
+dig	Digo		z
+dig	Digo		ɦ
+dig	Digo		m
+dig	Digo		n
+dig	Digo		ɲ
+dig	Digo		ŋ
+dig	Digo		ŋm
+dig	Digo		l
+dig	Digo		r
+dig	Digo		j
+dig	Digo		w
+dig	Digo		˦
+dig	Digo		˨	underlyinɡly toneless, phonetically L
+dig	Digo		ʒ
+
 dug	Duruma		i		[i]		mijikenda.pdf
-dug	Duruma		e		[e]		
-dug	Duruma		a		[a]		
-dug	Duruma		o		[o]		
-dug	Duruma		u		[u]		
-dug	Duruma		i		[ĩ]		
-dug	Duruma		e		[ẽ]		
-dug	Duruma		a		[ã]		
-dug	Duruma		o		[õ]		
-dug	Duruma		u		[ũ]		
-dug	Duruma		p		[p]		
-dug	Duruma		p		[pʰ]		
-dug	Duruma		b		[b]		
-dug	Duruma		b		[mb]		
-dug	Duruma		mb				
-dug	Duruma		t̪		[t̪]		
-dug	Duruma		t̪		[t̪ʰ]		
-dug	Duruma		d̪		[d̪]		
-dug	Duruma		d̪		[n̪d̪]		
-dug	Duruma		n̪d̪				
-dug	Duruma		t		[t]		
-dug	Duruma		t		[tʰ]		
-dug	Duruma		d		[d]		
-dug	Duruma		d		[nd]		
-dug	Duruma		nd				
-dug	Duruma		ts		[ts]		
-dug	Duruma		ts		[tsʰ]		
-dug	Duruma		dz		[dz]		
-dug	Duruma		dz		[ndz]		
-dug	Duruma		ndz				
-dug	Duruma		t̠ʃ		[t̠ʃ]		
-dug	Duruma		t̠ʃ		[t̠ʃʰ]		
-dug	Duruma		d̠ʒ		[d̠ʒ]		
-dug	Duruma		d̠ʒ		[n̠d̠ʒ]		
-dug	Duruma		n̠d̠ʒ				
-dug	Duruma		k		[k]		
-dug	Duruma		k		[kʰ]		
-dug	Duruma		ɡ		[ɡ]		
-dug	Duruma		ɡ		[ŋɡ]		
-dug	Duruma		ŋɡ				
-dug	Duruma		kp		[kp]		
-dug	Duruma		kp		[kpʰ]		
-dug	Duruma		ɡb		[ɡb]		
-dug	Duruma		ɡb		[ŋmɡb]		
-dug	Duruma		ŋmɡb				
-dug	Duruma		ʔ				
-dug	Duruma		f				
-dug	Duruma		s				
-dug	Duruma		ʃ				
-dug	Duruma		h				
-dug	Duruma		β	possibly [ʋ]			
-dug	Duruma		v				
-dug	Duruma		ð				
-dug	Duruma		z				
-dug	Duruma		ɦ				
-dug	Duruma		m				
-dug	Duruma		n				
-dug	Duruma		ɲ				
-dug	Duruma		ŋ				
-dug	Duruma		ŋm				
-dug	Duruma		l				
-dug	Duruma		r				
-dug	Duruma		j				
-dug	Duruma		w				
-dug	Duruma		˦				
-dug	Duruma		˨	underlyinɡly toneless, phonetically L			
-							
+dug	Duruma		e		[e]
+dug	Duruma		a		[a]
+dug	Duruma		o		[o]
+dug	Duruma		u		[u]
+dug	Duruma		i		[ĩ]
+dug	Duruma		e		[ẽ]
+dug	Duruma		a		[ã]
+dug	Duruma		o		[õ]
+dug	Duruma		u		[ũ]
+dug	Duruma		p		[p]
+dug	Duruma		p		[pʰ]
+dug	Duruma		b		[b]
+dug	Duruma		b		[mb]
+dug	Duruma		mb
+dug	Duruma		t̪		[t̪]
+dug	Duruma		t̪		[t̪ʰ]
+dug	Duruma		d̪		[d̪]
+dug	Duruma		d̪		[n̪d̪]
+dug	Duruma		n̪d̪
+dug	Duruma		t		[t]
+dug	Duruma		t		[tʰ]
+dug	Duruma		d		[d]
+dug	Duruma		d		[nd]
+dug	Duruma		nd
+dug	Duruma		ts		[ts]
+dug	Duruma		ts		[tsʰ]
+dug	Duruma		dz		[dz]
+dug	Duruma		dz		[ndz]
+dug	Duruma		ndz
+dug	Duruma		t̠ʃ		[t̠ʃ]
+dug	Duruma		t̠ʃ		[t̠ʃʰ]
+dug	Duruma		d̠ʒ		[d̠ʒ]
+dug	Duruma		d̠ʒ		[n̠d̠ʒ]
+dug	Duruma		n̠d̠ʒ
+dug	Duruma		k		[k]
+dug	Duruma		k		[kʰ]
+dug	Duruma		ɡ		[ɡ]
+dug	Duruma		ɡ		[ŋɡ]
+dug	Duruma		ŋɡ
+dug	Duruma		kp		[kp]
+dug	Duruma		kp		[kpʰ]
+dug	Duruma		ɡb		[ɡb]
+dug	Duruma		ɡb		[ŋmɡb]
+dug	Duruma		ŋmɡb
+dug	Duruma		ʔ
+dug	Duruma		f
+dug	Duruma		s
+dug	Duruma		ʃ
+dug	Duruma		h
+dug	Duruma		β	possibly [ʋ]
+dug	Duruma		v
+dug	Duruma		ð
+dug	Duruma		z
+dug	Duruma		ɦ
+dug	Duruma		m
+dug	Duruma		n
+dug	Duruma		ɲ
+dug	Duruma		ŋ
+dug	Duruma		ŋm
+dug	Duruma		l
+dug	Duruma		r
+dug	Duruma		j
+dug	Duruma		w
+dug	Duruma		˦
+dug	Duruma		˨	underlyinɡly toneless, phonetically L
+
 nyf	Giryama		i		[i]		mijikenda.pdf
-nyf	Giryama		e		[e]		
-nyf	Giryama		a		[a]		
-nyf	Giryama		o		[o]		
-nyf	Giryama		u		[u]		
-nyf	Giryama		i		[ĩ]		
-nyf	Giryama		e		[ẽ]		
-nyf	Giryama		a		[ã]		
-nyf	Giryama		o		[õ]		
-nyf	Giryama		u		[ũ]		
-nyf	Giryama		p		[p]		
-nyf	Giryama		p		[pʰ]		
-nyf	Giryama		b		[b]		
-nyf	Giryama		b		[mb]		
-nyf	Giryama		mb				
-nyf	Giryama		t̪		[t̪]		
-nyf	Giryama		t̪		[t̪ʰ]		
-nyf	Giryama		d̪		[d̪]		
-nyf	Giryama		d̪		[n̪d̪]		
-nyf	Giryama		n̪d̪				
-nyf	Giryama		t		[t]		
-nyf	Giryama		t		[tʰ]		
-nyf	Giryama		d		[d]		
-nyf	Giryama		d		[nd]		
-nyf	Giryama		nd				
-nyf	Giryama		ts		[ts]		
-nyf	Giryama		ts		[tsʰ]		
-nyf	Giryama		dz		[dz]		
-nyf	Giryama		dz		[ndz]		
-nyf	Giryama		ndz				
-nyf	Giryama		t̠ʃ		[t̠ʃ]		
-nyf	Giryama		t̠ʃ		[t̠ʃʰ]		
-nyf	Giryama		d̠ʒ		[d̠ʒ]		
-nyf	Giryama		d̠ʒ		[n̠d̠ʒ]		
-nyf	Giryama		n̠d̠ʒ				
-nyf	Giryama		k		[k]		
-nyf	Giryama		k		[kʰ]		
-nyf	Giryama		ɡ		[ɡ]		
-nyf	Giryama		ɡ		[ŋɡ]		
-nyf	Giryama		ŋɡ				
-nyf	Giryama		kp		[kp]		
-nyf	Giryama		kp		[kpʰ]		
-nyf	Giryama		ɡb		[ɡb]		
-nyf	Giryama		ɡb		[ŋmɡb]		
-nyf	Giryama		ŋmɡb				
-nyf	Giryama		ʔ				
-nyf	Giryama		f				
-nyf	Giryama		s				
-nyf	Giryama		ʃ				
-nyf	Giryama		h				
-nyf	Giryama		β	possibly [ʋ]			
-nyf	Giryama		v				
-nyf	Giryama		ð				
-nyf	Giryama		z				
-nyf	Giryama		ɦ				
-nyf	Giryama		m				
-nyf	Giryama		n				
-nyf	Giryama		ɲ				
-nyf	Giryama		ŋ				
-nyf	Giryama		ŋm				
-nyf	Giryama		l				
-nyf	Giryama		r				
-nyf	Giryama		j				
-nyf	Giryama		w				
-nyf	Giryama		˦				
-nyf	Giryama		˨	underlyinɡly toneless, phonetically L			
-							
+nyf	Giryama		e		[e]
+nyf	Giryama		a		[a]
+nyf	Giryama		o		[o]
+nyf	Giryama		u		[u]
+nyf	Giryama		i		[ĩ]
+nyf	Giryama		e		[ẽ]
+nyf	Giryama		a		[ã]
+nyf	Giryama		o		[õ]
+nyf	Giryama		u		[ũ]
+nyf	Giryama		p		[p]
+nyf	Giryama		p		[pʰ]
+nyf	Giryama		b		[b]
+nyf	Giryama		b		[mb]
+nyf	Giryama		mb
+nyf	Giryama		t̪		[t̪]
+nyf	Giryama		t̪		[t̪ʰ]
+nyf	Giryama		d̪		[d̪]
+nyf	Giryama		d̪		[n̪d̪]
+nyf	Giryama		n̪d̪
+nyf	Giryama		t		[t]
+nyf	Giryama		t		[tʰ]
+nyf	Giryama		d		[d]
+nyf	Giryama		d		[nd]
+nyf	Giryama		nd
+nyf	Giryama		ts		[ts]
+nyf	Giryama		ts		[tsʰ]
+nyf	Giryama		dz		[dz]
+nyf	Giryama		dz		[ndz]
+nyf	Giryama		ndz
+nyf	Giryama		t̠ʃ		[t̠ʃ]
+nyf	Giryama		t̠ʃ		[t̠ʃʰ]
+nyf	Giryama		d̠ʒ		[d̠ʒ]
+nyf	Giryama		d̠ʒ		[n̠d̠ʒ]
+nyf	Giryama		n̠d̠ʒ
+nyf	Giryama		k		[k]
+nyf	Giryama		k		[kʰ]
+nyf	Giryama		ɡ		[ɡ]
+nyf	Giryama		ɡ		[ŋɡ]
+nyf	Giryama		ŋɡ
+nyf	Giryama		kp		[kp]
+nyf	Giryama		kp		[kpʰ]
+nyf	Giryama		ɡb		[ɡb]
+nyf	Giryama		ɡb		[ŋmɡb]
+nyf	Giryama		ŋmɡb
+nyf	Giryama		ʔ
+nyf	Giryama		f
+nyf	Giryama		s
+nyf	Giryama		ʃ
+nyf	Giryama		h
+nyf	Giryama		β	possibly [ʋ]
+nyf	Giryama		v
+nyf	Giryama		ð
+nyf	Giryama		z
+nyf	Giryama		ɦ
+nyf	Giryama		m
+nyf	Giryama		n
+nyf	Giryama		ɲ
+nyf	Giryama		ŋ
+nyf	Giryama		ŋm
+nyf	Giryama		l
+nyf	Giryama		r
+nyf	Giryama		j
+nyf	Giryama		w
+nyf	Giryama		˦
+nyf	Giryama		˨	underlyinɡly toneless, phonetically L
+
 nyf	Jiβana		i		[i]		mijikenda.pdf
-nyf	Jiβana		e		[e]		
-nyf	Jiβana		a		[a]		
-nyf	Jiβana		o		[o]		
-nyf	Jiβana		u		[u]		
-nyf	Jiβana		i		[ĩ]		
-nyf	Jiβana		e		[ẽ]		
-nyf	Jiβana		a		[ã]		
-nyf	Jiβana		o		[õ]		
-nyf	Jiβana		u		[ũ]		
-nyf	Jiβana		p		[p]		
-nyf	Jiβana		p		[pʰ]		
-nyf	Jiβana		b		[b]		
-nyf	Jiβana		b		[mb]		
-nyf	Jiβana		mb				
-nyf	Jiβana		t̪		[t̪]		
-nyf	Jiβana		t̪		[t̪ʰ]		
-nyf	Jiβana		d̪		[d̪]		
-nyf	Jiβana		d̪		[n̪d̪]		
-nyf	Jiβana		n̪d̪				
-nyf	Jiβana		t		[t]		
-nyf	Jiβana		t		[tʰ]		
-nyf	Jiβana		d		[d]		
-nyf	Jiβana		d		[nd]		
-nyf	Jiβana		nd				
-nyf	Jiβana		ts		[ts]		
-nyf	Jiβana		ts		[tsʰ]		
-nyf	Jiβana		dz		[dz]		
-nyf	Jiβana		dz		[ndz]		
-nyf	Jiβana		ndz				
-nyf	Jiβana		t̠ʃ		[t̠ʃ]		
-nyf	Jiβana		t̠ʃ		[t̠ʃʰ]		
-nyf	Jiβana		d̠ʒ		[d̠ʒ]		
-nyf	Jiβana		d̠ʒ		[n̠d̠ʒ]		
-nyf	Jiβana		n̠d̠ʒ				
-nyf	Jiβana		k		[k]		
-nyf	Jiβana		k		[kʰ]		
-nyf	Jiβana		ɡ		[ɡ]		
-nyf	Jiβana		ɡ		[ŋɡ]		
-nyf	Jiβana		ŋɡ				
-nyf	Jiβana		kp		[kp]		
-nyf	Jiβana		kp		[kpʰ]		
-nyf	Jiβana		ɡb		[ɡb]		
-nyf	Jiβana		ɡb		[ŋmɡb]		
-nyf	Jiβana		ŋmɡb				
-nyf	Jiβana		ʔ				
-nyf	Jiβana		f				
-nyf	Jiβana		s				
-nyf	Jiβana		ʃ				
-nyf	Jiβana		h				
-nyf	Jiβana		β	possibly [ʋ]			
-nyf	Jiβana		v				
-nyf	Jiβana		ð				
-nyf	Jiβana		z				
-nyf	Jiβana		ɦ				
-nyf	Jiβana		m				
-nyf	Jiβana		n				
-nyf	Jiβana		ɲ				
-nyf	Jiβana		ŋ				
-nyf	Jiβana		ŋm				
-nyf	Jiβana		l				
-nyf	Jiβana		r				
-nyf	Jiβana		j				
-nyf	Jiβana		w				
-nyf	Jiβana		˦				
-nyf	Jiβana		˨	underlyinɡly toneless, phonetically L			
-							
+nyf	Jiβana		e		[e]
+nyf	Jiβana		a		[a]
+nyf	Jiβana		o		[o]
+nyf	Jiβana		u		[u]
+nyf	Jiβana		i		[ĩ]
+nyf	Jiβana		e		[ẽ]
+nyf	Jiβana		a		[ã]
+nyf	Jiβana		o		[õ]
+nyf	Jiβana		u		[ũ]
+nyf	Jiβana		p		[p]
+nyf	Jiβana		p		[pʰ]
+nyf	Jiβana		b		[b]
+nyf	Jiβana		b		[mb]
+nyf	Jiβana		mb
+nyf	Jiβana		t̪		[t̪]
+nyf	Jiβana		t̪		[t̪ʰ]
+nyf	Jiβana		d̪		[d̪]
+nyf	Jiβana		d̪		[n̪d̪]
+nyf	Jiβana		n̪d̪
+nyf	Jiβana		t		[t]
+nyf	Jiβana		t		[tʰ]
+nyf	Jiβana		d		[d]
+nyf	Jiβana		d		[nd]
+nyf	Jiβana		nd
+nyf	Jiβana		ts		[ts]
+nyf	Jiβana		ts		[tsʰ]
+nyf	Jiβana		dz		[dz]
+nyf	Jiβana		dz		[ndz]
+nyf	Jiβana		ndz
+nyf	Jiβana		t̠ʃ		[t̠ʃ]
+nyf	Jiβana		t̠ʃ		[t̠ʃʰ]
+nyf	Jiβana		d̠ʒ		[d̠ʒ]
+nyf	Jiβana		d̠ʒ		[n̠d̠ʒ]
+nyf	Jiβana		n̠d̠ʒ
+nyf	Jiβana		k		[k]
+nyf	Jiβana		k		[kʰ]
+nyf	Jiβana		ɡ		[ɡ]
+nyf	Jiβana		ɡ		[ŋɡ]
+nyf	Jiβana		ŋɡ
+nyf	Jiβana		kp		[kp]
+nyf	Jiβana		kp		[kpʰ]
+nyf	Jiβana		ɡb		[ɡb]
+nyf	Jiβana		ɡb		[ŋmɡb]
+nyf	Jiβana		ŋmɡb
+nyf	Jiβana		ʔ
+nyf	Jiβana		f
+nyf	Jiβana		s
+nyf	Jiβana		ʃ
+nyf	Jiβana		h
+nyf	Jiβana		β	possibly [ʋ]
+nyf	Jiβana		v
+nyf	Jiβana		ð
+nyf	Jiβana		z
+nyf	Jiβana		ɦ
+nyf	Jiβana		m
+nyf	Jiβana		n
+nyf	Jiβana		ɲ
+nyf	Jiβana		ŋ
+nyf	Jiβana		ŋm
+nyf	Jiβana		l
+nyf	Jiβana		r
+nyf	Jiβana		j
+nyf	Jiβana		w
+nyf	Jiβana		˦
+nyf	Jiβana		˨	underlyinɡly toneless, phonetically L
+
 nyf	Kambe		i		[i]		mijikenda.pdf
-nyf	Kambe		e		[e]		
-nyf	Kambe		a		[a]		
-nyf	Kambe		o		[o]		
-nyf	Kambe		u		[u]		
-nyf	Kambe		i		[ĩ]		
-nyf	Kambe		e		[ẽ]		
-nyf	Kambe		a		[ã]		
-nyf	Kambe		o		[õ]		
-nyf	Kambe		u		[ũ]		
-nyf	Kambe		p		[p]		
-nyf	Kambe		p		[pʰ]		
-nyf	Kambe		b		[b]		
-nyf	Kambe		b		[mb]		
-nyf	Kambe		mb				
-nyf	Kambe		t̪		[t̪]		
-nyf	Kambe		t̪		[t̪ʰ]		
-nyf	Kambe		d̪		[d̪]		
-nyf	Kambe		d̪		[n̪d̪]		
-nyf	Kambe		n̪d̪				
-nyf	Kambe		t		[t]		
-nyf	Kambe		t		[tʰ]		
-nyf	Kambe		d		[d]		
-nyf	Kambe		d		[nd]		
-nyf	Kambe		nd				
-nyf	Kambe		ts		[ts]		
-nyf	Kambe		ts		[tsʰ]		
-nyf	Kambe		dz		[dz]		
-nyf	Kambe		dz		[ndz]		
-nyf	Kambe		ndz				
-nyf	Kambe		t̠ʃ		[t̠ʃ]		
-nyf	Kambe		t̠ʃ		[t̠ʃʰ]		
-nyf	Kambe		d̠ʒ		[d̠ʒ]		
-nyf	Kambe		d̠ʒ		[n̠d̠ʒ]		
-nyf	Kambe		n̠d̠ʒ				
-nyf	Kambe		k		[k]		
-nyf	Kambe		k		[kʰ]		
-nyf	Kambe		ɡ		[ɡ]		
-nyf	Kambe		ɡ		[ŋɡ]		
-nyf	Kambe		ŋɡ				
-nyf	Kambe		kp		[kp]		
-nyf	Kambe		kp		[kpʰ]		
-nyf	Kambe		ɡb		[ɡb]		
-nyf	Kambe		ɡb		[ŋmɡb]		
-nyf	Kambe		ŋmɡb				
-nyf	Kambe		ʔ				
-nyf	Kambe		f				
-nyf	Kambe		s				
-nyf	Kambe		ʃ				
-nyf	Kambe		h				
-nyf	Kambe		β	possibly [ʋ]			
-nyf	Kambe		v				
-nyf	Kambe		ð				
-nyf	Kambe		z				
-nyf	Kambe		ɦ				
-nyf	Kambe		m				
-nyf	Kambe		n				
-nyf	Kambe		ɲ				
-nyf	Kambe		ŋ				
-nyf	Kambe		ŋm				
-nyf	Kambe		l				
-nyf	Kambe		r				
-nyf	Kambe		j				
-nyf	Kambe		w				
-nyf	Kambe		˦				
-nyf	Kambe		˨	underlyinɡly toneless, phonetically L			
-							
+nyf	Kambe		e		[e]
+nyf	Kambe		a		[a]
+nyf	Kambe		o		[o]
+nyf	Kambe		u		[u]
+nyf	Kambe		i		[ĩ]
+nyf	Kambe		e		[ẽ]
+nyf	Kambe		a		[ã]
+nyf	Kambe		o		[õ]
+nyf	Kambe		u		[ũ]
+nyf	Kambe		p		[p]
+nyf	Kambe		p		[pʰ]
+nyf	Kambe		b		[b]
+nyf	Kambe		b		[mb]
+nyf	Kambe		mb
+nyf	Kambe		t̪		[t̪]
+nyf	Kambe		t̪		[t̪ʰ]
+nyf	Kambe		d̪		[d̪]
+nyf	Kambe		d̪		[n̪d̪]
+nyf	Kambe		n̪d̪
+nyf	Kambe		t		[t]
+nyf	Kambe		t		[tʰ]
+nyf	Kambe		d		[d]
+nyf	Kambe		d		[nd]
+nyf	Kambe		nd
+nyf	Kambe		ts		[ts]
+nyf	Kambe		ts		[tsʰ]
+nyf	Kambe		dz		[dz]
+nyf	Kambe		dz		[ndz]
+nyf	Kambe		ndz
+nyf	Kambe		t̠ʃ		[t̠ʃ]
+nyf	Kambe		t̠ʃ		[t̠ʃʰ]
+nyf	Kambe		d̠ʒ		[d̠ʒ]
+nyf	Kambe		d̠ʒ		[n̠d̠ʒ]
+nyf	Kambe		n̠d̠ʒ
+nyf	Kambe		k		[k]
+nyf	Kambe		k		[kʰ]
+nyf	Kambe		ɡ		[ɡ]
+nyf	Kambe		ɡ		[ŋɡ]
+nyf	Kambe		ŋɡ
+nyf	Kambe		kp		[kp]
+nyf	Kambe		kp		[kpʰ]
+nyf	Kambe		ɡb		[ɡb]
+nyf	Kambe		ɡb		[ŋmɡb]
+nyf	Kambe		ŋmɡb
+nyf	Kambe		ʔ
+nyf	Kambe		f
+nyf	Kambe		s
+nyf	Kambe		ʃ
+nyf	Kambe		h
+nyf	Kambe		β	possibly [ʋ]
+nyf	Kambe		v
+nyf	Kambe		ð
+nyf	Kambe		z
+nyf	Kambe		ɦ
+nyf	Kambe		m
+nyf	Kambe		n
+nyf	Kambe		ɲ
+nyf	Kambe		ŋ
+nyf	Kambe		ŋm
+nyf	Kambe		l
+nyf	Kambe		r
+nyf	Kambe		j
+nyf	Kambe		w
+nyf	Kambe		˦
+nyf	Kambe		˨	underlyinɡly toneless, phonetically L
+
 nyf	Kauma		i		[i]		mijikenda.pdf
-nyf	Kauma		e		[e]		
-nyf	Kauma		a		[a]		
-nyf	Kauma		o		[o]		
-nyf	Kauma		u		[u]		
-nyf	Kauma		i		[ĩ]		
-nyf	Kauma		e		[ẽ]		
-nyf	Kauma		a		[ã]		
-nyf	Kauma		o		[õ]		
-nyf	Kauma		u		[ũ]		
-nyf	Kauma		p		[p]		
-nyf	Kauma		p		[pʰ]		
-nyf	Kauma		b		[b]		
-nyf	Kauma		b		[mb]		
-nyf	Kauma		mb				
-nyf	Kauma		t̪		[t̪]		
-nyf	Kauma		t̪		[t̪ʰ]		
-nyf	Kauma		d̪		[d̪]		
-nyf	Kauma		d̪		[n̪d̪]		
-nyf	Kauma		n̪d̪				
-nyf	Kauma		t		[t]		
-nyf	Kauma		t		[tʰ]		
-nyf	Kauma		d		[d]		
-nyf	Kauma		d		[nd]		
-nyf	Kauma		nd				
-nyf	Kauma		ts		[ts]		
-nyf	Kauma		ts		[tsʰ]		
-nyf	Kauma		dz		[dz]		
-nyf	Kauma		dz		[ndz]		
-nyf	Kauma		ndz				
-nyf	Kauma		t̠ʃ		[t̠ʃ]		
-nyf	Kauma		t̠ʃ		[t̠ʃʰ]		
-nyf	Kauma		d̠ʒ		[d̠ʒ]		
-nyf	Kauma		d̠ʒ		[n̠d̠ʒ]		
-nyf	Kauma		n̠d̠ʒ				
-nyf	Kauma		k		[k]		
-nyf	Kauma		k		[kʰ]		
-nyf	Kauma		ɡ		[ɡ]		
-nyf	Kauma		ɡ		[ŋɡ]		
-nyf	Kauma		ŋɡ				
-nyf	Kauma		kp		[kp]		
-nyf	Kauma		kp		[kpʰ]		
-nyf	Kauma		ɡb		[ɡb]		
-nyf	Kauma		ɡb		[ŋmɡb]		
-nyf	Kauma		ŋmɡb				
-nyf	Kauma		ʔ				
-nyf	Kauma		f				
-nyf	Kauma		s				
-nyf	Kauma		ʃ				
-nyf	Kauma		h				
-nyf	Kauma		β	possibly [ʋ]			
-nyf	Kauma		v				
-nyf	Kauma		ð				
-nyf	Kauma		z				
-nyf	Kauma		ɦ				
-nyf	Kauma		m				
-nyf	Kauma		n				
-nyf	Kauma		ɲ				
-nyf	Kauma		ŋ				
-nyf	Kauma		ŋm				
-nyf	Kauma		l				
-nyf	Kauma		r				
-nyf	Kauma		j				
-nyf	Kauma		w				
-nyf	Kauma		˦				
-nyf	Kauma		˨	underlyinɡly toneless, phonetically L			
-							
+nyf	Kauma		e		[e]
+nyf	Kauma		a		[a]
+nyf	Kauma		o		[o]
+nyf	Kauma		u		[u]
+nyf	Kauma		i		[ĩ]
+nyf	Kauma		e		[ẽ]
+nyf	Kauma		a		[ã]
+nyf	Kauma		o		[õ]
+nyf	Kauma		u		[ũ]
+nyf	Kauma		p		[p]
+nyf	Kauma		p		[pʰ]
+nyf	Kauma		b		[b]
+nyf	Kauma		b		[mb]
+nyf	Kauma		mb
+nyf	Kauma		t̪		[t̪]
+nyf	Kauma		t̪		[t̪ʰ]
+nyf	Kauma		d̪		[d̪]
+nyf	Kauma		d̪		[n̪d̪]
+nyf	Kauma		n̪d̪
+nyf	Kauma		t		[t]
+nyf	Kauma		t		[tʰ]
+nyf	Kauma		d		[d]
+nyf	Kauma		d		[nd]
+nyf	Kauma		nd
+nyf	Kauma		ts		[ts]
+nyf	Kauma		ts		[tsʰ]
+nyf	Kauma		dz		[dz]
+nyf	Kauma		dz		[ndz]
+nyf	Kauma		ndz
+nyf	Kauma		t̠ʃ		[t̠ʃ]
+nyf	Kauma		t̠ʃ		[t̠ʃʰ]
+nyf	Kauma		d̠ʒ		[d̠ʒ]
+nyf	Kauma		d̠ʒ		[n̠d̠ʒ]
+nyf	Kauma		n̠d̠ʒ
+nyf	Kauma		k		[k]
+nyf	Kauma		k		[kʰ]
+nyf	Kauma		ɡ		[ɡ]
+nyf	Kauma		ɡ		[ŋɡ]
+nyf	Kauma		ŋɡ
+nyf	Kauma		kp		[kp]
+nyf	Kauma		kp		[kpʰ]
+nyf	Kauma		ɡb		[ɡb]
+nyf	Kauma		ɡb		[ŋmɡb]
+nyf	Kauma		ŋmɡb
+nyf	Kauma		ʔ
+nyf	Kauma		f
+nyf	Kauma		s
+nyf	Kauma		ʃ
+nyf	Kauma		h
+nyf	Kauma		β	possibly [ʋ]
+nyf	Kauma		v
+nyf	Kauma		ð
+nyf	Kauma		z
+nyf	Kauma		ɦ
+nyf	Kauma		m
+nyf	Kauma		n
+nyf	Kauma		ɲ
+nyf	Kauma		ŋ
+nyf	Kauma		ŋm
+nyf	Kauma		l
+nyf	Kauma		r
+nyf	Kauma		j
+nyf	Kauma		w
+nyf	Kauma		˦
+nyf	Kauma		˨	underlyinɡly toneless, phonetically L
+
 nyf	Raβai		i		[i]		mijikenda.pdf
-nyf	Raβai		e		[e]		
-nyf	Raβai		a		[a]		
-nyf	Raβai		o		[o]		
-nyf	Raβai		u		[u]		
-nyf	Raβai		i		[ĩ]		
-nyf	Raβai		e		[ẽ]		
-nyf	Raβai		a		[ã]		
-nyf	Raβai		o		[õ]		
-nyf	Raβai		u		[ũ]		
-nyf	Raβai		p		[p]		
-nyf	Raβai		p		[pʰ]		
-nyf	Raβai		b		[b]		
-nyf	Raβai		b		[mb]		
-nyf	Raβai		mb				
-nyf	Raβai		t̪		[t̪]		
-nyf	Raβai		t̪		[t̪ʰ]		
-nyf	Raβai		d̪		[d̪]		
-nyf	Raβai		d̪		[n̪d̪]		
-nyf	Raβai		n̪d̪				
-nyf	Raβai		t		[t]		
-nyf	Raβai		t		[tʰ]		
-nyf	Raβai		d		[d]		
-nyf	Raβai		d		[nd]		
-nyf	Raβai		nd				
-nyf	Raβai		ts		[ts]		
-nyf	Raβai		ts		[tsʰ]		
-nyf	Raβai		dz		[dz]		
-nyf	Raβai		dz		[ndz]		
-nyf	Raβai		ndz				
-nyf	Raβai		t̠ʃ		[t̠ʃ]		
-nyf	Raβai		t̠ʃ		[t̠ʃʰ]		
-nyf	Raβai		d̠ʒ		[d̠ʒ]		
-nyf	Raβai		d̠ʒ		[n̠d̠ʒ]		
-nyf	Raβai		n̠d̠ʒ				
-nyf	Raβai		k		[k]		
-nyf	Raβai		k		[kʰ]		
-nyf	Raβai		ɡ		[ɡ]		
-nyf	Raβai		ɡ		[ŋɡ]		
-nyf	Raβai		ŋɡ				
-nyf	Raβai		kp		[kp]		
-nyf	Raβai		kp		[kpʰ]		
-nyf	Raβai		ɡb		[ɡb]		
-nyf	Raβai		ɡb		[ŋmɡb]		
-nyf	Raβai		ŋmɡb				
-nyf	Raβai		ʔ				
-nyf	Raβai		f				
-nyf	Raβai		s				
-nyf	Raβai		ʃ				
-nyf	Raβai		h				
-nyf	Raβai		β	possibly [ʋ]			
-nyf	Raβai		v				
-nyf	Raβai		ð				
-nyf	Raβai		z				
-nyf	Raβai		ɦ				
-nyf	Raβai		m				
-nyf	Raβai		n				
-nyf	Raβai		ɲ				
-nyf	Raβai		ŋ				
-nyf	Raβai		ŋm				
-nyf	Raβai		l				
-nyf	Raβai		r				
-nyf	Raβai		j				
-nyf	Raβai		w				
-nyf	Raβai		˦				
-nyf	Raβai		˨	underlyinɡly toneless, phonetically L			
-							
+nyf	Raβai		e		[e]
+nyf	Raβai		a		[a]
+nyf	Raβai		o		[o]
+nyf	Raβai		u		[u]
+nyf	Raβai		i		[ĩ]
+nyf	Raβai		e		[ẽ]
+nyf	Raβai		a		[ã]
+nyf	Raβai		o		[õ]
+nyf	Raβai		u		[ũ]
+nyf	Raβai		p		[p]
+nyf	Raβai		p		[pʰ]
+nyf	Raβai		b		[b]
+nyf	Raβai		b		[mb]
+nyf	Raβai		mb
+nyf	Raβai		t̪		[t̪]
+nyf	Raβai		t̪		[t̪ʰ]
+nyf	Raβai		d̪		[d̪]
+nyf	Raβai		d̪		[n̪d̪]
+nyf	Raβai		n̪d̪
+nyf	Raβai		t		[t]
+nyf	Raβai		t		[tʰ]
+nyf	Raβai		d		[d]
+nyf	Raβai		d		[nd]
+nyf	Raβai		nd
+nyf	Raβai		ts		[ts]
+nyf	Raβai		ts		[tsʰ]
+nyf	Raβai		dz		[dz]
+nyf	Raβai		dz		[ndz]
+nyf	Raβai		ndz
+nyf	Raβai		t̠ʃ		[t̠ʃ]
+nyf	Raβai		t̠ʃ		[t̠ʃʰ]
+nyf	Raβai		d̠ʒ		[d̠ʒ]
+nyf	Raβai		d̠ʒ		[n̠d̠ʒ]
+nyf	Raβai		n̠d̠ʒ
+nyf	Raβai		k		[k]
+nyf	Raβai		k		[kʰ]
+nyf	Raβai		ɡ		[ɡ]
+nyf	Raβai		ɡ		[ŋɡ]
+nyf	Raβai		ŋɡ
+nyf	Raβai		kp		[kp]
+nyf	Raβai		kp		[kpʰ]
+nyf	Raβai		ɡb		[ɡb]
+nyf	Raβai		ɡb		[ŋmɡb]
+nyf	Raβai		ŋmɡb
+nyf	Raβai		ʔ
+nyf	Raβai		f
+nyf	Raβai		s
+nyf	Raβai		ʃ
+nyf	Raβai		h
+nyf	Raβai		β	possibly [ʋ]
+nyf	Raβai		v
+nyf	Raβai		ð
+nyf	Raβai		z
+nyf	Raβai		ɦ
+nyf	Raβai		m
+nyf	Raβai		n
+nyf	Raβai		ɲ
+nyf	Raβai		ŋ
+nyf	Raβai		ŋm
+nyf	Raβai		l
+nyf	Raβai		r
+nyf	Raβai		j
+nyf	Raβai		w
+nyf	Raβai		˦
+nyf	Raβai		˨	underlyinɡly toneless, phonetically L
+
 nyf	Reβe		i		[i]		mijikenda.pdf
-nyf	Reβe		e		[e]		
-nyf	Reβe		a		[a]		
-nyf	Reβe		o		[o]		
-nyf	Reβe		u		[u]		
-nyf	Reβe		i		[ĩ]		
-nyf	Reβe		e		[ẽ]		
-nyf	Reβe		a		[ã]		
-nyf	Reβe		o		[õ]		
-nyf	Reβe		u		[ũ]		
-nyf	Reβe		p		[p]		
-nyf	Reβe		p		[pʰ]		
-nyf	Reβe		b		[b]		
-nyf	Reβe		b		[mb]		
-nyf	Reβe		mb				
-nyf	Reβe		t̪		[t̪]		
-nyf	Reβe		t̪		[t̪ʰ]		
-nyf	Reβe		d̪		[d̪]		
-nyf	Reβe		d̪		[n̪d̪]		
-nyf	Reβe		n̪d̪				
-nyf	Reβe		t		[t]		
-nyf	Reβe		t		[tʰ]		
-nyf	Reβe		d		[d]		
-nyf	Reβe		d		[nd]		
-nyf	Reβe		nd				
-nyf	Reβe		ts		[ts]		
-nyf	Reβe		ts		[tsʰ]		
-nyf	Reβe		dz		[dz]		
-nyf	Reβe		dz		[ndz]		
-nyf	Reβe		ndz				
-nyf	Reβe		t̠ʃ		[t̠ʃ]		
-nyf	Reβe		t̠ʃ		[t̠ʃʰ]		
-nyf	Reβe		d̠ʒ		[d̠ʒ]		
-nyf	Reβe		d̠ʒ		[n̠d̠ʒ]		
-nyf	Reβe		n̠d̠ʒ				
-nyf	Reβe		k		[k]		
-nyf	Reβe		k		[kʰ]		
-nyf	Reβe		ɡ		[ɡ]		
-nyf	Reβe		ɡ		[ŋɡ]		
-nyf	Reβe		ŋɡ				
-nyf	Reβe		kp		[kp]		
-nyf	Reβe		kp		[kpʰ]		
-nyf	Reβe		ɡb		[ɡb]		
-nyf	Reβe		ɡb		[ŋmɡb]		
-nyf	Reβe		ŋmɡb				
-nyf	Reβe		ʔ				
-nyf	Reβe		f				
-nyf	Reβe		s				
-nyf	Reβe		ʃ				
-nyf	Reβe		h				
-nyf	Reβe		β	possibly [ʋ]			
-nyf	Reβe		v				
-nyf	Reβe		ð				
-nyf	Reβe		z				
-nyf	Reβe		ɦ				
-nyf	Reβe		m				
-nyf	Reβe		n				
-nyf	Reβe		ɲ				
-nyf	Reβe		ŋ				
-nyf	Reβe		ŋm				
-nyf	Reβe		l				
-nyf	Reβe		r				
-nyf	Reβe		j				
-nyf	Reβe		w				
-nyf	Reβe		˦				
-nyf	Reβe		˨	underlyinɡly toneless, phonetically L			
-							
+nyf	Reβe		e		[e]
+nyf	Reβe		a		[a]
+nyf	Reβe		o		[o]
+nyf	Reβe		u		[u]
+nyf	Reβe		i		[ĩ]
+nyf	Reβe		e		[ẽ]
+nyf	Reβe		a		[ã]
+nyf	Reβe		o		[õ]
+nyf	Reβe		u		[ũ]
+nyf	Reβe		p		[p]
+nyf	Reβe		p		[pʰ]
+nyf	Reβe		b		[b]
+nyf	Reβe		b		[mb]
+nyf	Reβe		mb
+nyf	Reβe		t̪		[t̪]
+nyf	Reβe		t̪		[t̪ʰ]
+nyf	Reβe		d̪		[d̪]
+nyf	Reβe		d̪		[n̪d̪]
+nyf	Reβe		n̪d̪
+nyf	Reβe		t		[t]
+nyf	Reβe		t		[tʰ]
+nyf	Reβe		d		[d]
+nyf	Reβe		d		[nd]
+nyf	Reβe		nd
+nyf	Reβe		ts		[ts]
+nyf	Reβe		ts		[tsʰ]
+nyf	Reβe		dz		[dz]
+nyf	Reβe		dz		[ndz]
+nyf	Reβe		ndz
+nyf	Reβe		t̠ʃ		[t̠ʃ]
+nyf	Reβe		t̠ʃ		[t̠ʃʰ]
+nyf	Reβe		d̠ʒ		[d̠ʒ]
+nyf	Reβe		d̠ʒ		[n̠d̠ʒ]
+nyf	Reβe		n̠d̠ʒ
+nyf	Reβe		k		[k]
+nyf	Reβe		k		[kʰ]
+nyf	Reβe		ɡ		[ɡ]
+nyf	Reβe		ɡ		[ŋɡ]
+nyf	Reβe		ŋɡ
+nyf	Reβe		kp		[kp]
+nyf	Reβe		kp		[kpʰ]
+nyf	Reβe		ɡb		[ɡb]
+nyf	Reβe		ɡb		[ŋmɡb]
+nyf	Reβe		ŋmɡb
+nyf	Reβe		ʔ
+nyf	Reβe		f
+nyf	Reβe		s
+nyf	Reβe		ʃ
+nyf	Reβe		h
+nyf	Reβe		β	possibly [ʋ]
+nyf	Reβe		v
+nyf	Reβe		ð
+nyf	Reβe		z
+nyf	Reβe		ɦ
+nyf	Reβe		m
+nyf	Reβe		n
+nyf	Reβe		ɲ
+nyf	Reβe		ŋ
+nyf	Reβe		ŋm
+nyf	Reβe		l
+nyf	Reβe		r
+nyf	Reβe		j
+nyf	Reβe		w
+nyf	Reβe		˦
+nyf	Reβe		˨	underlyinɡly toneless, phonetically L
+
 mlr	Vame		i				mlr.pdf
-mlr	Vame		e				
-mlr	Vame		a				
-mlr	Vame		u				
-mlr	Vame		ə				
-mlr	Vame		p				
-mlr	Vame		b				
-mlr	Vame		ɓ				
-mlr	Vame		m				
-mlr	Vame		mb				
-mlr	Vame		t				
-mlr	Vame		d				
-mlr	Vame		ɗ				
-mlr	Vame		ts				
-mlr	Vame		dz				
-mlr	Vame		n				
-mlr	Vame		nd				
-mlr	Vame		nz				
-mlr	Vame		s				
-mlr	Vame		z				
-mlr	Vame		ɬ				
-mlr	Vame		ɮ				
-mlr	Vame		r				
-mlr	Vame		l				
-mlr	Vame		j				
-mlr	Vame		t̠ʃ				
-mlr	Vame		d̠ʒ				
-mlr	Vame		n̠d̠ʒ				
-mlr	Vame		ʃ				
-mlr	Vame		ʒ				
-mlr	Vame		k				
-mlr	Vame		ɡ				
-mlr	Vame		ŋ				
-mlr	Vame		ŋɡ				
-mlr	Vame		ɣ				
-mlr	Vame		kʷ				
-mlr	Vame		ɡʷ				
-mlr	Vame		ŋʷ				
-mlr	Vame		ŋɡʷ				
-mlr	Vame		ɣʷ				
-mlr	Vame		w				
-mlr	Vame		h				
-mlr	Vame		hʷ				
-mlr	Vame		˦	tone appears only to be contrastive in verbs			
-mlr	Vame		˨	tone appears only to be contrastive in verbs			
-mlr	Vame		˧	tone appears only to be contrastive in verbs			
-							
+mlr	Vame		e
+mlr	Vame		a
+mlr	Vame		u
+mlr	Vame		ə
+mlr	Vame		p
+mlr	Vame		b
+mlr	Vame		ɓ
+mlr	Vame		m
+mlr	Vame		mb
+mlr	Vame		t
+mlr	Vame		d
+mlr	Vame		ɗ
+mlr	Vame		ts
+mlr	Vame		dz
+mlr	Vame		n
+mlr	Vame		nd
+mlr	Vame		nz
+mlr	Vame		s
+mlr	Vame		z
+mlr	Vame		ɬ
+mlr	Vame		ɮ
+mlr	Vame		r
+mlr	Vame		l
+mlr	Vame		j
+mlr	Vame		t̠ʃ
+mlr	Vame		d̠ʒ
+mlr	Vame		n̠d̠ʒ
+mlr	Vame		ʃ
+mlr	Vame		ʒ
+mlr	Vame		k
+mlr	Vame		ɡ
+mlr	Vame		ŋ
+mlr	Vame		ŋɡ
+mlr	Vame		ɣ
+mlr	Vame		kʷ
+mlr	Vame		ɡʷ
+mlr	Vame		ŋʷ
+mlr	Vame		ŋɡʷ
+mlr	Vame		ɣʷ
+mlr	Vame		w
+mlr	Vame		h
+mlr	Vame		hʷ
+mlr	Vame		˦	tone appears only to be contrastive in verbs
+mlr	Vame		˨	tone appears only to be contrastive in verbs
+mlr	Vame		˧	tone appears only to be contrastive in verbs
+
 mmu	Numala		p		[pʰ]		mmu.pdf
-mmu	Numala		t		[tʰ]		
-mmu	Numala		k		[kʰ]		
-mmu	Numala		b		[b]		
-mmu	Numala		b		[p]	final position	
-mmu	Numala		d		[d]		
-mmu	Numala		d		[t]	final position	
-mmu	Numala		ɡ		[ɡ]		
-mmu	Numala		ɡ		[k]	final position	
-mmu	Numala		f		[f]		
-mmu	Numala		s		[s]		
-mmu	Numala		s		[t̠ʃ]	post nasal	
-mmu	Numala		t̠ʃ				
-mmu	Numala		m		[m]		
-mmu	Numala		n		[n]		
-mmu	Numala		ɲ				
-mmu	Numala		ŋ				
-mmu	Numala		l		[l]		
-mmu	Numala		l		[d]	post nasal	
-mmu	Numala		w				
-mmu	Numala		j				
-mmu	Numala		mpʰ	initial position only			
-mmu	Numala		<ntʰ>	borrowinɡs only			
-mmu	Numala		ŋkʰ				
-mmu	Numala		mb				
-mmu	Numala		nd				
-mmu	Numala		<ŋɡ>	borrowinɡs only			
-mmu	Numala		ɱf				
-mmu	Numala		t		[tʲ]		
-mmu	Numala		k		[kʲ]		
-mmu	Numala		b		[bʲ]		
-mmu	Numala		d		[dʲ]		
-mmu	Numala		ɡ		[ɡʲ]		
-mmu	Numala		l		[lʲ]		
-mmu	Numala		s		[sʲ]		
-mmu	Numala		p		[pʷ]		
-mmu	Numala		k		[kʷ]		
-mmu	Numala		b		[bʷ]		
-mmu	Numala		d		[dʷ]		
-mmu	Numala		ɡ		[ɡʷ]		
-mmu	Numala		f		[fʷ]		
-mmu	Numala		s		[sʷ]		
-mmu	Numala		s		[t̠ʃʷ]		
-mmu	Numala		m		[mʷ]		
-mmu	Numala		n		[nʷ]		
-mmu	Numala		i				
-mmu	Numala		ɪ				
-mmu	Numala		u				
-mmu	Numala		ʊ				
-mmu	Numala		e				
-mmu	Numala		o				
-mmu	Numala		ɛ				
-mmu	Numala		ɔ				
-mmu	Numala		a				
-mmu	Numala		˦				
-mmu	Numala		˨				
-							
+mmu	Numala		t		[tʰ]
+mmu	Numala		k		[kʰ]
+mmu	Numala		b		[b]
+mmu	Numala		b		[p]	final position
+mmu	Numala		d		[d]
+mmu	Numala		d		[t]	final position
+mmu	Numala		ɡ		[ɡ]
+mmu	Numala		ɡ		[k]	final position
+mmu	Numala		f		[f]
+mmu	Numala		s		[s]
+mmu	Numala		s		[t̠ʃ]	post nasal
+mmu	Numala		t̠ʃ
+mmu	Numala		m		[m]
+mmu	Numala		n		[n]
+mmu	Numala		ɲ
+mmu	Numala		ŋ
+mmu	Numala		l		[l]
+mmu	Numala		l		[d]	post nasal
+mmu	Numala		w
+mmu	Numala		j
+mmu	Numala		mpʰ	initial position only
+mmu	Numala		<ntʰ>	borrowinɡs only
+mmu	Numala		ŋkʰ
+mmu	Numala		mb
+mmu	Numala		nd
+mmu	Numala		<ŋɡ>	borrowinɡs only
+mmu	Numala		ɱf
+mmu	Numala		t		[tʲ]
+mmu	Numala		k		[kʲ]
+mmu	Numala		b		[bʲ]
+mmu	Numala		d		[dʲ]
+mmu	Numala		ɡ		[ɡʲ]
+mmu	Numala		l		[lʲ]
+mmu	Numala		s		[sʲ]
+mmu	Numala		p		[pʷ]
+mmu	Numala		k		[kʷ]
+mmu	Numala		b		[bʷ]
+mmu	Numala		d		[dʷ]
+mmu	Numala		ɡ		[ɡʷ]
+mmu	Numala		f		[fʷ]
+mmu	Numala		s		[sʷ]
+mmu	Numala		s		[t̠ʃʷ]
+mmu	Numala		m		[mʷ]
+mmu	Numala		n		[nʷ]
+mmu	Numala		i
+mmu	Numala		ɪ
+mmu	Numala		u
+mmu	Numala		ʊ
+mmu	Numala		e
+mmu	Numala		o
+mmu	Numala		ɛ
+mmu	Numala		ɔ
+mmu	Numala		a
+mmu	Numala		˦
+mmu	Numala		˨
+
 mpi	Kotoko	Makary	b				mpi.pdf
-mpi	Kotoko	Makary	ɓ				
-mpi	Kotoko	Makary	t̠ʃ				
-mpi	Kotoko	Makary	t̠ʃʼ				
-mpi	Kotoko	Makary	d				
-mpi	Kotoko	Makary	ɗ				
-mpi	Kotoko	Makary	f				
-mpi	Kotoko	Makary	ɡ				
-mpi	Kotoko	Makary	h				
-mpi	Kotoko	Makary	d̠ʒ				
-mpi	Kotoko	Makary	k				
-mpi	Kotoko	Makary	kʼ				
-mpi	Kotoko	Makary	l				
-mpi	Kotoko	Makary	m				
-mpi	Kotoko	Makary	n		[n]		
-mpi	Kotoko	Makary	n		[ŋ]		
-mpi	Kotoko	Makary	p				
-mpi	Kotoko	Makary	r				
-mpi	Kotoko	Makary	s				
-mpi	Kotoko	Makary	tsʼ				
-mpi	Kotoko	Makary	ʃ				
-mpi	Kotoko	Makary	t				
-mpi	Kotoko	Makary	w				
-mpi	Kotoko	Makary	j				
-mpi	Kotoko	Makary	z				
-mpi	Kotoko	Makary	ɡʷ				
-mpi	Kotoko	Makary	kʷ				
-mpi	Kotoko	Makary	kʷʼ				
-mpi	Kotoko	Makary	mb				
-mpi	Kotoko	Makary	nd				
-mpi	Kotoko	Makary	ŋɡ				
-mpi	Kotoko	Makary	a				
-mpi	Kotoko	Makary	e				
-mpi	Kotoko	Makary	i				
-mpi	Kotoko	Makary	ɨ				
-mpi	Kotoko	Makary	o				
-mpi	Kotoko	Makary	u				
-mpi	Kotoko	Makary	˦˨				
-mpi	Kotoko	Makary	˦				
-mpi	Kotoko	Makary	˨				
-mpi	Kotoko	Makary	˧				
-							
+mpi	Kotoko	Makary	ɓ
+mpi	Kotoko	Makary	t̠ʃ
+mpi	Kotoko	Makary	t̠ʃʼ
+mpi	Kotoko	Makary	d
+mpi	Kotoko	Makary	ɗ
+mpi	Kotoko	Makary	f
+mpi	Kotoko	Makary	ɡ
+mpi	Kotoko	Makary	h
+mpi	Kotoko	Makary	d̠ʒ
+mpi	Kotoko	Makary	k
+mpi	Kotoko	Makary	kʼ
+mpi	Kotoko	Makary	l
+mpi	Kotoko	Makary	m
+mpi	Kotoko	Makary	n		[n]
+mpi	Kotoko	Makary	n		[ŋ]
+mpi	Kotoko	Makary	p
+mpi	Kotoko	Makary	r
+mpi	Kotoko	Makary	s
+mpi	Kotoko	Makary	tsʼ
+mpi	Kotoko	Makary	ʃ
+mpi	Kotoko	Makary	t
+mpi	Kotoko	Makary	w
+mpi	Kotoko	Makary	j
+mpi	Kotoko	Makary	z
+mpi	Kotoko	Makary	ɡʷ
+mpi	Kotoko	Makary	kʷ
+mpi	Kotoko	Makary	kʷʼ
+mpi	Kotoko	Makary	mb
+mpi	Kotoko	Makary	nd
+mpi	Kotoko	Makary	ŋɡ
+mpi	Kotoko	Makary	a
+mpi	Kotoko	Makary	e
+mpi	Kotoko	Makary	i
+mpi	Kotoko	Makary	ɨ
+mpi	Kotoko	Makary	o
+mpi	Kotoko	Makary	u
+mpi	Kotoko	Makary	˦˨
+mpi	Kotoko	Makary	˦
+mpi	Kotoko	Makary	˨
+mpi	Kotoko	Makary	˧
+
 mif	Mofu, South	Gudur	p				mif.pdf
-mif	Mofu, South	Gudur	b				
-mif	Mofu, South	Gudur	mb				
-mif	Mofu, South	Gudur	f				
-mif	Mofu, South	Gudur	v				
-mif	Mofu, South	Gudur	ⱱ				
-mif	Mofu, South	Gudur	kp				
-mif	Mofu, South	Gudur	ɡb				
-mif	Mofu, South	Gudur	ŋmɡb				
-mif	Mofu, South	Gudur	l				
-mif	Mofu, South	Gudur	r				
-mif	Mofu, South	Gudur	ɓ		[ɓ]		
-mif	Mofu, South	Gudur	ɓ		[ɓ̚]		
-mif	Mofu, South	Gudur	t		[t]		
-mif	Mofu, South	Gudur	t		[tʰ]		
-mif	Mofu, South	Gudur	d				
-mif	Mofu, South	Gudur	nd				
-mif	Mofu, South	Gudur	s				
-mif	Mofu, South	Gudur	z				
-mif	Mofu, South	Gudur	n				
-mif	Mofu, South	Gudur	ɗ		[ɗ]		
-mif	Mofu, South	Gudur	ɗ		[ɗ̚]		
-mif	Mofu, South	Gudur	t̠ʃ				
-mif	Mofu, South	Gudur	d̠ʒ				
-mif	Mofu, South	Gudur	n̠d̠ʒ				
-mif	Mofu, South	Gudur	ɬ				
-mif	Mofu, South	Gudur	ɮ				
-mif	Mofu, South	Gudur	j				
-mif	Mofu, South	Gudur	k				
-mif	Mofu, South	Gudur	ɡ				
-mif	Mofu, South	Gudur	ŋ		[ŋ]		
-mif	Mofu, South	Gudur	ŋ		[ŋɡ]		
-mif	Mofu, South	Gudur	h				
-mif	Mofu, South	Gudur	ʔ				
-mif	Mofu, South	Gudur	kʷ				
-mif	Mofu, South	Gudur	ɡʷ				
-mif	Mofu, South	Gudur	ŋɡʷ				
-mif	Mofu, South	Gudur	hʷ				
-mif	Mofu, South	Gudur	w				
-mif	Mofu, South	Gudur	ə		[ə]		
-mif	Mofu, South	Gudur	ə		[ʉ]		
-mif	Mofu, South	Gudur	ə		[ɨ]		
-mif	Mofu, South	Gudur	ə		[ʊ]		
-mif	Mofu, South	Gudur	ə		[u]		
-mif	Mofu, South	Gudur	ə		[i]		
-mif	Mofu, South	Gudur	a				
-mif	Mofu, South	Gudur	aː				
-mif	Mofu, South	Gudur	e				
-mif	Mofu, South	Gudur	eː				
-							
+mif	Mofu, South	Gudur	b
+mif	Mofu, South	Gudur	mb
+mif	Mofu, South	Gudur	f
+mif	Mofu, South	Gudur	v
+mif	Mofu, South	Gudur	ⱱ
+mif	Mofu, South	Gudur	kp
+mif	Mofu, South	Gudur	ɡb
+mif	Mofu, South	Gudur	ŋmɡb
+mif	Mofu, South	Gudur	l
+mif	Mofu, South	Gudur	r
+mif	Mofu, South	Gudur	ɓ		[ɓ]
+mif	Mofu, South	Gudur	ɓ		[ɓ̚]
+mif	Mofu, South	Gudur	t		[t]
+mif	Mofu, South	Gudur	t		[tʰ]
+mif	Mofu, South	Gudur	d
+mif	Mofu, South	Gudur	nd
+mif	Mofu, South	Gudur	s
+mif	Mofu, South	Gudur	z
+mif	Mofu, South	Gudur	n
+mif	Mofu, South	Gudur	ɗ		[ɗ]
+mif	Mofu, South	Gudur	ɗ		[ɗ̚]
+mif	Mofu, South	Gudur	t̠ʃ
+mif	Mofu, South	Gudur	d̠ʒ
+mif	Mofu, South	Gudur	n̠d̠ʒ
+mif	Mofu, South	Gudur	ɬ
+mif	Mofu, South	Gudur	ɮ
+mif	Mofu, South	Gudur	j
+mif	Mofu, South	Gudur	k
+mif	Mofu, South	Gudur	ɡ
+mif	Mofu, South	Gudur	ŋ		[ŋ]
+mif	Mofu, South	Gudur	ŋ		[ŋɡ]
+mif	Mofu, South	Gudur	h
+mif	Mofu, South	Gudur	ʔ
+mif	Mofu, South	Gudur	kʷ
+mif	Mofu, South	Gudur	ɡʷ
+mif	Mofu, South	Gudur	ŋɡʷ
+mif	Mofu, South	Gudur	hʷ
+mif	Mofu, South	Gudur	w
+mif	Mofu, South	Gudur	ə		[ə]
+mif	Mofu, South	Gudur	ə		[ʉ]
+mif	Mofu, South	Gudur	ə		[ɨ]
+mif	Mofu, South	Gudur	ə		[ʊ]
+mif	Mofu, South	Gudur	ə		[u]
+mif	Mofu, South	Gudur	ə		[i]
+mif	Mofu, South	Gudur	a
+mif	Mofu, South	Gudur	aː
+mif	Mofu, South	Gudur	e
+mif	Mofu, South	Gudur	eː
+
 mtk	Mbe		i				mtk.pdf
-mtk	Mbe		e				
-mtk	Mbe		ɛ				
-mtk	Mbe		a				
-mtk	Mbe		u				
-mtk	Mbe		o				
-mtk	Mbe		ɔ				
-mtk	Mbe		p				
-mtk	Mbe		pʷ				
-mtk	Mbe		pʲ				
-mtk	Mbe		b				
-mtk	Mbe		bʷ				
-mtk	Mbe		bʲ				
-mtk	Mbe		f				
-mtk	Mbe		fʷ				
-mtk	Mbe		m				
-mtk	Mbe		mʷ				
-mtk	Mbe		mʲ				
-mtk	Mbe		t				
-mtk	Mbe		tʷ				
-mtk	Mbe		d				
-mtk	Mbe		dʷ				
-mtk	Mbe		s				
-mtk	Mbe		sʷ				
-mtk	Mbe		ts				
-mtk	Mbe		tsʷ				
-mtk	Mbe		dz				
-mtk	Mbe		dzʷ				
-mtk	Mbe		r				
-mtk	Mbe		rʷ				
-mtk	Mbe		rʲ				
-mtk	Mbe		l				
-mtk	Mbe		lʷ				
-mtk	Mbe		lʲ				
-mtk	Mbe		ʃ				
-mtk	Mbe		ʃʷ				
-mtk	Mbe		t̠ʃ				
-mtk	Mbe		t̠ʃʷ				
-mtk	Mbe		d̠ʒ				
-mtk	Mbe		d̠ʒʷ				
-mtk	Mbe		ɲ				
-mtk	Mbe		ɲʷ				
-mtk	Mbe		j				
-mtk	Mbe		jʷ				
-mtk	Mbe		k				
-mtk	Mbe		kʷ				
-mtk	Mbe		kʲ				
-mtk	Mbe		ɡ				
-mtk	Mbe		ɡʷ				
-mtk	Mbe		ɡʲ				
-mtk	Mbe		kp				
-mtk	Mbe		ɡb				
-mtk	Mbe		w				
-mtk	Mbe		ŋ				
-mtk	Mbe		ŋʷ				
-mtk	Mbe		˦				
-mtk	Mbe		˨				
-							
+mtk	Mbe		e
+mtk	Mbe		ɛ
+mtk	Mbe		a
+mtk	Mbe		u
+mtk	Mbe		o
+mtk	Mbe		ɔ
+mtk	Mbe		p
+mtk	Mbe		pʷ
+mtk	Mbe		pʲ
+mtk	Mbe		b
+mtk	Mbe		bʷ
+mtk	Mbe		bʲ
+mtk	Mbe		f
+mtk	Mbe		fʷ
+mtk	Mbe		m
+mtk	Mbe		mʷ
+mtk	Mbe		mʲ
+mtk	Mbe		t
+mtk	Mbe		tʷ
+mtk	Mbe		d
+mtk	Mbe		dʷ
+mtk	Mbe		s
+mtk	Mbe		sʷ
+mtk	Mbe		ts
+mtk	Mbe		tsʷ
+mtk	Mbe		dz
+mtk	Mbe		dzʷ
+mtk	Mbe		r
+mtk	Mbe		rʷ
+mtk	Mbe		rʲ
+mtk	Mbe		l
+mtk	Mbe		lʷ
+mtk	Mbe		lʲ
+mtk	Mbe		ʃ
+mtk	Mbe		ʃʷ
+mtk	Mbe		t̠ʃ
+mtk	Mbe		t̠ʃʷ
+mtk	Mbe		d̠ʒ
+mtk	Mbe		d̠ʒʷ
+mtk	Mbe		ɲ
+mtk	Mbe		ɲʷ
+mtk	Mbe		j
+mtk	Mbe		jʷ
+mtk	Mbe		k
+mtk	Mbe		kʷ
+mtk	Mbe		kʲ
+mtk	Mbe		ɡ
+mtk	Mbe		ɡʷ
+mtk	Mbe		ɡʲ
+mtk	Mbe		kp
+mtk	Mbe		ɡb
+mtk	Mbe		w
+mtk	Mbe		ŋ
+mtk	Mbe		ŋʷ
+mtk	Mbe		˦
+mtk	Mbe		˨
+
 ncr	Nchane		b		[b]		ncr.pdf
-ncr	Nchane		tʰ				
-ncr	Nchane		d		[d]		
-ncr	Nchane		d		[ɾ]	free variation with [d] intervocalically	
-ncr	Nchane		k		[kʰ]		
-ncr	Nchane		ɡ		[ɡ]		
-ncr	Nchane		t̠ʃ		[t̠ʃ]		
-ncr	Nchane		d̠ʒ		[d̠ʒ]		
-ncr	Nchane		f		[f]		
-ncr	Nchane		s				
-ncr	Nchane		ʃ		[ʃ]		
-ncr	Nchane		m		[m]		
-ncr	Nchane		n				
-ncr	Nchane		ɲ				
-ncr	Nchane		ŋ		[ŋ]		
-ncr	Nchane		l				
-ncr	Nchane		w				
-ncr	Nchane		j		[j]	free variation	
-ncr	Nchane		j		[ʒ]	free variation	
-ncr	Nchane		m		[mʲ]		
-ncr	Nchane		b		[bʲ]		
-ncr	Nchane		f		[fʲ]		
-ncr	Nchane		b		[bʷ]		
-ncr	Nchane		d		[dʷ]		
-ncr	Nchane		k		[kʷ]		
-ncr	Nchane		ɡ		[ɡʷ]		
-ncr	Nchane		t̠ʃ		[t̠ʃʷ]		
-ncr	Nchane		d̠ʒ		[d̠ʒʷ]		
-ncr	Nchane		f		[fʷ]		
-ncr	Nchane		ʃ		[ʃʷ]		
-ncr	Nchane		m		[mʷ]		
-ncr	Nchane		ŋ		[ŋʷ]		
-ncr	Nchane		b		[bv]	labialized before [u]	
-ncr	Nchane		k		[kf]	labialized before [u]	
-ncr	Nchane		ɡ		[ɡv]	labialized before [u]	
-ncr	Nchane		i				
-ncr	Nchane		u				
-ncr	Nchane		e		[ɪ]	free variation	
-ncr	Nchane		e		[ɨ]	free variation	
-ncr	Nchane		o				
-ncr	Nchane		ɛ		[ɛ]		
-ncr	Nchane		ɛ		[ə]	often before velar consonants	
-ncr	Nchane		ɔ				
-ncr	Nchane		a				
-ncr	Nchane		iː				
-ncr	Nchane		ɛː				
-ncr	Nchane		ɔː				
-ncr	Nchane		oː				
-ncr	Nchane		aː				
-ncr	Nchane		ĩ	contrast found only word-finally			
-ncr	Nchane		ɛ̃	contrast found only word-finally			
-ncr	Nchane		ã	contrast found only word-finally			
-ncr	Nchane		ũ	contrast found only word-finally			
-ncr	Nchane		õ	contrast found only word-finally			
-ncr	Nchane		ɔ̃	contrast found only word-finally			
-ncr	Nchane		˦˧				
-ncr	Nchane		˨˧				
-ncr	Nchane		˨˧				
-ncr	Nchane		˧˨				
-ncr	Nchane		˦				
-ncr	Nchane		˨				
-ncr	Nchane		˧				
-							
+ncr	Nchane		tʰ
+ncr	Nchane		d		[d]
+ncr	Nchane		d		[ɾ]	free variation with [d] intervocalically
+ncr	Nchane		k		[kʰ]
+ncr	Nchane		ɡ		[ɡ]
+ncr	Nchane		t̠ʃ		[t̠ʃ]
+ncr	Nchane		d̠ʒ		[d̠ʒ]
+ncr	Nchane		f		[f]
+ncr	Nchane		s
+ncr	Nchane		ʃ		[ʃ]
+ncr	Nchane		m		[m]
+ncr	Nchane		n
+ncr	Nchane		ɲ
+ncr	Nchane		ŋ		[ŋ]
+ncr	Nchane		l
+ncr	Nchane		w
+ncr	Nchane		j		[j]	free variation
+ncr	Nchane		j		[ʒ]	free variation
+ncr	Nchane		m		[mʲ]
+ncr	Nchane		b		[bʲ]
+ncr	Nchane		f		[fʲ]
+ncr	Nchane		b		[bʷ]
+ncr	Nchane		d		[dʷ]
+ncr	Nchane		k		[kʷ]
+ncr	Nchane		ɡ		[ɡʷ]
+ncr	Nchane		t̠ʃ		[t̠ʃʷ]
+ncr	Nchane		d̠ʒ		[d̠ʒʷ]
+ncr	Nchane		f		[fʷ]
+ncr	Nchane		ʃ		[ʃʷ]
+ncr	Nchane		m		[mʷ]
+ncr	Nchane		ŋ		[ŋʷ]
+ncr	Nchane		b		[bv]	labialized before [u]
+ncr	Nchane		k		[kf]	labialized before [u]
+ncr	Nchane		ɡ		[ɡv]	labialized before [u]
+ncr	Nchane		i
+ncr	Nchane		u
+ncr	Nchane		e		[ɪ]	free variation
+ncr	Nchane		e		[ɨ]	free variation
+ncr	Nchane		o
+ncr	Nchane		ɛ		[ɛ]
+ncr	Nchane		ɛ		[ə]	often before velar consonants
+ncr	Nchane		ɔ
+ncr	Nchane		a
+ncr	Nchane		iː
+ncr	Nchane		ɛː
+ncr	Nchane		ɔː
+ncr	Nchane		oː
+ncr	Nchane		aː
+ncr	Nchane		ĩ	contrast found only word-finally
+ncr	Nchane		ɛ̃	contrast found only word-finally
+ncr	Nchane		ã	contrast found only word-finally
+ncr	Nchane		ũ	contrast found only word-finally
+ncr	Nchane		õ	contrast found only word-finally
+ncr	Nchane		ɔ̃	contrast found only word-finally
+ncr	Nchane		˦˧
+ncr	Nchane		˨˧
+ncr	Nchane		˨˧
+ncr	Nchane		˧˨
+ncr	Nchane		˦
+ncr	Nchane		˨
+ncr	Nchane		˧
+
 nfu	Mfumte		p				nfu.pdf
-nfu	Mfumte		b				
-nfu	Mfumte		bʱ				
-nfu	Mfumte		t				
-nfu	Mfumte		d				
-nfu	Mfumte		k				
-nfu	Mfumte		ɡ				
-nfu	Mfumte		kp				
-nfu	Mfumte		ɡb				
-nfu	Mfumte		ts				
-nfu	Mfumte		dz				
-nfu	Mfumte		<t̠ʃ>	marginal			
-nfu	Mfumte		<d̠ʒ>	marginal			
-nfu	Mfumte		f				
-nfu	Mfumte		v				
-nfu	Mfumte		s				
-nfu	Mfumte		z				
-nfu	Mfumte		ʃ				
-nfu	Mfumte		<ʒ>	reduplicated words only			
-nfu	Mfumte		x				
-nfu	Mfumte		ɣ				
-nfu	Mfumte		h		[h]		
-nfu	Mfumte		h		[ʔ]		
-nfu	Mfumte		l				
-nfu	Mfumte		ɾ				
-nfu	Mfumte		m				
-nfu	Mfumte		n				
-nfu	Mfumte		ɲ				
-nfu	Mfumte		<ŋ>	reduplicated words only			
-nfu	Mfumte		w				
-nfu	Mfumte		<j>	reduplicated words only			
-nfu	Mfumte		ɥ				
-nfu	Mfumte		mp				
-nfu	Mfumte		mb				
-nfu	Mfumte		nt				
-nfu	Mfumte		nd				
-nfu	Mfumte		ŋmkp				
-nfu	Mfumte		ŋmɡb				
-nfu	Mfumte		nts				
-nfu	Mfumte		ndz				
-nfu	Mfumte		n̠d̠ʒ				
-nfu	Mfumte		ɱf				
-nfu	Mfumte		ɱv				
-nfu	Mfumte		ns				
-nfu	Mfumte		n̠ʃ				
-nfu	Mfumte		ŋɣ				
-nfu	Mfumte		ŋh				
-nfu	Mfumte		pʲ				
-nfu	Mfumte		bʲ				
-nfu	Mfumte		kʲ				
-nfu	Mfumte		ɡʲ				
-nfu	Mfumte		hʲ				
-nfu	Mfumte		mpʲ				
-nfu	Mfumte		mbʲ				
-nfu	Mfumte		ŋkʲ				
-nfu	Mfumte		ŋɡʲ				
-nfu	Mfumte		ɱfʲ				
-nfu	Mfumte		ŋɣʲ				
-nfu	Mfumte		ŋhʲ				
-nfu	Mfumte		hᶣ				
-nfu	Mfumte		ŋhᶣ				
-nfu	Mfumte		ŋɣᶣ				
-nfu	Mfumte		pʷ				
-nfu	Mfumte		kʷ				
-nfu	Mfumte		ɡʷ				
-nfu	Mfumte		fʷ				
-nfu	Mfumte		hʷ				
-nfu	Mfumte		ɲʷ				
-nfu	Mfumte		ŋʷ				
-nfu	Mfumte		ŋkʷ				
-nfu	Mfumte		ŋɡʷ				
-nfu	Mfumte		ŋɣʷ				
-nfu	Mfumte		ŋhʷ				
-nfu	Mfumte		bˠ				
-nfu	Mfumte		mbˠ				
-nfu	Mfumte		i				
-nfu	Mfumte		e		[e]	word-initial	
-nfu	Mfumte		e		[ɛ]		
-nfu	Mfumte		y				
-nfu	Mfumte		ø				
-nfu	Mfumte		ɯ				
-nfu	Mfumte		ə				
-nfu	Mfumte		a				
-nfu	Mfumte		u				
-nfu	Mfumte		o				
-nfu	Mfumte		ɔ				
-nfu	Mfumte		˨˦				
-nfu	Mfumte		˦˨				
-nfu	Mfumte		˨				
-nfu	Mfumte		˧				
-nfu	Mfumte		˥˩				
-							
+nfu	Mfumte		b
+nfu	Mfumte		bʱ
+nfu	Mfumte		t
+nfu	Mfumte		d
+nfu	Mfumte		k
+nfu	Mfumte		ɡ
+nfu	Mfumte		kp
+nfu	Mfumte		ɡb
+nfu	Mfumte		ts
+nfu	Mfumte		dz
+nfu	Mfumte		<t̠ʃ>	marginal
+nfu	Mfumte		<d̠ʒ>	marginal
+nfu	Mfumte		f
+nfu	Mfumte		v
+nfu	Mfumte		s
+nfu	Mfumte		z
+nfu	Mfumte		ʃ
+nfu	Mfumte		<ʒ>	reduplicated words only
+nfu	Mfumte		x
+nfu	Mfumte		ɣ
+nfu	Mfumte		h		[h]
+nfu	Mfumte		h		[ʔ]
+nfu	Mfumte		l
+nfu	Mfumte		ɾ
+nfu	Mfumte		m
+nfu	Mfumte		n
+nfu	Mfumte		ɲ
+nfu	Mfumte		<ŋ>	reduplicated words only
+nfu	Mfumte		w
+nfu	Mfumte		<j>	reduplicated words only
+nfu	Mfumte		ɥ
+nfu	Mfumte		mp
+nfu	Mfumte		mb
+nfu	Mfumte		nt
+nfu	Mfumte		nd
+nfu	Mfumte		ŋmkp
+nfu	Mfumte		ŋmɡb
+nfu	Mfumte		nts
+nfu	Mfumte		ndz
+nfu	Mfumte		n̠d̠ʒ
+nfu	Mfumte		ɱf
+nfu	Mfumte		ɱv
+nfu	Mfumte		ns
+nfu	Mfumte		n̠ʃ
+nfu	Mfumte		ŋɣ
+nfu	Mfumte		ŋh
+nfu	Mfumte		pʲ
+nfu	Mfumte		bʲ
+nfu	Mfumte		kʲ
+nfu	Mfumte		ɡʲ
+nfu	Mfumte		hʲ
+nfu	Mfumte		mpʲ
+nfu	Mfumte		mbʲ
+nfu	Mfumte		ŋkʲ
+nfu	Mfumte		ŋɡʲ
+nfu	Mfumte		ɱfʲ
+nfu	Mfumte		ŋɣʲ
+nfu	Mfumte		ŋhʲ
+nfu	Mfumte		hᶣ
+nfu	Mfumte		ŋhᶣ
+nfu	Mfumte		ŋɣᶣ
+nfu	Mfumte		pʷ
+nfu	Mfumte		kʷ
+nfu	Mfumte		ɡʷ
+nfu	Mfumte		fʷ
+nfu	Mfumte		hʷ
+nfu	Mfumte		ɲʷ
+nfu	Mfumte		ŋʷ
+nfu	Mfumte		ŋkʷ
+nfu	Mfumte		ŋɡʷ
+nfu	Mfumte		ŋɣʷ
+nfu	Mfumte		ŋhʷ
+nfu	Mfumte		bˠ
+nfu	Mfumte		mbˠ
+nfu	Mfumte		i
+nfu	Mfumte		e		[e]	word-initial
+nfu	Mfumte		e		[ɛ]
+nfu	Mfumte		y
+nfu	Mfumte		ø
+nfu	Mfumte		ɯ
+nfu	Mfumte		ə
+nfu	Mfumte		a
+nfu	Mfumte		u
+nfu	Mfumte		o
+nfu	Mfumte		ɔ
+nfu	Mfumte		˨˦
+nfu	Mfumte		˦˨
+nfu	Mfumte		˨
+nfu	Mfumte		˧
+nfu	Mfumte		˥˩
+
 njy	Njem		p				njy.pdf
-njy	Njem		b				
-njy	Njem		m				
-njy	Njem		w				
-njy	Njem		<f>	limited distribution			
-njy	Njem		<v>	limited distribution			
-njy	Njem		t				
-njy	Njem		d		[d]	root-initial	
-njy	Njem		n				
-njy	Njem		s		[s]	root-initial, free variation with [ʃ]	
-njy	Njem		ts		[ts]		
-njy	Njem		dz		[dz]		
-njy	Njem		l				
-njy	Njem		d		[r]	root-medial and final	
-njy	Njem		ɲ		[ɲ]	root-initial	
-njy	Njem		ʃ				
-njy	Njem		ts		[t̠ʃ]	before hiɡh vowels	
-njy	Njem		dz		[d̠ʒ]	before hiɡh vowels	
-njy	Njem		j				
-njy	Njem		k		[k]	root-initial	
-njy	Njem		ɡ				
-njy	Njem		ɲ		[ŋ]	root-medial and final	
-njy	Njem		k		[ʔ]	root-medial and final	
-njy	Njem		s		[h]	root-medial and final	
-njy	Njem		<kp>	limited distribution			
-njy	Njem		<ɡb>	limited distribution			
-njy	Njem		i				
-njy	Njem		ɪ				
-njy	Njem		e				
-njy	Njem		ɛ				
-njy	Njem		œ				
-njy	Njem		ɑ				
-njy	Njem		u				
-njy	Njem		ʊ				
-njy	Njem		o				
-njy	Njem		ɔ				
-njy	Njem		iː				
-njy	Njem		ɪː				
-njy	Njem		eː				
-njy	Njem		ɛː				
-njy	Njem		œː				
-njy	Njem		ɑː				
-njy	Njem		uː				
-njy	Njem		ʊː				
-njy	Njem		ɔː				
-njy	Njem		oː				
-njy	Njem		˦				
-njy	Njem		˨				
+njy	Njem		b
+njy	Njem		m
+njy	Njem		w
+njy	Njem		<f>	limited distribution
+njy	Njem		<v>	limited distribution
+njy	Njem		t
+njy	Njem		d		[d]	root-initial
+njy	Njem		n
+njy	Njem		s		[s]	root-initial, free variation with [ʃ]
+njy	Njem		ts		[ts]
+njy	Njem		dz		[dz]
+njy	Njem		l
+njy	Njem		d		[r]	root-medial and final
+njy	Njem		ɲ		[ɲ]	root-initial
+njy	Njem		ʃ
+njy	Njem		ts		[t̠ʃ]	before hiɡh vowels
+njy	Njem		dz		[d̠ʒ]	before hiɡh vowels
+njy	Njem		j
+njy	Njem		k		[k]	root-initial
+njy	Njem		ɡ
+njy	Njem		ɲ		[ŋ]	root-medial and final
+njy	Njem		k		[ʔ]	root-medial and final
+njy	Njem		s		[h]	root-medial and final
+njy	Njem		<kp>	limited distribution
+njy	Njem		<ɡb>	limited distribution
+njy	Njem		i
+njy	Njem		ɪ
+njy	Njem		e
+njy	Njem		ɛ
+njy	Njem		œ
+njy	Njem		ɑ
+njy	Njem		u
+njy	Njem		ʊ
+njy	Njem		o
+njy	Njem		ɔ
+njy	Njem		iː
+njy	Njem		ɪː
+njy	Njem		eː
+njy	Njem		ɛː
+njy	Njem		œː
+njy	Njem		ɑː
+njy	Njem		uː
+njy	Njem		ʊː
+njy	Njem		ɔː
+njy	Njem		oː
+njy	Njem		˦
+njy	Njem		˨
 
 box	Bwamut	Bondoukuy	ɓ		[ɓ]		Manessy_bwamu_box.pdf
-box	Bwamut	Bondoukuy	ɓ		[ɓʷ]	before front vowels	
-box	Bwamut	Bondoukuy	p				
-box	Bwamut	Bondoukuy	b				
-box	Bwamut	Bondoukuy	m				
-box	Bwamut	Bondoukuy	f				
-box	Bwamut	Bondoukuy	v				
-box	Bwamut	Bondoukuy	t̪				
-box	Bwamut	Bondoukuy	d̪				
-box	Bwamut	Bondoukuy	n̪				
-box	Bwamut	Bondoukuy	s̪				
-box	Bwamut	Bondoukuy	z̪				
-box	Bwamut	Bondoukuy	l̪		[ɹ]		
-box	Bwamut	Bondoukuy	l̪		[ɹ̃]		
-box	Bwamut	Bondoukuy	l̪		[l̪]		
-box	Bwamut	Bondoukuy	c			this is described as 'pre-palatal', but differentiated from [t̪], while post-palatals are typical velar stops	
-box	Bwamut	Bondoukuy	ɲ			this is described as pre-palatal	
-box	Bwamut	Bondoukuy	k				
-box	Bwamut	Bondoukuy	ɡ		[ɡ]		
-box	Bwamut	Bondoukuy	ɡ		[q]		
-box	Bwamut	Bondoukuy	h				
-box	Bwamut	Bondoukuy	i		[i]		
-box	Bwamut	Bondoukuy	i		[y]		
-box	Bwamut	Bondoukuy	ĩ		[ĩ]		
-box	Bwamut	Bondoukuy	ĩ		[ỹ]		
-box	Bwamut	Bondoukuy	e		[ɛ]		
-box	Bwamut	Bondoukuy	e		[e]		
-box	Bwamut	Bondoukuy	a		[æ]		
-box	Bwamut	Bondoukuy	a		[ɛ]		
-box	Bwamut	Bondoukuy	ã		[æ̃]		
-box	Bwamut	Bondoukuy	ã		[ã]		
-box	Bwamut	Bondoukuy	u		[u]		
-box	Bwamut	Bondoukuy	u		[wiy]		
-box	Bwamut	Bondoukuy	u		[ẅiy]		
-box	Bwamut	Bondoukuy	u		[w]		
-box	Bwamut	Bondoukuy	u		[ŋʷ]		
-box	Bwamut	Bondoukuy	ũ		[ɔ̃]		
-box	Bwamut	Bondoukuy	ũ		[ũ]		
-box	Bwamut	Bondoukuy	ũ		[w̃]		
-box	Bwamut	Bondoukuy	o		[o̝]		
-box	Bwamut	Bondoukuy	o		[ɔ]		
-box	Bwamut	Bondoukuy	o		[ə]		
-box	Bwamut	Bondoukuy	o		[w]		
-box	Bwamut	Bondoukuy	˦				
-box	Bwamut	Bondoukuy	˧				
-box	Bwamut	Bondoukuy	˨				
-							
+box	Bwamut	Bondoukuy	ɓ		[ɓʷ]	before front vowels
+box	Bwamut	Bondoukuy	p
+box	Bwamut	Bondoukuy	b
+box	Bwamut	Bondoukuy	m
+box	Bwamut	Bondoukuy	f
+box	Bwamut	Bondoukuy	v
+box	Bwamut	Bondoukuy	t̪
+box	Bwamut	Bondoukuy	d̪
+box	Bwamut	Bondoukuy	n̪
+box	Bwamut	Bondoukuy	s̪
+box	Bwamut	Bondoukuy	z̪
+box	Bwamut	Bondoukuy	l̪		[ɹ]
+box	Bwamut	Bondoukuy	l̪		[ɹ̃]
+box	Bwamut	Bondoukuy	l̪		[l̪]
+box	Bwamut	Bondoukuy	c			this is described as 'pre-palatal', but differentiated from [t̪], while post-palatals are typical velar stops
+box	Bwamut	Bondoukuy	ɲ			this is described as pre-palatal
+box	Bwamut	Bondoukuy	k
+box	Bwamut	Bondoukuy	ɡ		[ɡ]
+box	Bwamut	Bondoukuy	ɡ		[q]
+box	Bwamut	Bondoukuy	h
+box	Bwamut	Bondoukuy	i		[i]
+box	Bwamut	Bondoukuy	i		[y]
+box	Bwamut	Bondoukuy	ĩ		[ĩ]
+box	Bwamut	Bondoukuy	ĩ		[ỹ]
+box	Bwamut	Bondoukuy	e		[ɛ]
+box	Bwamut	Bondoukuy	e		[e]
+box	Bwamut	Bondoukuy	a		[æ]
+box	Bwamut	Bondoukuy	a		[ɛ]
+box	Bwamut	Bondoukuy	ã		[æ̃]
+box	Bwamut	Bondoukuy	ã		[ã]
+box	Bwamut	Bondoukuy	u		[u]
+box	Bwamut	Bondoukuy	u		[wiy]
+box	Bwamut	Bondoukuy	u		[ẅiy]
+box	Bwamut	Bondoukuy	u		[w]
+box	Bwamut	Bondoukuy	u		[ŋʷ]
+box	Bwamut	Bondoukuy	ũ		[ɔ̃]
+box	Bwamut	Bondoukuy	ũ		[ũ]
+box	Bwamut	Bondoukuy	ũ		[w̃]
+box	Bwamut	Bondoukuy	o		[o̝]
+box	Bwamut	Bondoukuy	o		[ɔ]
+box	Bwamut	Bondoukuy	o		[ə]
+box	Bwamut	Bondoukuy	o		[w]
+box	Bwamut	Bondoukuy	˦
+box	Bwamut	Bondoukuy	˧
+box	Bwamut	Bondoukuy	˨
+
 ktf	Kwami		p				Leger_kwami_ktf.pdf
-ktf	Kwami		b				
-ktf	Kwami		ɓ				
-ktf	Kwami		mb				
-ktf	Kwami		m				
-ktf	Kwami		w				
-ktf	Kwami		f				
-ktf	Kwami		t				
-ktf	Kwami		d				
-ktf	Kwami		ɗ				
-ktf	Kwami		nd				
-ktf	Kwami		s				
-ktf	Kwami		z				
-ktf	Kwami		n				
-ktf	Kwami		l				
-ktf	Kwami		r				
-ktf	Kwami		ʃ				
-ktf	Kwami		t̠ʃ				
-ktf	Kwami		d̠ʒ				
-ktf	Kwami		j				
-ktf	Kwami		k				
-ktf	Kwami		ɡ				
-ktf	Kwami		ŋɡ				
-ktf	Kwami		kʷ				
-ktf	Kwami		ɡʷ				
-ktf	Kwami		ŋɡʷ				
-ktf	Kwami		ʔ				
-ktf	Kwami		h				
-ktf	Kwami		i				
-ktf	Kwami		iː				
-ktf	Kwami		e				
-ktf	Kwami		eː				
-ktf	Kwami		a				
-ktf	Kwami		aː				
-ktf	Kwami		ɔ				
-ktf	Kwami		ɔː				
-ktf	Kwami		u				
-ktf	Kwami		uː				
-ktf	Kwami		˦				
-ktf	Kwami		˨				
-							
+ktf	Kwami		b
+ktf	Kwami		ɓ
+ktf	Kwami		mb
+ktf	Kwami		m
+ktf	Kwami		w
+ktf	Kwami		f
+ktf	Kwami		t
+ktf	Kwami		d
+ktf	Kwami		ɗ
+ktf	Kwami		nd
+ktf	Kwami		s
+ktf	Kwami		z
+ktf	Kwami		n
+ktf	Kwami		l
+ktf	Kwami		r
+ktf	Kwami		ʃ
+ktf	Kwami		t̠ʃ
+ktf	Kwami		d̠ʒ
+ktf	Kwami		j
+ktf	Kwami		k
+ktf	Kwami		ɡ
+ktf	Kwami		ŋɡ
+ktf	Kwami		kʷ
+ktf	Kwami		ɡʷ
+ktf	Kwami		ŋɡʷ
+ktf	Kwami		ʔ
+ktf	Kwami		h
+ktf	Kwami		i
+ktf	Kwami		iː
+ktf	Kwami		e
+ktf	Kwami		eː
+ktf	Kwami		a
+ktf	Kwami		aː
+ktf	Kwami		ɔ
+ktf	Kwami		ɔː
+ktf	Kwami		u
+ktf	Kwami		uː
+ktf	Kwami		˦
+ktf	Kwami		˨
+
 goa	Gouro		i		[i]		Benoit_gouro_goa.pdf
-goa	Gouro		ɪ				
-goa	Gouro		e				
-goa	Gouro		ɛ				
-goa	Gouro		a				
-goa	Gouro		ɔ				
-goa	Gouro		o				
-goa	Gouro		ʊ				
-goa	Gouro		u				
-goa	Gouro		i		[y]	before [ɛ]	
-goa	Gouro		u		[y]	before [ɛ]	
-goa	Gouro		ĩ				
-goa	Gouro		ɛ̃				
-goa	Gouro		ã				
-goa	Gouro		ɔ̃				
-goa	Gouro		ũ				
-goa	Gouro		iː				
-goa	Gouro		ɪː				
-goa	Gouro		eː				
-goa	Gouro		ɛː				
-goa	Gouro		aː				
-goa	Gouro		ɔː				
-goa	Gouro		oː				
-goa	Gouro		ʊː				
-goa	Gouro		uː				
-goa	Gouro		ĩː				
-goa	Gouro		ɛ̃ː				
-goa	Gouro		ãː				
-goa	Gouro		ɔ̃ː				
-goa	Gouro		ũː				
-goa	Gouro		w				
-goa	Gouro		j				
-goa	Gouro		p				
-goa	Gouro		b				
-goa	Gouro		m				
-goa	Gouro		v				
-goa	Gouro		f				
-goa	Gouro		bʷ				
-goa	Gouro		pʷ	this looks like a typo in the source, listed as kʷ			
-goa	Gouro		<sʷ>				
-goa	Gouro		d̪	free variation with [l] for some speakers			
-goa	Gouro		t̪				
-goa	Gouro		n̪				
-goa	Gouro		l̪	free variation with [d̪] for some speakers	[l̪]		
-goa	Gouro		l̪		[r]	after [d̪,t̪,z̪,s̪]	
-goa	Gouro		z̪				
-goa	Gouro		s̪				
-goa	Gouro		ɽ	author states that this may be /d̪/			
-goa	Gouro		dʲ				
-goa	Gouro		nʲ				
-goa	Gouro		sʲ				
-goa	Gouro		ɡʲ				
-goa	Gouro		kʲ				
-goa	Gouro		ɡ				
-goa	Gouro		k				
-goa	Gouro		ɡb				
-goa	Gouro		kp				
-goa	Gouro		˦				
-goa	Gouro		˧				
-goa	Gouro		˨				
-							
+goa	Gouro		ɪ
+goa	Gouro		e
+goa	Gouro		ɛ
+goa	Gouro		a
+goa	Gouro		ɔ
+goa	Gouro		o
+goa	Gouro		ʊ
+goa	Gouro		u
+goa	Gouro		i		[y]	before [ɛ]
+goa	Gouro		u		[y]	before [ɛ]
+goa	Gouro		ĩ
+goa	Gouro		ɛ̃
+goa	Gouro		ã
+goa	Gouro		ɔ̃
+goa	Gouro		ũ
+goa	Gouro		iː
+goa	Gouro		ɪː
+goa	Gouro		eː
+goa	Gouro		ɛː
+goa	Gouro		aː
+goa	Gouro		ɔː
+goa	Gouro		oː
+goa	Gouro		ʊː
+goa	Gouro		uː
+goa	Gouro		ĩː
+goa	Gouro		ɛ̃ː
+goa	Gouro		ãː
+goa	Gouro		ɔ̃ː
+goa	Gouro		ũː
+goa	Gouro		w
+goa	Gouro		j
+goa	Gouro		p
+goa	Gouro		b
+goa	Gouro		m
+goa	Gouro		v
+goa	Gouro		f
+goa	Gouro		bʷ
+goa	Gouro		pʷ	this looks like a typo in the source, listed as kʷ
+goa	Gouro		<sʷ>
+goa	Gouro		d̪	free variation with [l] for some speakers
+goa	Gouro		t̪
+goa	Gouro		n̪
+goa	Gouro		l̪	free variation with [d̪] for some speakers	[l̪]
+goa	Gouro		l̪		[r]	after [d̪,t̪,z̪,s̪]
+goa	Gouro		z̪
+goa	Gouro		s̪
+goa	Gouro		ɽ	author states that this may be /d̪/
+goa	Gouro		dʲ
+goa	Gouro		nʲ
+goa	Gouro		sʲ
+goa	Gouro		ɡʲ
+goa	Gouro		kʲ
+goa	Gouro		ɡ
+goa	Gouro		k
+goa	Gouro		ɡb
+goa	Gouro		kp
+goa	Gouro		˦
+goa	Gouro		˧
+goa	Gouro		˨
+
 kea	Cape Verde Creole		p				Veiga_cap-vert_kea.pdf
-kea	Cape Verde Creole		b		[ɡ]	in Santiago dialect	
-kea	Cape Verde Creole		b		[b]		
-kea	Cape Verde Creole		m				
-kea	Cape Verde Creole		f				
-kea	Cape Verde Creole		v		[b]	in Saõ Vicente dialect	
-kea	Cape Verde Creole		v		[v]		
-kea	Cape Verde Creole		t		[tʲ]	before palatal vowels in some dialects	
-kea	Cape Verde Creole		t		[t]		
-kea	Cape Verde Creole		d				
-kea	Cape Verde Creole		n				
-kea	Cape Verde Creole		s		[r]	in Santiago dialect	
-kea	Cape Verde Creole		s		[s]		
-kea	Cape Verde Creole		z				
-kea	Cape Verde Creole		l	variation with [r]			
-kea	Cape Verde Creole		r	variation with [l]			
-kea	Cape Verde Creole		c				
-kea	Cape Verde Creole		ɟ				
-kea	Cape Verde Creole		ɲ				
-kea	Cape Verde Creole		ʃ				
-kea	Cape Verde Creole		ʒ				
-kea	Cape Verde Creole		ʎ				
-kea	Cape Verde Creole		k	velar nasal approximant			
-kea	Cape Verde Creole		ɡ				
-kea	Cape Verde Creole		<ŋ̞>				
-kea	Cape Verde Creole		i		[i]		
-kea	Cape Verde Creole		i		[ĩ]		
-kea	Cape Verde Creole		e		[e]		
-kea	Cape Verde Creole		e		[ẽ]		
-kea	Cape Verde Creole		ɛ		[ɛ]		
-kea	Cape Verde Creole		ɛ		[ɛ̃]		
-kea	Cape Verde Creole		o		[o]		
-kea	Cape Verde Creole		o		[õ]		
-kea	Cape Verde Creole		ɔ		[ɔ]		
-kea	Cape Verde Creole		ɔ		[ɔ̃]		
-kea	Cape Verde Creole		a		[a]		
-kea	Cape Verde Creole		a		[ã]		
-kea	Cape Verde Creole		u		[u]		
-kea	Cape Verde Creole		u		[ũ]		
-							
+kea	Cape Verde Creole		b		[ɡ]	in Santiago dialect
+kea	Cape Verde Creole		b		[b]
+kea	Cape Verde Creole		m
+kea	Cape Verde Creole		f
+kea	Cape Verde Creole		v		[b]	in Saõ Vicente dialect
+kea	Cape Verde Creole		v		[v]
+kea	Cape Verde Creole		t		[tʲ]	before palatal vowels in some dialects
+kea	Cape Verde Creole		t		[t]
+kea	Cape Verde Creole		d
+kea	Cape Verde Creole		n
+kea	Cape Verde Creole		s		[r]	in Santiago dialect
+kea	Cape Verde Creole		s		[s]
+kea	Cape Verde Creole		z
+kea	Cape Verde Creole		l	variation with [r]
+kea	Cape Verde Creole		r	variation with [l]
+kea	Cape Verde Creole		c
+kea	Cape Verde Creole		ɟ
+kea	Cape Verde Creole		ɲ
+kea	Cape Verde Creole		ʃ
+kea	Cape Verde Creole		ʒ
+kea	Cape Verde Creole		ʎ
+kea	Cape Verde Creole		k	velar nasal approximant
+kea	Cape Verde Creole		ɡ
+kea	Cape Verde Creole		<ŋ̞>
+kea	Cape Verde Creole		i		[i]
+kea	Cape Verde Creole		i		[ĩ]
+kea	Cape Verde Creole		e		[e]
+kea	Cape Verde Creole		e		[ẽ]
+kea	Cape Verde Creole		ɛ		[ɛ]
+kea	Cape Verde Creole		ɛ		[ɛ̃]
+kea	Cape Verde Creole		o		[o]
+kea	Cape Verde Creole		o		[õ]
+kea	Cape Verde Creole		ɔ		[ɔ]
+kea	Cape Verde Creole		ɔ		[ɔ̃]
+kea	Cape Verde Creole		a		[a]
+kea	Cape Verde Creole		a		[ã]
+kea	Cape Verde Creole		u		[u]
+kea	Cape Verde Creole		u		[ũ]
+
 nku	Kulango	Bouna	p		[pʲ]		Elders_kulango_nku.pdf
-nku	Kulango	Bouna	p		[pʷ]		
-nku	Kulango	Bouna	p		[p]		
-nku	Kulango	Bouna	b		[b]		
-nku	Kulango	Bouna	b		[bʲ]		
-nku	Kulango	Bouna	f		[f]		
-nku	Kulango	Bouna	f		[fʲ]		
-nku	Kulango	Bouna	f		[fʷ]		
-nku	Kulango	Bouna	v		[v]		
-nku	Kulango	Bouna	v		[vʷ]		
-nku	Kulango	Bouna	m		[m]		
-nku	Kulango	Bouna	m		[mʲ]		
-nku	Kulango	Bouna	m		[mʷ]		
-nku	Kulango	Bouna	t		[t]		
-nku	Kulango	Bouna	t		[tʲ]		
-nku	Kulango	Bouna	t		[tʷ]		
-nku	Kulango	Bouna	d		[d]		
-nku	Kulango	Bouna	d		[dʷ]		
-nku	Kulango	Bouna	s		[s]		
-nku	Kulango	Bouna	s		[sʲ]		
-nku	Kulango	Bouna	s		[sʷ]		
-nku	Kulango	Bouna	z				
-nku	Kulango	Bouna	n				
-nku	Kulango	Bouna	l		[l]		
-nku	Kulango	Bouna	l		[lʷ]		
-nku	Kulango	Bouna	r				
-nku	Kulango	Bouna	ɟ				
-nku	Kulango	Bouna	ʃ				
-nku	Kulango	Bouna	ʒ				
-nku	Kulango	Bouna	ɲ		[ɲ]		
-nku	Kulango	Bouna	ɲ		[ɲʷ]		
-nku	Kulango	Bouna	ɲ		[ɲᶣ]		
-nku	Kulango	Bouna	j		[j]		
-nku	Kulango	Bouna	j		[jʷ]		
-nku	Kulango	Bouna	k		[kʲ]		
-nku	Kulango	Bouna	k		[kʷ]		
-nku	Kulango	Bouna	k		[k]		
-nku	Kulango	Bouna	ɡ		[ɡ]		
-nku	Kulango	Bouna	ɡ		[ɡʷ]		
-nku	Kulango	Bouna	ɡ		[ɣ]	intervocalic	
-nku	Kulango	Bouna	ɡ		[ʝ]	intervocalic before tense vowels	
-nku	Kulango	Bouna	ɡ		[ɡʲ]		
-nku	Kulango	Bouna	x		[x]		
-nku	Kulango	Bouna	x		[ç]		
-nku	Kulango	Bouna	x		[xʷ]		
-nku	Kulango	Bouna	ŋ		[ŋ]		
-nku	Kulango	Bouna	ŋ		[ŋʷ]		
-nku	Kulango	Bouna	kp				
-nku	Kulango	Bouna	ɡb				
-nku	Kulango	Bouna	ŋm				
-nku	Kulango	Bouna	w				
-nku	Kulango	Bouna	ʔ				
-nku	Kulango	Bouna	h		[h]		
-nku	Kulango	Bouna	h		[hʷ]		
-nku	Kulango	Bouna	i		[i]		
-nku	Kulango	Bouna	i		[ĩ]		
-nku	Kulango	Bouna	ɪ		[ɪ]		
-nku	Kulango	Bouna	ɪ		[ɪ̃]		
-nku	Kulango	Bouna	e		[e]		
-nku	Kulango	Bouna	e		[ẽ]		
-nku	Kulango	Bouna	ɛ		[ɛ]		
-nku	Kulango	Bouna	ɛ		[ɛ̃]		
-nku	Kulango	Bouna	a		[a]		
-nku	Kulango	Bouna	a		[ã]		
-nku	Kulango	Bouna	o		[o]		
-nku	Kulango	Bouna	o		[õ]		
-nku	Kulango	Bouna	ɔ		[ɔ]		
-nku	Kulango	Bouna	ɔ		[ɔ̃]		
-nku	Kulango	Bouna	u		[u]		
-nku	Kulango	Bouna	u		[ũ]		
-nku	Kulango	Bouna	ĩ				
-nku	Kulango	Bouna	ɪ̃				
-nku	Kulango	Bouna	ɛ̃				
-nku	Kulango	Bouna	ẽ				
-nku	Kulango	Bouna	ã				
-nku	Kulango	Bouna	õ				
-nku	Kulango	Bouna	ɔ̃				
-nku	Kulango	Bouna	ũ				
-nku	Kulango	Bouna	ʊ		[ʊ]		
-nku	Kulango	Bouna	ʊ		[ʊ̃]		
-nku	Kulango	Bouna	˦				
-nku	Kulango	Bouna	˨				
-							
+nku	Kulango	Bouna	p		[pʷ]
+nku	Kulango	Bouna	p		[p]
+nku	Kulango	Bouna	b		[b]
+nku	Kulango	Bouna	b		[bʲ]
+nku	Kulango	Bouna	f		[f]
+nku	Kulango	Bouna	f		[fʲ]
+nku	Kulango	Bouna	f		[fʷ]
+nku	Kulango	Bouna	v		[v]
+nku	Kulango	Bouna	v		[vʷ]
+nku	Kulango	Bouna	m		[m]
+nku	Kulango	Bouna	m		[mʲ]
+nku	Kulango	Bouna	m		[mʷ]
+nku	Kulango	Bouna	t		[t]
+nku	Kulango	Bouna	t		[tʲ]
+nku	Kulango	Bouna	t		[tʷ]
+nku	Kulango	Bouna	d		[d]
+nku	Kulango	Bouna	d		[dʷ]
+nku	Kulango	Bouna	s		[s]
+nku	Kulango	Bouna	s		[sʲ]
+nku	Kulango	Bouna	s		[sʷ]
+nku	Kulango	Bouna	z
+nku	Kulango	Bouna	n
+nku	Kulango	Bouna	l		[l]
+nku	Kulango	Bouna	l		[lʷ]
+nku	Kulango	Bouna	r
+nku	Kulango	Bouna	ɟ
+nku	Kulango	Bouna	ʃ
+nku	Kulango	Bouna	ʒ
+nku	Kulango	Bouna	ɲ		[ɲ]
+nku	Kulango	Bouna	ɲ		[ɲʷ]
+nku	Kulango	Bouna	ɲ		[ɲᶣ]
+nku	Kulango	Bouna	j		[j]
+nku	Kulango	Bouna	j		[jʷ]
+nku	Kulango	Bouna	k		[kʲ]
+nku	Kulango	Bouna	k		[kʷ]
+nku	Kulango	Bouna	k		[k]
+nku	Kulango	Bouna	ɡ		[ɡ]
+nku	Kulango	Bouna	ɡ		[ɡʷ]
+nku	Kulango	Bouna	ɡ		[ɣ]	intervocalic
+nku	Kulango	Bouna	ɡ		[ʝ]	intervocalic before tense vowels
+nku	Kulango	Bouna	ɡ		[ɡʲ]
+nku	Kulango	Bouna	x		[x]
+nku	Kulango	Bouna	x		[ç]
+nku	Kulango	Bouna	x		[xʷ]
+nku	Kulango	Bouna	ŋ		[ŋ]
+nku	Kulango	Bouna	ŋ		[ŋʷ]
+nku	Kulango	Bouna	kp
+nku	Kulango	Bouna	ɡb
+nku	Kulango	Bouna	ŋm
+nku	Kulango	Bouna	w
+nku	Kulango	Bouna	ʔ
+nku	Kulango	Bouna	h		[h]
+nku	Kulango	Bouna	h		[hʷ]
+nku	Kulango	Bouna	i		[i]
+nku	Kulango	Bouna	i		[ĩ]
+nku	Kulango	Bouna	ɪ		[ɪ]
+nku	Kulango	Bouna	ɪ		[ɪ̃]
+nku	Kulango	Bouna	e		[e]
+nku	Kulango	Bouna	e		[ẽ]
+nku	Kulango	Bouna	ɛ		[ɛ]
+nku	Kulango	Bouna	ɛ		[ɛ̃]
+nku	Kulango	Bouna	a		[a]
+nku	Kulango	Bouna	a		[ã]
+nku	Kulango	Bouna	o		[o]
+nku	Kulango	Bouna	o		[õ]
+nku	Kulango	Bouna	ɔ		[ɔ]
+nku	Kulango	Bouna	ɔ		[ɔ̃]
+nku	Kulango	Bouna	u		[u]
+nku	Kulango	Bouna	u		[ũ]
+nku	Kulango	Bouna	ĩ
+nku	Kulango	Bouna	ɪ̃
+nku	Kulango	Bouna	ɛ̃
+nku	Kulango	Bouna	ẽ
+nku	Kulango	Bouna	ã
+nku	Kulango	Bouna	õ
+nku	Kulango	Bouna	ɔ̃
+nku	Kulango	Bouna	ũ
+nku	Kulango	Bouna	ʊ		[ʊ]
+nku	Kulango	Bouna	ʊ		[ʊ̃]
+nku	Kulango	Bouna	˦
+nku	Kulango	Bouna	˨
+
 tsb	Ts'amakko		p		[p]		Sava_tsamakko_tsb.pdf
-tsb	Ts'amakko		p		[pʰ]		
-tsb	Ts'amakko		p		[f]		
-tsb	Ts'amakko		p		[ɸ]		
-tsb	Ts'amakko		b				
-tsb	Ts'amakko		t				
-tsb	Ts'amakko		d				
-tsb	Ts'amakko		k				
-tsb	Ts'amakko		ɡ				
-tsb	Ts'amakko		ʔ				
-tsb	Ts'amakko		s				
-tsb	Ts'amakko		z				
-tsb	Ts'amakko		ʃ				
-tsb	Ts'amakko		ʒ		[ʒ]		
-tsb	Ts'amakko		ʒ		[d̠ʒ]		
-tsb	Ts'amakko		x		[χ]		
-tsb	Ts'amakko		x		[χ̃]	voiceless trilled uvular pulmonic fricative	
-tsb	Ts'amakko		ħ		[ħ]		
-tsb	Ts'amakko		ħ		[ħ̃]	voiceless trilled pharynɡeal pulmonic fricative	
-tsb	Ts'amakko		ʕ		[ʕ]		
-tsb	Ts'amakko		ʕ		[ʕˀ]	voiced ɡlottalized pharynɡeal pulmonic fricative	
-tsb	Ts'amakko		h				
-tsb	Ts'amakko		m				
-tsb	Ts'amakko		n		[n]		
-tsb	Ts'amakko		n		[m]		
-tsb	Ts'amakko		n		[ŋ]		
-tsb	Ts'amakko		ɲ				
-tsb	Ts'amakko		c		[t̠ʃ]		
-tsb	Ts'amakko		c		[t̠ʃʼ]		
-tsb	Ts'amakko		qʼ		[qʼ]		
-tsb	Ts'amakko		qʼ		[qxʼ]		
-tsb	Ts'amakko		qʼ		[ʛ̥]		
-tsb	Ts'amakko		qʼ		[ʛ]		
-tsb	Ts'amakko		tsʼ		[tsʼ]		
-tsb	Ts'amakko		tsʼ		[sʼ]		
-tsb	Ts'amakko		ɓ		[ɓ]		
-tsb	Ts'amakko		ɓ		[ɓ̥]		
-tsb	Ts'amakko		ɗ		[ɗ̺]		
-tsb	Ts'amakko		ɗ		[ɗ]		
-tsb	Ts'amakko		ɠ		[ɠ]		
-tsb	Ts'amakko		ɠ		[ɠ̥]		
-tsb	Ts'amakko		w				
-tsb	Ts'amakko		j				
-tsb	Ts'amakko		l				
-tsb	Ts'amakko		r				
-tsb	Ts'amakko		pː		[pː]		
-tsb	Ts'amakko		pː		[pʰː]		
-tsb	Ts'amakko		pː		[fː]		
-tsb	Ts'amakko		ʃː				
-tsb	Ts'amakko		ɓː				
-tsb	Ts'amakko		ɠː				
-tsb	Ts'amakko		hː				
-tsb	Ts'amakko		cː		[t̠ʃː]		
-tsb	Ts'amakko		ɲː				
-tsb	Ts'amakko		bː				
-tsb	Ts'amakko		tː				
-tsb	Ts'amakko		dː				
-tsb	Ts'amakko		kː				
-tsb	Ts'amakko		ɡː				
-tsb	Ts'amakko		ʔː				
-tsb	Ts'amakko		d̠ʒː				
-tsb	Ts'amakko		sː				
-tsb	Ts'amakko		zː				
-tsb	Ts'amakko		xː		[χː]		
-tsb	Ts'amakko		ħː				
-tsb	Ts'amakko		ʕː				
-tsb	Ts'amakko		mː				
-tsb	Ts'amakko		nː				
-tsb	Ts'amakko		qʼː		[qʼː]		
-tsb	Ts'amakko		qʼː		[ʛː]		
-tsb	Ts'amakko		qʼː		[ʛ̥ː]		
-tsb	Ts'amakko		cʼː		[t̠ʃʼː]		
-tsb	Ts'amakko		tsʼː		[tsʼː]		
-tsb	Ts'amakko		tsʼː		[sʼː]		
-tsb	Ts'amakko		ɗ		[ˀd̺ː]		
-tsb	Ts'amakko		wː				
-tsb	Ts'amakko		jː				
-tsb	Ts'amakko		lː				
-tsb	Ts'amakko		rː				
-tsb	Ts'amakko		i				
-tsb	Ts'amakko		e				
-tsb	Ts'amakko		a				
-tsb	Ts'amakko		o				
-tsb	Ts'amakko		u				
-tsb	Ts'amakko		iː				
-tsb	Ts'amakko		oː				
-tsb	Ts'amakko		eː				
-tsb	Ts'amakko		aː				
-tsb	Ts'amakko		uː				
-tsb	Ts'amakko		˦				
-tsb	Ts'amakko		˨				
-							
+tsb	Ts'amakko		p		[pʰ]
+tsb	Ts'amakko		p		[f]
+tsb	Ts'amakko		p		[ɸ]
+tsb	Ts'amakko		b
+tsb	Ts'amakko		t
+tsb	Ts'amakko		d
+tsb	Ts'amakko		k
+tsb	Ts'amakko		ɡ
+tsb	Ts'amakko		ʔ
+tsb	Ts'amakko		s
+tsb	Ts'amakko		z
+tsb	Ts'amakko		ʃ
+tsb	Ts'amakko		ʒ		[ʒ]
+tsb	Ts'amakko		ʒ		[d̠ʒ]
+tsb	Ts'amakko		x		[χ]
+tsb	Ts'amakko		x		[χ̃]	voiceless trilled uvular pulmonic fricative
+tsb	Ts'amakko		ħ		[ħ]
+tsb	Ts'amakko		ħ		[ħ̃]	voiceless trilled pharynɡeal pulmonic fricative
+tsb	Ts'amakko		ʕ		[ʕ]
+tsb	Ts'amakko		ʕ		[ʕˀ]	voiced ɡlottalized pharynɡeal pulmonic fricative
+tsb	Ts'amakko		h
+tsb	Ts'amakko		m
+tsb	Ts'amakko		n		[n]
+tsb	Ts'amakko		n		[m]
+tsb	Ts'amakko		n		[ŋ]
+tsb	Ts'amakko		ɲ
+tsb	Ts'amakko		c		[t̠ʃ]
+tsb	Ts'amakko		c		[t̠ʃʼ]
+tsb	Ts'amakko		qʼ		[qʼ]
+tsb	Ts'amakko		qʼ		[qxʼ]
+tsb	Ts'amakko		qʼ		[ʛ̥]
+tsb	Ts'amakko		qʼ		[ʛ]
+tsb	Ts'amakko		tsʼ		[tsʼ]
+tsb	Ts'amakko		tsʼ		[sʼ]
+tsb	Ts'amakko		ɓ		[ɓ]
+tsb	Ts'amakko		ɓ		[ɓ̥]
+tsb	Ts'amakko		ɗ		[ɗ̺]
+tsb	Ts'amakko		ɗ		[ɗ]
+tsb	Ts'amakko		ɠ		[ɠ]
+tsb	Ts'amakko		ɠ		[ɠ̥]
+tsb	Ts'amakko		w
+tsb	Ts'amakko		j
+tsb	Ts'amakko		l
+tsb	Ts'amakko		r
+tsb	Ts'amakko		pː		[pː]
+tsb	Ts'amakko		pː		[pʰː]
+tsb	Ts'amakko		pː		[fː]
+tsb	Ts'amakko		ʃː
+tsb	Ts'amakko		ɓː
+tsb	Ts'amakko		ɠː
+tsb	Ts'amakko		hː
+tsb	Ts'amakko		cː		[t̠ʃː]
+tsb	Ts'amakko		ɲː
+tsb	Ts'amakko		bː
+tsb	Ts'amakko		tː
+tsb	Ts'amakko		dː
+tsb	Ts'amakko		kː
+tsb	Ts'amakko		ɡː
+tsb	Ts'amakko		ʔː
+tsb	Ts'amakko		d̠ʒː
+tsb	Ts'amakko		sː
+tsb	Ts'amakko		zː
+tsb	Ts'amakko		xː		[χː]
+tsb	Ts'amakko		ħː
+tsb	Ts'amakko		ʕː
+tsb	Ts'amakko		mː
+tsb	Ts'amakko		nː
+tsb	Ts'amakko		qʼː		[qʼː]
+tsb	Ts'amakko		qʼː		[ʛː]
+tsb	Ts'amakko		qʼː		[ʛ̥ː]
+tsb	Ts'amakko		cʼː		[t̠ʃʼː]
+tsb	Ts'amakko		tsʼː		[tsʼː]
+tsb	Ts'amakko		tsʼː		[sʼː]
+tsb	Ts'amakko		ɗ		[ˀd̺ː]
+tsb	Ts'amakko		wː
+tsb	Ts'amakko		jː
+tsb	Ts'amakko		lː
+tsb	Ts'amakko		rː
+tsb	Ts'amakko		i
+tsb	Ts'amakko		e
+tsb	Ts'amakko		a
+tsb	Ts'amakko		o
+tsb	Ts'amakko		u
+tsb	Ts'amakko		iː
+tsb	Ts'amakko		oː
+tsb	Ts'amakko		eː
+tsb	Ts'amakko		aː
+tsb	Ts'amakko		uː
+tsb	Ts'amakko		˦
+tsb	Ts'amakko		˨
+
 tzm	Tamazight Berber		a		[a]		Hdouch_tzm.pdf
-tzm	Tamazight Berber		a		[æ]	with emphatic consonants	
-tzm	Tamazight Berber		i		[i]		
-tzm	Tamazight Berber		i		[ɛ]	with emphatic consonants	
-tzm	Tamazight Berber		u		[u]		
-tzm	Tamazight Berber		u		[ɔ]	with emphatic consonants	
-tzm	Tamazight Berber		b				
-tzm	Tamazight Berber		f				
-tzm	Tamazight Berber		m				
-tzm	Tamazight Berber		w				
-tzm	Tamazight Berber		t				
-tzm	Tamazight Berber		tˀ				
-tzm	Tamazight Berber		d				
-tzm	Tamazight Berber		dˀ				
-tzm	Tamazight Berber		s				
-tzm	Tamazight Berber		sˀ				
-tzm	Tamazight Berber		z				
-tzm	Tamazight Berber		zˀ				
-tzm	Tamazight Berber		n				
-tzm	Tamazight Berber		l				
-tzm	Tamazight Berber		lˀ				
-tzm	Tamazight Berber		r				
-tzm	Tamazight Berber		rˀ				
-tzm	Tamazight Berber		ʃ				
-tzm	Tamazight Berber		ʃˀ				
-tzm	Tamazight Berber		ʒ				
-tzm	Tamazight Berber		ʒˀ				
-tzm	Tamazight Berber		j				
-tzm	Tamazight Berber		k				
-tzm	Tamazight Berber		kʷ				
-tzm	Tamazight Berber		x				
-tzm	Tamazight Berber		xʷ				
-tzm	Tamazight Berber		ɡ				
-tzm	Tamazight Berber		ɡʷ				
-tzm	Tamazight Berber		q				
-tzm	Tamazight Berber		qʷ				
-tzm	Tamazight Berber		ɣ				
-tzm	Tamazight Berber		ɣʷ				
-tzm	Tamazight Berber		ɣˀ				
-tzm	Tamazight Berber		ħ				
-tzm	Tamazight Berber		h				
-tzm	Tamazight Berber		ʕ	this is marked as [ɛ] in the source, but I'm assuming this is not correct, in comparison to other Berber languages			
-							
+tzm	Tamazight Berber		a		[æ]	with emphatic consonants
+tzm	Tamazight Berber		i		[i]
+tzm	Tamazight Berber		i		[ɛ]	with emphatic consonants
+tzm	Tamazight Berber		u		[u]
+tzm	Tamazight Berber		u		[ɔ]	with emphatic consonants
+tzm	Tamazight Berber		b
+tzm	Tamazight Berber		f
+tzm	Tamazight Berber		m
+tzm	Tamazight Berber		w
+tzm	Tamazight Berber		t
+tzm	Tamazight Berber		tˀ
+tzm	Tamazight Berber		d
+tzm	Tamazight Berber		dˀ
+tzm	Tamazight Berber		s
+tzm	Tamazight Berber		sˀ
+tzm	Tamazight Berber		z
+tzm	Tamazight Berber		zˀ
+tzm	Tamazight Berber		n
+tzm	Tamazight Berber		l
+tzm	Tamazight Berber		lˀ
+tzm	Tamazight Berber		r
+tzm	Tamazight Berber		rˀ
+tzm	Tamazight Berber		ʃ
+tzm	Tamazight Berber		ʃˀ
+tzm	Tamazight Berber		ʒ
+tzm	Tamazight Berber		ʒˀ
+tzm	Tamazight Berber		j
+tzm	Tamazight Berber		k
+tzm	Tamazight Berber		kʷ
+tzm	Tamazight Berber		x
+tzm	Tamazight Berber		xʷ
+tzm	Tamazight Berber		ɡ
+tzm	Tamazight Berber		ɡʷ
+tzm	Tamazight Berber		q
+tzm	Tamazight Berber		qʷ
+tzm	Tamazight Berber		ɣ
+tzm	Tamazight Berber		ɣʷ
+tzm	Tamazight Berber		ɣˀ
+tzm	Tamazight Berber		ħ
+tzm	Tamazight Berber		h
+tzm	Tamazight Berber		ʕ	this is marked as [ɛ] in the source, but I'm assuming this is not correct, in comparison to other Berber languages
+
 siz	Siwi		b				Walker_siz.pdf
-siz	Siwi		d	thickened slightly, perhaps meaning retroflex			
-siz	Siwi		f				
-siz	Siwi		ɡ				
-siz	Siwi		h				
-siz	Siwi		d̠ʒ				
-siz	Siwi		k				
-siz	Siwi		l		[l]		
-siz	Siwi		l		[lː]	medially	
-siz	Siwi		m				
-siz	Siwi		n				
-siz	Siwi		p				
-siz	Siwi		r				
-siz	Siwi		s				
-siz	Siwi		t				
-siz	Siwi		w				
-siz	Siwi		j				
-siz	Siwi		z				
-siz	Siwi		æ				
-siz	Siwi		a				
-siz	Siwi		ʕ				
-siz	Siwi		ʕː				
-siz	Siwi		ɪ				
-siz	Siwi		ɪː	examples is as in British 'ride'			
-siz	Siwi		ɛ				
-siz	Siwi		e				
-siz	Siwi		i				
-siz	Siwi		o				
-siz	Siwi		ɔ				
-siz	Siwi		u				
-siz	Siwi		ʌ				
-siz	Siwi		ʊ				
-siz	Siwi		ʀ				
-siz	Siwi		t̠ʃ				
-siz	Siwi		ʃ				
-siz	Siwi		ħ		[ħ]		
-siz	Siwi		ħ		[x]		
-siz	Siwi		rː				
-siz	Siwi		sː				
-siz	Siwi		ŋ				
-							
+siz	Siwi		d	thickened slightly, perhaps meaning retroflex
+siz	Siwi		f
+siz	Siwi		ɡ
+siz	Siwi		h
+siz	Siwi		d̠ʒ
+siz	Siwi		k
+siz	Siwi		l		[l]
+siz	Siwi		l		[lː]	medially
+siz	Siwi		m
+siz	Siwi		n
+siz	Siwi		p
+siz	Siwi		r
+siz	Siwi		s
+siz	Siwi		t
+siz	Siwi		w
+siz	Siwi		j
+siz	Siwi		z
+siz	Siwi		æ
+siz	Siwi		a
+siz	Siwi		ʕ
+siz	Siwi		ʕː
+siz	Siwi		ɪ
+siz	Siwi		ɪː	examples is as in British 'ride'
+siz	Siwi		ɛ
+siz	Siwi		e
+siz	Siwi		i
+siz	Siwi		o
+siz	Siwi		ɔ
+siz	Siwi		u
+siz	Siwi		ʌ
+siz	Siwi		ʊ
+siz	Siwi		ʀ
+siz	Siwi		t̠ʃ
+siz	Siwi		ʃ
+siz	Siwi		ħ		[ħ]
+siz	Siwi		ħ		[x]
+siz	Siwi		rː
+siz	Siwi		sː
+siz	Siwi		ŋ
+
 ndj	Ndamba		i				Edelsten_ndj.pdf
-ndj	Ndamba		e				
-ndj	Ndamba		a				
-ndj	Ndamba		u				
-ndj	Ndamba		o				
-ndj	Ndamba		b				
-ndj	Ndamba		t̠ʃ		[t̠ʃ]		
-ndj	Ndamba		t̠ʃ		[d̠ʒ]		
-ndj	Ndamba		d				
-ndj	Ndamba		f		[f]		
-ndj	Ndamba		f		[v]		
-ndj	Ndamba		ɡ				
-ndj	Ndamba		ɣ	alternates with [v] in some contexts			
-ndj	Ndamba		h				
-ndj	Ndamba		d̠ʒ				
-ndj	Ndamba		k		[k]		
-ndj	Ndamba		k		[ɡ]		
-ndj	Ndamba		l				
-ndj	Ndamba		m				
-ndj	Ndamba		n				
-ndj	Ndamba		ŋ				
-ndj	Ndamba		p		[p]		
-ndj	Ndamba		p		[b]		
-ndj	Ndamba		s		[s]		
-ndj	Ndamba		t		[t]		
-ndj	Ndamba		t		[d]		
-ndj	Ndamba		v	alternates with [ɣ] in some contexts			
-ndj	Ndamba		w				
-ndj	Ndamba		j				
-ndj	Ndamba		s		[z]		
-							
+ndj	Ndamba		e
+ndj	Ndamba		a
+ndj	Ndamba		u
+ndj	Ndamba		o
+ndj	Ndamba		b
+ndj	Ndamba		t̠ʃ		[t̠ʃ]
+ndj	Ndamba		t̠ʃ		[d̠ʒ]
+ndj	Ndamba		d
+ndj	Ndamba		f		[f]
+ndj	Ndamba		f		[v]
+ndj	Ndamba		ɡ
+ndj	Ndamba		ɣ	alternates with [v] in some contexts
+ndj	Ndamba		h
+ndj	Ndamba		d̠ʒ
+ndj	Ndamba		k		[k]
+ndj	Ndamba		k		[ɡ]
+ndj	Ndamba		l
+ndj	Ndamba		m
+ndj	Ndamba		n
+ndj	Ndamba		ŋ
+ndj	Ndamba		p		[p]
+ndj	Ndamba		p		[b]
+ndj	Ndamba		s		[s]
+ndj	Ndamba		t		[t]
+ndj	Ndamba		t		[d]
+ndj	Ndamba		v	alternates with [ɣ] in some contexts
+ndj	Ndamba		w
+ndj	Ndamba		j
+ndj	Ndamba		s		[z]
+
 bva	Barein (Jalkiya)	Jalkiya	p				Lovestrand_bva.pdf
-bva	Barein (Jalkiya)	Jalkiya	b				
-bva	Barein (Jalkiya)	Jalkiya	m				
-bva	Barein (Jalkiya)	Jalkiya	w				
-bva	Barein (Jalkiya)	Jalkiya	t				
-bva	Barein (Jalkiya)	Jalkiya	d				
-bva	Barein (Jalkiya)	Jalkiya	s				
-bva	Barein (Jalkiya)	Jalkiya	n				
-bva	Barein (Jalkiya)	Jalkiya	l				
-bva	Barein (Jalkiya)	Jalkiya	r				
-bva	Barein (Jalkiya)	Jalkiya	ɟ				
-bva	Barein (Jalkiya)	Jalkiya	ɲ				
-bva	Barein (Jalkiya)	Jalkiya	j				
-bva	Barein (Jalkiya)	Jalkiya	k				
-bva	Barein (Jalkiya)	Jalkiya	ɡ				
-bva	Barein (Jalkiya)	Jalkiya	ŋ				
-bva	Barein (Jalkiya)	Jalkiya	pː				
-bva	Barein (Jalkiya)	Jalkiya	bː				
-bva	Barein (Jalkiya)	Jalkiya	mː				
-bva	Barein (Jalkiya)	Jalkiya	tː				
-bva	Barein (Jalkiya)	Jalkiya	dː				
-bva	Barein (Jalkiya)	Jalkiya	sː				
-bva	Barein (Jalkiya)	Jalkiya	nː				
-bva	Barein (Jalkiya)	Jalkiya	lː				
-bva	Barein (Jalkiya)	Jalkiya	ɟː				
-bva	Barein (Jalkiya)	Jalkiya	ɲː				
-bva	Barein (Jalkiya)	Jalkiya	kː				
-bva	Barein (Jalkiya)	Jalkiya	ɡː				
-bva	Barein (Jalkiya)	Jalkiya	i				
-bva	Barein (Jalkiya)	Jalkiya	iː				
-bva	Barein (Jalkiya)	Jalkiya	e				
-bva	Barein (Jalkiya)	Jalkiya	eː				
-bva	Barein (Jalkiya)	Jalkiya	a				
-bva	Barein (Jalkiya)	Jalkiya	aː				
-bva	Barein (Jalkiya)	Jalkiya	u				
-bva	Barein (Jalkiya)	Jalkiya	uː				
-bva	Barein (Jalkiya)	Jalkiya	o				
-bva	Barein (Jalkiya)	Jalkiya	oː				
-bva	Barein (Jalkiya)	Jalkiya	˦				
-bva	Barein (Jalkiya)	Jalkiya	˧				
-bva	Barein (Jalkiya)	Jalkiya	˨				
-							
+bva	Barein (Jalkiya)	Jalkiya	b
+bva	Barein (Jalkiya)	Jalkiya	m
+bva	Barein (Jalkiya)	Jalkiya	w
+bva	Barein (Jalkiya)	Jalkiya	t
+bva	Barein (Jalkiya)	Jalkiya	d
+bva	Barein (Jalkiya)	Jalkiya	s
+bva	Barein (Jalkiya)	Jalkiya	n
+bva	Barein (Jalkiya)	Jalkiya	l
+bva	Barein (Jalkiya)	Jalkiya	r
+bva	Barein (Jalkiya)	Jalkiya	ɟ
+bva	Barein (Jalkiya)	Jalkiya	ɲ
+bva	Barein (Jalkiya)	Jalkiya	j
+bva	Barein (Jalkiya)	Jalkiya	k
+bva	Barein (Jalkiya)	Jalkiya	ɡ
+bva	Barein (Jalkiya)	Jalkiya	ŋ
+bva	Barein (Jalkiya)	Jalkiya	pː
+bva	Barein (Jalkiya)	Jalkiya	bː
+bva	Barein (Jalkiya)	Jalkiya	mː
+bva	Barein (Jalkiya)	Jalkiya	tː
+bva	Barein (Jalkiya)	Jalkiya	dː
+bva	Barein (Jalkiya)	Jalkiya	sː
+bva	Barein (Jalkiya)	Jalkiya	nː
+bva	Barein (Jalkiya)	Jalkiya	lː
+bva	Barein (Jalkiya)	Jalkiya	ɟː
+bva	Barein (Jalkiya)	Jalkiya	ɲː
+bva	Barein (Jalkiya)	Jalkiya	kː
+bva	Barein (Jalkiya)	Jalkiya	ɡː
+bva	Barein (Jalkiya)	Jalkiya	i
+bva	Barein (Jalkiya)	Jalkiya	iː
+bva	Barein (Jalkiya)	Jalkiya	e
+bva	Barein (Jalkiya)	Jalkiya	eː
+bva	Barein (Jalkiya)	Jalkiya	a
+bva	Barein (Jalkiya)	Jalkiya	aː
+bva	Barein (Jalkiya)	Jalkiya	u
+bva	Barein (Jalkiya)	Jalkiya	uː
+bva	Barein (Jalkiya)	Jalkiya	o
+bva	Barein (Jalkiya)	Jalkiya	oː
+bva	Barein (Jalkiya)	Jalkiya	˦
+bva	Barein (Jalkiya)	Jalkiya	˧
+bva	Barein (Jalkiya)	Jalkiya	˨
+
 bva	Barein (Giliya)	Giliya	p				Lovestrand_bva.pdf
-bva	Barein (Giliya)	Giliya	b				
-bva	Barein (Giliya)	Giliya	m				
-bva	Barein (Giliya)	Giliya	w				
-bva	Barein (Giliya)	Giliya	t				
-bva	Barein (Giliya)	Giliya	d				
-bva	Barein (Giliya)	Giliya	s				
-bva	Barein (Giliya)	Giliya	n				
-bva	Barein (Giliya)	Giliya	l				
-bva	Barein (Giliya)	Giliya	r				
-bva	Barein (Giliya)	Giliya	ɟ				
-bva	Barein (Giliya)	Giliya	ɲ				
-bva	Barein (Giliya)	Giliya	j				
-bva	Barein (Giliya)	Giliya	k				
-bva	Barein (Giliya)	Giliya	ɡ				
-bva	Barein (Giliya)	Giliya	ŋ				
-bva	Barein (Giliya)	Giliya	i				
-bva	Barein (Giliya)	Giliya	iː				
-bva	Barein (Giliya)	Giliya	e				
-bva	Barein (Giliya)	Giliya	eː				
-bva	Barein (Giliya)	Giliya	a				
-bva	Barein (Giliya)	Giliya	aː				
-bva	Barein (Giliya)	Giliya	o				
-bva	Barein (Giliya)	Giliya	oː				
-bva	Barein (Giliya)	Giliya	u				
-bva	Barein (Giliya)	Giliya	uː				
-bva	Barein (Giliya)	Giliya	˦				
-bva	Barein (Giliya)	Giliya	˧				
-bva	Barein (Giliya)	Giliya	˨				
-							
+bva	Barein (Giliya)	Giliya	b
+bva	Barein (Giliya)	Giliya	m
+bva	Barein (Giliya)	Giliya	w
+bva	Barein (Giliya)	Giliya	t
+bva	Barein (Giliya)	Giliya	d
+bva	Barein (Giliya)	Giliya	s
+bva	Barein (Giliya)	Giliya	n
+bva	Barein (Giliya)	Giliya	l
+bva	Barein (Giliya)	Giliya	r
+bva	Barein (Giliya)	Giliya	ɟ
+bva	Barein (Giliya)	Giliya	ɲ
+bva	Barein (Giliya)	Giliya	j
+bva	Barein (Giliya)	Giliya	k
+bva	Barein (Giliya)	Giliya	ɡ
+bva	Barein (Giliya)	Giliya	ŋ
+bva	Barein (Giliya)	Giliya	i
+bva	Barein (Giliya)	Giliya	iː
+bva	Barein (Giliya)	Giliya	e
+bva	Barein (Giliya)	Giliya	eː
+bva	Barein (Giliya)	Giliya	a
+bva	Barein (Giliya)	Giliya	aː
+bva	Barein (Giliya)	Giliya	o
+bva	Barein (Giliya)	Giliya	oː
+bva	Barein (Giliya)	Giliya	u
+bva	Barein (Giliya)	Giliya	uː
+bva	Barein (Giliya)	Giliya	˦
+bva	Barein (Giliya)	Giliya	˧
+bva	Barein (Giliya)	Giliya	˨
+
 bva	Barein (Jalking)	Jalking	p				Lovestrand_bva.pdf
-bva	Barein (Jalking)	Jalking	b				
-bva	Barein (Jalking)	Jalking	m				
-bva	Barein (Jalking)	Jalking	w				
-bva	Barein (Jalking)	Jalking	t				
-bva	Barein (Jalking)	Jalking	d				
-bva	Barein (Jalking)	Jalking	s				
-bva	Barein (Jalking)	Jalking	n				
-bva	Barein (Jalking)	Jalking	l				
-bva	Barein (Jalking)	Jalking	r				
-bva	Barein (Jalking)	Jalking	ɟ				
-bva	Barein (Jalking)	Jalking	ɲ				
-bva	Barein (Jalking)	Jalking	j				
-bva	Barein (Jalking)	Jalking	k				
-bva	Barein (Jalking)	Jalking	ɡ				
-bva	Barein (Jalking)	Jalking	ŋ				
-bva	Barein (Jalking)	Jalking	pː				
-bva	Barein (Jalking)	Jalking	bː				
-bva	Barein (Jalking)	Jalking	mː				
-bva	Barein (Jalking)	Jalking	tː				
-bva	Barein (Jalking)	Jalking	dː				
-bva	Barein (Jalking)	Jalking	sː				
-bva	Barein (Jalking)	Jalking	nː				
-bva	Barein (Jalking)	Jalking	lː				
-bva	Barein (Jalking)	Jalking	rː				
-bva	Barein (Jalking)	Jalking	ɟː				
-bva	Barein (Jalking)	Jalking	ɲː				
-bva	Barein (Jalking)	Jalking	jː				
-bva	Barein (Jalking)	Jalking	kː				
-bva	Barein (Jalking)	Jalking	ɡː				
-bva	Barein (Jalking)	Jalking	ŋː				
-bva	Barein (Jalking)	Jalking	i				
-bva	Barein (Jalking)	Jalking	iː				
-bva	Barein (Jalking)	Jalking	e				
-bva	Barein (Jalking)	Jalking	eː				
-bva	Barein (Jalking)	Jalking	a				
-bva	Barein (Jalking)	Jalking	aː				
-bva	Barein (Jalking)	Jalking	u				
-bva	Barein (Jalking)	Jalking	uː				
-bva	Barein (Jalking)	Jalking	o				
-bva	Barein (Jalking)	Jalking	oː				
-bva	Barein (Jalking)	Jalking	˦				
-bva	Barein (Jalking)	Jalking	˧				
-bva	Barein (Jalking)	Jalking	˨				
-							
+bva	Barein (Jalking)	Jalking	b
+bva	Barein (Jalking)	Jalking	m
+bva	Barein (Jalking)	Jalking	w
+bva	Barein (Jalking)	Jalking	t
+bva	Barein (Jalking)	Jalking	d
+bva	Barein (Jalking)	Jalking	s
+bva	Barein (Jalking)	Jalking	n
+bva	Barein (Jalking)	Jalking	l
+bva	Barein (Jalking)	Jalking	r
+bva	Barein (Jalking)	Jalking	ɟ
+bva	Barein (Jalking)	Jalking	ɲ
+bva	Barein (Jalking)	Jalking	j
+bva	Barein (Jalking)	Jalking	k
+bva	Barein (Jalking)	Jalking	ɡ
+bva	Barein (Jalking)	Jalking	ŋ
+bva	Barein (Jalking)	Jalking	pː
+bva	Barein (Jalking)	Jalking	bː
+bva	Barein (Jalking)	Jalking	mː
+bva	Barein (Jalking)	Jalking	tː
+bva	Barein (Jalking)	Jalking	dː
+bva	Barein (Jalking)	Jalking	sː
+bva	Barein (Jalking)	Jalking	nː
+bva	Barein (Jalking)	Jalking	lː
+bva	Barein (Jalking)	Jalking	rː
+bva	Barein (Jalking)	Jalking	ɟː
+bva	Barein (Jalking)	Jalking	ɲː
+bva	Barein (Jalking)	Jalking	jː
+bva	Barein (Jalking)	Jalking	kː
+bva	Barein (Jalking)	Jalking	ɡː
+bva	Barein (Jalking)	Jalking	ŋː
+bva	Barein (Jalking)	Jalking	i
+bva	Barein (Jalking)	Jalking	iː
+bva	Barein (Jalking)	Jalking	e
+bva	Barein (Jalking)	Jalking	eː
+bva	Barein (Jalking)	Jalking	a
+bva	Barein (Jalking)	Jalking	aː
+bva	Barein (Jalking)	Jalking	u
+bva	Barein (Jalking)	Jalking	uː
+bva	Barein (Jalking)	Jalking	o
+bva	Barein (Jalking)	Jalking	oː
+bva	Barein (Jalking)	Jalking	˦
+bva	Barein (Jalking)	Jalking	˧
+bva	Barein (Jalking)	Jalking	˨
+
 bva	Barein (Komiya)	Komiya	p				Lovestrand_bva.pdf
-bva	Barein (Komiya)	Komiya	b				
-bva	Barein (Komiya)	Komiya	m				
-bva	Barein (Komiya)	Komiya	w				
-bva	Barein (Komiya)	Komiya	t				
-bva	Barein (Komiya)	Komiya	d				
-bva	Barein (Komiya)	Komiya	ɗ				
-bva	Barein (Komiya)	Komiya	s				
-bva	Barein (Komiya)	Komiya	n				
-bva	Barein (Komiya)	Komiya	l				
-bva	Barein (Komiya)	Komiya	r				
-bva	Barein (Komiya)	Komiya	ɟ				
-bva	Barein (Komiya)	Komiya	ɲ				
-bva	Barein (Komiya)	Komiya	j				
-bva	Barein (Komiya)	Komiya	k				
-bva	Barein (Komiya)	Komiya	ɡ				
-bva	Barein (Komiya)	Komiya	ŋ				
-bva	Barein (Komiya)	Komiya	<h>	rare			
-bva	Barein (Komiya)	Komiya	pː				
-bva	Barein (Komiya)	Komiya	bː				
-bva	Barein (Komiya)	Komiya	mː				
-bva	Barein (Komiya)	Komiya	tː				
-bva	Barein (Komiya)	Komiya	dː				
-bva	Barein (Komiya)	Komiya	ɗː				
-bva	Barein (Komiya)	Komiya	sː				
-bva	Barein (Komiya)	Komiya	nː				
-bva	Barein (Komiya)	Komiya	lː				
-bva	Barein (Komiya)	Komiya	ɟː				
-bva	Barein (Komiya)	Komiya	ɲː				
-bva	Barein (Komiya)	Komiya	jː				
-bva	Barein (Komiya)	Komiya	kː				
-bva	Barein (Komiya)	Komiya	ɡː				
-bva	Barein (Komiya)	Komiya	i				
-bva	Barein (Komiya)	Komiya	iː				
-bva	Barein (Komiya)	Komiya	e				
-bva	Barein (Komiya)	Komiya	eː				
-bva	Barein (Komiya)	Komiya	a				
-bva	Barein (Komiya)	Komiya	aː				
-bva	Barein (Komiya)	Komiya	u				
-bva	Barein (Komiya)	Komiya	uː				
-bva	Barein (Komiya)	Komiya	o				
-bva	Barein (Komiya)	Komiya	oː				
-bva	Barein (Komiya)	Komiya	˦				
-bva	Barein (Komiya)	Komiya	˨				
-							
+bva	Barein (Komiya)	Komiya	b
+bva	Barein (Komiya)	Komiya	m
+bva	Barein (Komiya)	Komiya	w
+bva	Barein (Komiya)	Komiya	t
+bva	Barein (Komiya)	Komiya	d
+bva	Barein (Komiya)	Komiya	ɗ
+bva	Barein (Komiya)	Komiya	s
+bva	Barein (Komiya)	Komiya	n
+bva	Barein (Komiya)	Komiya	l
+bva	Barein (Komiya)	Komiya	r
+bva	Barein (Komiya)	Komiya	ɟ
+bva	Barein (Komiya)	Komiya	ɲ
+bva	Barein (Komiya)	Komiya	j
+bva	Barein (Komiya)	Komiya	k
+bva	Barein (Komiya)	Komiya	ɡ
+bva	Barein (Komiya)	Komiya	ŋ
+bva	Barein (Komiya)	Komiya	<h>	rare
+bva	Barein (Komiya)	Komiya	pː
+bva	Barein (Komiya)	Komiya	bː
+bva	Barein (Komiya)	Komiya	mː
+bva	Barein (Komiya)	Komiya	tː
+bva	Barein (Komiya)	Komiya	dː
+bva	Barein (Komiya)	Komiya	ɗː
+bva	Barein (Komiya)	Komiya	sː
+bva	Barein (Komiya)	Komiya	nː
+bva	Barein (Komiya)	Komiya	lː
+bva	Barein (Komiya)	Komiya	ɟː
+bva	Barein (Komiya)	Komiya	ɲː
+bva	Barein (Komiya)	Komiya	jː
+bva	Barein (Komiya)	Komiya	kː
+bva	Barein (Komiya)	Komiya	ɡː
+bva	Barein (Komiya)	Komiya	i
+bva	Barein (Komiya)	Komiya	iː
+bva	Barein (Komiya)	Komiya	e
+bva	Barein (Komiya)	Komiya	eː
+bva	Barein (Komiya)	Komiya	a
+bva	Barein (Komiya)	Komiya	aː
+bva	Barein (Komiya)	Komiya	u
+bva	Barein (Komiya)	Komiya	uː
+bva	Barein (Komiya)	Komiya	o
+bva	Barein (Komiya)	Komiya	oː
+bva	Barein (Komiya)	Komiya	˦
+bva	Barein (Komiya)	Komiya	˨
+
 tbi	Gaahmg		p				stirtz_tbi.pdf
-tbi	Gaahmg		b		[b]		
-tbi	Gaahmg		b		[w]	bilabial approximant	
-tbi	Gaahmg		b		[b̥]		
-tbi	Gaahmg		f				
-tbi	Gaahmg		fː				
-tbi	Gaahmg		m				
-tbi	Gaahmg		mː				
-tbi	Gaahmg		w				
-tbi	Gaahmg		t̪				
-tbi	Gaahmg		d̪		[d̪]		
-tbi	Gaahmg		d̪		[d̞]		
-tbi	Gaahmg		d̪		[d̪̥]		
-tbi	Gaahmg		d̞	dental approximant			
-tbi	Gaahmg		t				
-tbi	Gaahmg		d				
-tbi	Gaahmg		s				
-tbi	Gaahmg		sː				
-tbi	Gaahmg		n				
-tbi	Gaahmg		nː				
-tbi	Gaahmg		l				
-tbi	Gaahmg		lː				
-tbi	Gaahmg		ɾ				
-tbi	Gaahmg		r				
-tbi	Gaahmg		c				
-tbi	Gaahmg		ɟ		[j]	intervocalic	
-tbi	Gaahmg		ɟ		[ɟ]		
-tbi	Gaahmg		ɟ		[ɟ̥]		
-tbi	Gaahmg		ɲ				
-tbi	Gaahmg		ɲː				
-tbi	Gaahmg		j				
-tbi	Gaahmg		k				
-tbi	Gaahmg		ɡ				
-tbi	Gaahmg		ɡ		[ɡ̥]		
-tbi	Gaahmg		ŋ				
-tbi	Gaahmg		ŋː				
-tbi	Gaahmg		bː		[b]		
-tbi	Gaahmg		ɟː		[ɟ]		
-tbi	Gaahmg		ɡː		[ɡ]		
-tbi	Gaahmg		d̪ː		[d̪]		
-tbi	Gaahmg		dː		[d]		
-tbi	Gaahmg		i				
-tbi	Gaahmg		ɛ				
-tbi	Gaahmg		ə				
-tbi	Gaahmg		a				
-tbi	Gaahmg		u				
-tbi	Gaahmg		ɔ				
-tbi	Gaahmg		iː				
-tbi	Gaahmg		ɛː				
-tbi	Gaahmg		əː				
-tbi	Gaahmg		aː				
-tbi	Gaahmg		uː				
-tbi	Gaahmg		ɔː				
-tbi	Gaahmg		˦				
-tbi	Gaahmg		˧				
-tbi	Gaahmg		˨				
-							
+tbi	Gaahmg		b		[b]
+tbi	Gaahmg		b		[w]	bilabial approximant
+tbi	Gaahmg		b		[b̥]
+tbi	Gaahmg		f
+tbi	Gaahmg		fː
+tbi	Gaahmg		m
+tbi	Gaahmg		mː
+tbi	Gaahmg		w
+tbi	Gaahmg		t̪
+tbi	Gaahmg		d̪		[d̪]
+tbi	Gaahmg		d̪		[d̞]
+tbi	Gaahmg		d̪		[d̪̥]
+tbi	Gaahmg		d̞	dental approximant
+tbi	Gaahmg		t
+tbi	Gaahmg		d
+tbi	Gaahmg		s
+tbi	Gaahmg		sː
+tbi	Gaahmg		n
+tbi	Gaahmg		nː
+tbi	Gaahmg		l
+tbi	Gaahmg		lː
+tbi	Gaahmg		ɾ
+tbi	Gaahmg		r
+tbi	Gaahmg		c
+tbi	Gaahmg		ɟ		[j]	intervocalic
+tbi	Gaahmg		ɟ		[ɟ]
+tbi	Gaahmg		ɟ		[ɟ̥]
+tbi	Gaahmg		ɲ
+tbi	Gaahmg		ɲː
+tbi	Gaahmg		j
+tbi	Gaahmg		k
+tbi	Gaahmg		ɡ
+tbi	Gaahmg		ɡ		[ɡ̥]
+tbi	Gaahmg		ŋ
+tbi	Gaahmg		ŋː
+tbi	Gaahmg		bː		[b]
+tbi	Gaahmg		ɟː		[ɟ]
+tbi	Gaahmg		ɡː		[ɡ]
+tbi	Gaahmg		d̪ː		[d̪]
+tbi	Gaahmg		dː		[d]
+tbi	Gaahmg		i
+tbi	Gaahmg		ɛ
+tbi	Gaahmg		ə
+tbi	Gaahmg		a
+tbi	Gaahmg		u
+tbi	Gaahmg		ɔ
+tbi	Gaahmg		iː
+tbi	Gaahmg		ɛː
+tbi	Gaahmg		əː
+tbi	Gaahmg		aː
+tbi	Gaahmg		uː
+tbi	Gaahmg		ɔː
+tbi	Gaahmg		˦
+tbi	Gaahmg		˧
+tbi	Gaahmg		˨
+
 mij	Mungbam	Munken	<p>	marɡinal			Good_fungom.pdf
-mij	Mungbam	Munken	b				
-mij	Mungbam	Munken	f				
-mij	Mungbam	Munken	m				
-mij	Mungbam	Munken	t̪				
-mij	Mungbam	Munken	d̪				
-mij	Mungbam	Munken	s̪				
-mij	Mungbam	Munken	t̪s̪				
-mij	Mungbam	Munken	d̪z̪				
-mij	Mungbam	Munken	n̪				
-mij	Mungbam	Munken	l̪				
-mij	Mungbam	Munken	ɕ				
-mij	Mungbam	Munken	tɕ				
-mij	Mungbam	Munken	dʑ				
-mij	Mungbam	Munken	ɲ				
-mij	Mungbam	Munken	ɥ				
-mij	Mungbam	Munken	j				
-mij	Mungbam	Munken	k				
-mij	Mungbam	Munken	ɡ				
-mij	Mungbam	Munken	ŋ				
-mij	Mungbam	Munken	kp				
-mij	Mungbam	Munken	ɡb				
-mij	Mungbam	Munken	w				
-mij	Mungbam	Munken	h				
-mij	Mungbam	Munken	i				
-mij	Mungbam	Munken	e				
-mij	Mungbam	Munken	ɛ				
-mij	Mungbam	Munken	<ə>				
-mij	Mungbam	Munken	a				
-mij	Mungbam	Munken	u				
-mij	Mungbam	Munken	o				
-mij	Mungbam	Munken	ɔ				
-mij	Mungbam	Munken	˦				
-mij	Mungbam	Munken	˧				
-mij	Mungbam	Munken	˨				
-mij	Mungbam	Munken	˥				
-							
+mij	Mungbam	Munken	b
+mij	Mungbam	Munken	f
+mij	Mungbam	Munken	m
+mij	Mungbam	Munken	t̪
+mij	Mungbam	Munken	d̪
+mij	Mungbam	Munken	s̪
+mij	Mungbam	Munken	t̪s̪
+mij	Mungbam	Munken	d̪z̪
+mij	Mungbam	Munken	n̪
+mij	Mungbam	Munken	l̪
+mij	Mungbam	Munken	ɕ
+mij	Mungbam	Munken	tɕ
+mij	Mungbam	Munken	dʑ
+mij	Mungbam	Munken	ɲ
+mij	Mungbam	Munken	ɥ
+mij	Mungbam	Munken	j
+mij	Mungbam	Munken	k
+mij	Mungbam	Munken	ɡ
+mij	Mungbam	Munken	ŋ
+mij	Mungbam	Munken	kp
+mij	Mungbam	Munken	ɡb
+mij	Mungbam	Munken	w
+mij	Mungbam	Munken	h
+mij	Mungbam	Munken	i
+mij	Mungbam	Munken	e
+mij	Mungbam	Munken	ɛ
+mij	Mungbam	Munken	<ə>
+mij	Mungbam	Munken	a
+mij	Mungbam	Munken	u
+mij	Mungbam	Munken	o
+mij	Mungbam	Munken	ɔ
+mij	Mungbam	Munken	˦
+mij	Mungbam	Munken	˧
+mij	Mungbam	Munken	˨
+mij	Mungbam	Munken	˥
+
 boe	Mundabli		b				Good_fungom.pdf
-boe	Mundabli		f				
-boe	Mundabli		m				
-boe	Mundabli		t̪				
-boe	Mundabli		d̪				
-boe	Mundabli		s̪				
-boe	Mundabli		t̪s̪				
-boe	Mundabli		d̪z̪				
-boe	Mundabli		n̪				
-boe	Mundabli		l̪				
-boe	Mundabli		ʃ				
-boe	Mundabli		t̠ʃ				
-boe	Mundabli		d̠ʒ				
-boe	Mundabli		ɲ				
-boe	Mundabli		ɥ				
-boe	Mundabli		j				
-boe	Mundabli		k				
-boe	Mundabli		ɡ				
-boe	Mundabli		ŋ				
-boe	Mundabli		kp				
-boe	Mundabli		ɡb				
-boe	Mundabli		w				
-boe	Mundabli		i	produced with some frication		note that the author states that contrastive vowel pharyngealization is a feature of the language, yet the details have not be established phonetically	
-boe	Mundabli		ɨ				
-boe	Mundabli		u	produced with some frication			
-boe	Mundabli		ɪ				
-boe	Mundabli		ʊ				
-boe	Mundabli		e				
-boe	Mundabli		o				
-boe	Mundabli		ɛ				
-boe	Mundabli		ə				
-boe	Mundabli		ɔ				
-boe	Mundabli		a				
-boe	Mundabli		<ɒ>	questionable phonemic status			
-boe	Mundabli		˦				
-boe	Mundabli		˧				
-boe	Mundabli		˨				
-boe	Mundabli		˥				
-							
+boe	Mundabli		f
+boe	Mundabli		m
+boe	Mundabli		t̪
+boe	Mundabli		d̪
+boe	Mundabli		s̪
+boe	Mundabli		t̪s̪
+boe	Mundabli		d̪z̪
+boe	Mundabli		n̪
+boe	Mundabli		l̪
+boe	Mundabli		ʃ
+boe	Mundabli		t̠ʃ
+boe	Mundabli		d̠ʒ
+boe	Mundabli		ɲ
+boe	Mundabli		ɥ
+boe	Mundabli		j
+boe	Mundabli		k
+boe	Mundabli		ɡ
+boe	Mundabli		ŋ
+boe	Mundabli		kp
+boe	Mundabli		ɡb
+boe	Mundabli		w
+boe	Mundabli		i	produced with some frication		note that the author states that contrastive vowel pharyngealization is a feature of the language, yet the details have not be established phonetically
+boe	Mundabli		ɨ
+boe	Mundabli		u	produced with some frication
+boe	Mundabli		ɪ
+boe	Mundabli		ʊ
+boe	Mundabli		e
+boe	Mundabli		o
+boe	Mundabli		ɛ
+boe	Mundabli		ə
+boe	Mundabli		ɔ
+boe	Mundabli		a
+boe	Mundabli		<ɒ>	questionable phonemic status
+boe	Mundabli		˦
+boe	Mundabli		˧
+boe	Mundabli		˨
+boe	Mundabli		˥
+
 muc	Ajumbu		b				Good_fungom.pdf
-muc	Ajumbu		f				
-muc	Ajumbu		v				
-muc	Ajumbu		t̪				
-muc	Ajumbu		d̪				
-muc	Ajumbu		s̪				
-muc	Ajumbu		z̪				
-muc	Ajumbu		t̪s̪				
-muc	Ajumbu		d̪z̪				
-muc	Ajumbu		n̪				
-muc	Ajumbu		l̪				
-muc	Ajumbu		ʃ				
-muc	Ajumbu		<ʒ>	may be an allophone of [z]			
-muc	Ajumbu		t̠ʃ				
-muc	Ajumbu		d̠ʒ				
-muc	Ajumbu		ɲ				
-muc	Ajumbu		ɥ				
-muc	Ajumbu		j				
-muc	Ajumbu		k				
-muc	Ajumbu		ɡ				
-muc	Ajumbu		<ɣ>	rare			
-muc	Ajumbu		ŋ				
-muc	Ajumbu		kp				
-muc	Ajumbu		ɡb				
-muc	Ajumbu		w				
-muc	Ajumbu		ʔ				
-muc	Ajumbu		u		[u]		
-muc	Ajumbu		u		[ɥ]	before [y]	
-muc	Ajumbu		i	note that there may be a vowel lenɡth contrast, but this has not been investiɡated thorouɡhly			
-muc	Ajumbu		y	this is described as a front rounded vowel, althouɡh [ʉ] is used. It is said to sometimes resemeble a whistled fricative vowel.			
-muc	Ajumbu		e				
-muc	Ajumbu		ɛ				
-muc	Ajumbu		ə				
-muc	Ajumbu		a				
-muc	Ajumbu		u				
-muc	Ajumbu		o				
-muc	Ajumbu		ɔ				
-muc	Ajumbu		<ɨ>	this is rare and may be an unrounded fricative counterpart of [ʉ], i.e. [y]			
-muc	Ajumbu		˦				
-muc	Ajumbu		˧				
-muc	Ajumbu		˨				
-							
+muc	Ajumbu		f
+muc	Ajumbu		v
+muc	Ajumbu		t̪
+muc	Ajumbu		d̪
+muc	Ajumbu		s̪
+muc	Ajumbu		z̪
+muc	Ajumbu		t̪s̪
+muc	Ajumbu		d̪z̪
+muc	Ajumbu		n̪
+muc	Ajumbu		l̪
+muc	Ajumbu		ʃ
+muc	Ajumbu		<ʒ>	may be an allophone of [z]
+muc	Ajumbu		t̠ʃ
+muc	Ajumbu		d̠ʒ
+muc	Ajumbu		ɲ
+muc	Ajumbu		ɥ
+muc	Ajumbu		j
+muc	Ajumbu		k
+muc	Ajumbu		ɡ
+muc	Ajumbu		<ɣ>	rare
+muc	Ajumbu		ŋ
+muc	Ajumbu		kp
+muc	Ajumbu		ɡb
+muc	Ajumbu		w
+muc	Ajumbu		ʔ
+muc	Ajumbu		u		[u]
+muc	Ajumbu		u		[ɥ]	before [y]
+muc	Ajumbu		i	note that there may be a vowel lenɡth contrast, but this has not been investiɡated thorouɡhly
+muc	Ajumbu		y	this is described as a front rounded vowel, althouɡh [ʉ] is used. It is said to sometimes resemeble a whistled fricative vowel.
+muc	Ajumbu		e
+muc	Ajumbu		ɛ
+muc	Ajumbu		ə
+muc	Ajumbu		a
+muc	Ajumbu		u
+muc	Ajumbu		o
+muc	Ajumbu		ɔ
+muc	Ajumbu		<ɨ>	this is rare and may be an unrounded fricative counterpart of [ʉ], i.e. [y]
+muc	Ajumbu		˦
+muc	Ajumbu		˧
+muc	Ajumbu		˨
+
 kid	Koshin		b				Good_fungom.pdf
-kid	Koshin		f				
-kid	Koshin		m				
-kid	Koshin		t̪				
-kid	Koshin		d̪				
-kid	Koshin		s̪				
-kid	Koshin		<z̪>	alternative pronunciation of [d̪z̪]			
-kid	Koshin		t̪s̪				
-kid	Koshin		d̪z̪				
-kid	Koshin		n̪				
-kid	Koshin		l̪				
-kid	Koshin		ʃ				
-kid	Koshin		<ʒ>	alternative pronunciation of [d̠ʒ]			
-kid	Koshin		t̠ʃ				
-kid	Koshin		d̠ʒ				
-kid	Koshin		ɲ				
-kid	Koshin		j				
-kid	Koshin		k				
-kid	Koshin		ɡ				
-kid	Koshin		ŋ				
-kid	Koshin		kp				
-kid	Koshin		ɡb				
-kid	Koshin		w				
-kid	Koshin		i̜	fricative vowel			
-kid	Koshin		i	note that there appears to be contrastive nasalization, but a full inventory of nasalized vowels has not been established			
-kid	Koshin		e				
-kid	Koshin		ɛ				
-kid	Koshin		<æ>	rare			
-kid	Koshin		ɨ̜	fricative vowel			
-kid	Koshin		ə				
-kid	Koshin		a				
-kid	Koshin		u				
-kid	Koshin		ɔ				
-kid	Koshin		u̜	fricative vowel			
-kid	Koshin		˦				
-kid	Koshin		˧				
-kid	Koshin		˨				
-							
+kid	Koshin		f
+kid	Koshin		m
+kid	Koshin		t̪
+kid	Koshin		d̪
+kid	Koshin		s̪
+kid	Koshin		<z̪>	alternative pronunciation of [d̪z̪]
+kid	Koshin		t̪s̪
+kid	Koshin		d̪z̪
+kid	Koshin		n̪
+kid	Koshin		l̪
+kid	Koshin		ʃ
+kid	Koshin		<ʒ>	alternative pronunciation of [d̠ʒ]
+kid	Koshin		t̠ʃ
+kid	Koshin		d̠ʒ
+kid	Koshin		ɲ
+kid	Koshin		j
+kid	Koshin		k
+kid	Koshin		ɡ
+kid	Koshin		ŋ
+kid	Koshin		kp
+kid	Koshin		ɡb
+kid	Koshin		w
+kid	Koshin		i̜	fricative vowel
+kid	Koshin		i	note that there appears to be contrastive nasalization, but a full inventory of nasalized vowels has not been established
+kid	Koshin		e
+kid	Koshin		ɛ
+kid	Koshin		<æ>	rare
+kid	Koshin		ɨ̜	fricative vowel
+kid	Koshin		ə
+kid	Koshin		a
+kid	Koshin		u
+kid	Koshin		ɔ
+kid	Koshin		u̜	fricative vowel
+kid	Koshin		˦
+kid	Koshin		˧
+kid	Koshin		˨
+
 fak	Fang		b				Good_fungom.pdf
-fak	Fang		<p>	marɡinal			
-fak	Fang		f				
-fak	Fang		v				
-fak	Fang		m				
-fak	Fang		<ɱ>	marɡinal			
-fak	Fang		t̪				
-fak	Fang		d̪				
-fak	Fang		s̪				
-fak	Fang		t̪s̪				
-fak	Fang		n̪				
-fak	Fang		l̪				
-fak	Fang		ʒ				
-fak	Fang		t̠ʃ				
-fak	Fang		d̠ʒ				
-fak	Fang		ɲ				
-fak	Fang		j				
-fak	Fang		k				
-fak	Fang		ɡ				
-fak	Fang		ŋ				
-fak	Fang		kp				
-fak	Fang		ɡb				
-fak	Fang		w				
-fak	Fang		i̜	fricative vowel			
-fak	Fang		u̜	fricative vowel			
-fak	Fang		i				
-fak	Fang		e				
-fak	Fang		ɛ				
-fak	Fang		ə				
-fak	Fang		a				
-fak	Fang		u				
-fak	Fang		o				
-fak	Fang		ɔ				
-fak	Fang		˦	the tonal system has not been completely analyzed, but there is evidence for at least a three way contrast			
-fak	Fang		˧				
-fak	Fang		˨				
-							
+fak	Fang		<p>	marɡinal
+fak	Fang		f
+fak	Fang		v
+fak	Fang		m
+fak	Fang		<ɱ>	marɡinal
+fak	Fang		t̪
+fak	Fang		d̪
+fak	Fang		s̪
+fak	Fang		t̪s̪
+fak	Fang		n̪
+fak	Fang		l̪
+fak	Fang		ʒ
+fak	Fang		t̠ʃ
+fak	Fang		d̠ʒ
+fak	Fang		ɲ
+fak	Fang		j
+fak	Fang		k
+fak	Fang		ɡ
+fak	Fang		ŋ
+fak	Fang		kp
+fak	Fang		ɡb
+fak	Fang		w
+fak	Fang		i̜	fricative vowel
+fak	Fang		u̜	fricative vowel
+fak	Fang		i
+fak	Fang		e
+fak	Fang		ɛ
+fak	Fang		ə
+fak	Fang		a
+fak	Fang		u
+fak	Fang		o
+fak	Fang		ɔ
+fak	Fang		˦	the tonal system has not been completely analyzed, but there is evidence for at least a three way contrast
+fak	Fang		˧
+fak	Fang		˨
+
 knk	Kuranko		p				Kastenholz_knk.pdf
-knk	Kuranko		b				
-knk	Kuranko		m				
-knk	Kuranko		mb				
-knk	Kuranko		mp				
-knk	Kuranko		w				
-knk	Kuranko		f				
-knk	Kuranko		ɱf				
-knk	Kuranko		ɡb				
-knk	Kuranko		ŋmɡb				
-knk	Kuranko		d				
-knk	Kuranko		t				
-knk	Kuranko		s		[s]		
-knk	Kuranko		s		[ʃ]	in the Western dialect	
-knk	Kuranko		l				
-knk	Kuranko		ɹ				
-knk	Kuranko		n				
-knk	Kuranko		nd				
-knk	Kuranko		nt				
-knk	Kuranko		<c>	̩			
-knk	Kuranko		ɲ				
-knk	Kuranko		j				
-knk	Kuranko		<ɡ>				
-knk	Kuranko		k				
-knk	Kuranko		ŋ		[ŋʷ]		
-knk	Kuranko		ŋk				
-knk	Kuranko		h				
-knk	Kuranko		i				
-knk	Kuranko		e				
-knk	Kuranko		ɛ				
-knk	Kuranko		a				
-knk	Kuranko		ɔ				
-knk	Kuranko		o				
-knk	Kuranko		u				
-knk	Kuranko		iː				
-knk	Kuranko		eː				
-knk	Kuranko		ɛː				
-knk	Kuranko		aː				
-knk	Kuranko		ɔː				
-knk	Kuranko		oː				
-knk	Kuranko		uː				
-knk	Kuranko		ĩ				
-knk	Kuranko		ẽ				
-knk	Kuranko		ɛ̃				
-knk	Kuranko		ã				
-knk	Kuranko		ɔ̃				
-knk	Kuranko		õ				
-knk	Kuranko		ũ				
-knk	Kuranko		ĩː				
-knk	Kuranko		ẽː				
-knk	Kuranko		ɛ̃ː				
-knk	Kuranko		ãː				
-knk	Kuranko		ɔ̃ː				
-knk	Kuranko		õː				
-knk	Kuranko		ũː				
-							
+knk	Kuranko		b
+knk	Kuranko		m
+knk	Kuranko		mb
+knk	Kuranko		mp
+knk	Kuranko		w
+knk	Kuranko		f
+knk	Kuranko		ɱf
+knk	Kuranko		ɡb
+knk	Kuranko		ŋmɡb
+knk	Kuranko		d
+knk	Kuranko		t
+knk	Kuranko		s		[s]
+knk	Kuranko		s		[ʃ]	in the Western dialect
+knk	Kuranko		l
+knk	Kuranko		ɹ
+knk	Kuranko		n
+knk	Kuranko		nd
+knk	Kuranko		nt
+knk	Kuranko		<c>	̩
+knk	Kuranko		ɲ
+knk	Kuranko		j
+knk	Kuranko		<ɡ>
+knk	Kuranko		k
+knk	Kuranko		ŋ		[ŋʷ]
+knk	Kuranko		ŋk
+knk	Kuranko		h
+knk	Kuranko		i
+knk	Kuranko		e
+knk	Kuranko		ɛ
+knk	Kuranko		a
+knk	Kuranko		ɔ
+knk	Kuranko		o
+knk	Kuranko		u
+knk	Kuranko		iː
+knk	Kuranko		eː
+knk	Kuranko		ɛː
+knk	Kuranko		aː
+knk	Kuranko		ɔː
+knk	Kuranko		oː
+knk	Kuranko		uː
+knk	Kuranko		ĩ
+knk	Kuranko		ẽ
+knk	Kuranko		ɛ̃
+knk	Kuranko		ã
+knk	Kuranko		ɔ̃
+knk	Kuranko		õ
+knk	Kuranko		ũ
+knk	Kuranko		ĩː
+knk	Kuranko		ẽː
+knk	Kuranko		ɛ̃ː
+knk	Kuranko		ãː
+knk	Kuranko		ɔ̃ː
+knk	Kuranko		õː
+knk	Kuranko		ũː
+
 nie	Lwaa		p				Boyeldieu_boua.pdf
-nie	Lwaa		b				
-nie	Lwaa		ɓ				
-nie	Lwaa		mb				
-nie	Lwaa		m				
-nie	Lwaa		ŋm				
-nie	Lwaa		w				
-nie	Lwaa		t				
-nie	Lwaa		d				
-nie	Lwaa		ɗ				
-nie	Lwaa		s				
-nie	Lwaa		nd				
-nie	Lwaa		n				
-nie	Lwaa		l				
-nie	Lwaa		r				
-nie	Lwaa		c				
-nie	Lwaa		ɟ				
-nie	Lwaa		ɲɟ				
-nie	Lwaa		ɲ				
-nie	Lwaa		j				
-nie	Lwaa		k				
-nie	Lwaa		ɡ				
-nie	Lwaa		ʔ				
-nie	Lwaa		h				
-nie	Lwaa		ŋɡ				
-nie	Lwaa		i				
-nie	Lwaa		e				
-nie	Lwaa		ia				
-nie	Lwaa		ə				
-nie	Lwaa		a				
-nie	Lwaa		u				
-nie	Lwaa		o				
-nie	Lwaa		ua				
-nie	Lwaa		iː				
-nie	Lwaa		eː				
-nie	Lwaa		iaː				
-nie	Lwaa		əː				
-nie	Lwaa		aː				
-nie	Lwaa		uː				
-nie	Lwaa		oː				
-nie	Lwaa		uaː				
-nie	Lwaa		ĩ				
-nie	Lwaa		ẽ				
-nie	Lwaa		iã				
-nie	Lwaa		ə̃				
-nie	Lwaa		ã				
-nie	Lwaa		ũ				
-nie	Lwaa		õ				
-nie	Lwaa		uã				
-nie	Lwaa		ĩː				
-nie	Lwaa		jãː				
-nie	Lwaa		ə̃ː				
-nie	Lwaa		ãː				
-nie	Lwaa		ũː				
-nie	Lwaa		õː				
-nie	Lwaa		uãː				
-nie	Lwaa		˦				
-nie	Lwaa		˧				
-nie	Lwaa		˨				
-							
+nie	Lwaa		b
+nie	Lwaa		ɓ
+nie	Lwaa		mb
+nie	Lwaa		m
+nie	Lwaa		ŋm
+nie	Lwaa		w
+nie	Lwaa		t
+nie	Lwaa		d
+nie	Lwaa		ɗ
+nie	Lwaa		s
+nie	Lwaa		nd
+nie	Lwaa		n
+nie	Lwaa		l
+nie	Lwaa		r
+nie	Lwaa		c
+nie	Lwaa		ɟ
+nie	Lwaa		ɲɟ
+nie	Lwaa		ɲ
+nie	Lwaa		j
+nie	Lwaa		k
+nie	Lwaa		ɡ
+nie	Lwaa		ʔ
+nie	Lwaa		h
+nie	Lwaa		ŋɡ
+nie	Lwaa		i
+nie	Lwaa		e
+nie	Lwaa		ia
+nie	Lwaa		ə
+nie	Lwaa		a
+nie	Lwaa		u
+nie	Lwaa		o
+nie	Lwaa		ua
+nie	Lwaa		iː
+nie	Lwaa		eː
+nie	Lwaa		iaː
+nie	Lwaa		əː
+nie	Lwaa		aː
+nie	Lwaa		uː
+nie	Lwaa		oː
+nie	Lwaa		uaː
+nie	Lwaa		ĩ
+nie	Lwaa		ẽ
+nie	Lwaa		iã
+nie	Lwaa		ə̃
+nie	Lwaa		ã
+nie	Lwaa		ũ
+nie	Lwaa		õ
+nie	Lwaa		uã
+nie	Lwaa		ĩː
+nie	Lwaa		jãː
+nie	Lwaa		ə̃ː
+nie	Lwaa		ãː
+nie	Lwaa		ũː
+nie	Lwaa		õː
+nie	Lwaa		uãː
+nie	Lwaa		˦
+nie	Lwaa		˧
+nie	Lwaa		˨
+
 gis	Gisiga	North	b				Lukas_gis.pdf
-gis	Gisiga	North	mb				
-gis	Gisiga	North	ɓ				
-gis	Gisiga	North	f				
-gis	Gisiga	North	v				
-gis	Gisiga	North	t				
-gis	Gisiga	North	d				
-gis	Gisiga	North	nd				
-gis	Gisiga	North	ɗ				
-gis	Gisiga	North	t̠ʃ		[t̠ʃ]		
-gis	Gisiga	North	t̠ʃ		[ts]		
-gis	Gisiga	North	d̠ʒ		[d̠ʒ]		
-gis	Gisiga	North	d̠ʒ		[dz]		
-gis	Gisiga	North	s		[s]		
-gis	Gisiga	North	s		[ʃ]		
-gis	Gisiga	North	z		[z]		
-gis	Gisiga	North	z		[ʒ]		
-gis	Gisiga	North	ndz				
-gis	Gisiga	North	n				
-gis	Gisiga	North	l				
-gis	Gisiga	North	ɬ				
-gis	Gisiga	North	ɮ				
-gis	Gisiga	North	r				
-gis	Gisiga	North	j				
-gis	Gisiga	North	k				
-gis	Gisiga	North	ɡ				
-gis	Gisiga	North	ŋɡ				
-gis	Gisiga	North	kʷ				
-gis	Gisiga	North	ɡʷ				
-gis	Gisiga	North	ŋ				
-gis	Gisiga	North	w				
-gis	Gisiga	North	ʔ				
-gis	Gisiga	North	h				
-gis	Gisiga	North	a		[a]		
-gis	Gisiga	North	a		[ə]		
-gis	Gisiga	North	e		[e]		
-gis	Gisiga	North	e		[i]		
-gis	Gisiga	North	o		[o]		
-gis	Gisiga	North	o		[u]		
-gis	Gisiga	North	˦				
-gis	Gisiga	North	˧				
-gis	Gisiga	North	˨				
-gis	Gisiga	North	˩˥				
-gis	Gisiga	North	˥˩				
-							
+gis	Gisiga	North	mb
+gis	Gisiga	North	ɓ
+gis	Gisiga	North	f
+gis	Gisiga	North	v
+gis	Gisiga	North	t
+gis	Gisiga	North	d
+gis	Gisiga	North	nd
+gis	Gisiga	North	ɗ
+gis	Gisiga	North	t̠ʃ		[t̠ʃ]
+gis	Gisiga	North	t̠ʃ		[ts]
+gis	Gisiga	North	d̠ʒ		[d̠ʒ]
+gis	Gisiga	North	d̠ʒ		[dz]
+gis	Gisiga	North	s		[s]
+gis	Gisiga	North	s		[ʃ]
+gis	Gisiga	North	z		[z]
+gis	Gisiga	North	z		[ʒ]
+gis	Gisiga	North	ndz
+gis	Gisiga	North	n
+gis	Gisiga	North	l
+gis	Gisiga	North	ɬ
+gis	Gisiga	North	ɮ
+gis	Gisiga	North	r
+gis	Gisiga	North	j
+gis	Gisiga	North	k
+gis	Gisiga	North	ɡ
+gis	Gisiga	North	ŋɡ
+gis	Gisiga	North	kʷ
+gis	Gisiga	North	ɡʷ
+gis	Gisiga	North	ŋ
+gis	Gisiga	North	w
+gis	Gisiga	North	ʔ
+gis	Gisiga	North	h
+gis	Gisiga	North	a		[a]
+gis	Gisiga	North	a		[ə]
+gis	Gisiga	North	e		[e]
+gis	Gisiga	North	e		[i]
+gis	Gisiga	North	o		[o]
+gis	Gisiga	North	o		[u]
+gis	Gisiga	North	˦
+gis	Gisiga	North	˧
+gis	Gisiga	North	˨
+gis	Gisiga	North	˩˥
+gis	Gisiga	North	˥˩
+
 mgo	Moghamo		p				Mbah_mgo.pdf
-mgo	Moghamo		b				
-mgo	Moghamo		t				
-mgo	Moghamo		d		[d]		
-mgo	Moghamo		d		[ɾ]	stem-medial	
-mgo	Moghamo		k		[k]		
-mgo	Moghamo		k		[ʔ]	syllable-final or intervocalic	
-mgo	Moghamo		ɡ				
-mgo	Moghamo		d̠ʒ				
-mgo	Moghamo		t̠ʃ				
-mgo	Moghamo		f				
-mgo	Moghamo		s	varies with [ʃ]			
-mgo	Moghamo		z	varies with [ʒ]			
-mgo	Moghamo		ɣ				
-mgo	Moghamo		m				
-mgo	Moghamo		n				
-mgo	Moghamo		ŋ				
-mgo	Moghamo		w		[w]		
-mgo	Moghamo		w		[ɥ]	before [i]	
-mgo	Moghamo		mb				
-mgo	Moghamo		nd				
-mgo	Moghamo		ŋɡ				
-mgo	Moghamo		n̠d̠ʒ	source: ndʒ; CG: ɲdʒ changed to n̠d̠ʒ by SM			
-mgo	Moghamo		kʲ				
-mgo	Moghamo		ɡʲ				
-mgo	Moghamo		fʲ				
-mgo	Moghamo		tʷ				
-mgo	Moghamo		dʷ				
-mgo	Moghamo		kʷ				
-mgo	Moghamo		ɡʷ				
-mgo	Moghamo		t̠ʃʷ				
-mgo	Moghamo		d̠ʒʷ				
-mgo	Moghamo		sʷ	varies with [ʃʷ]			
-mgo	Moghamo		zʷ	varies with [ʒʷ]			
-mgo	Moghamo		nʷ				
-mgo	Moghamo		ŋʷ				
-mgo	Moghamo		i	varies with [ɨ]			
-mgo	Moghamo		e	varies with [ɛ]			
-mgo	Moghamo		ə				
-mgo	Moghamo		a				
-mgo	Moghamo		u				
-mgo	Moghamo		o				
-mgo	Moghamo		ɔ				
-mgo	Moghamo		ĩ	varies with [ɨ̃]			
-mgo	Moghamo		ẽ	varies with [ɛ̃]			
-mgo	Moghamo		ə̃				
-mgo	Moghamo		ã				
-mgo	Moghamo		õ				
-mgo	Moghamo		ɔ̃				
-mgo	Moghamo		ũ				
-mgo	Moghamo		˦				
-mgo	Moghamo		˧				
-mgo	Moghamo		˨				
-							
+mgo	Moghamo		b
+mgo	Moghamo		t
+mgo	Moghamo		d		[d]
+mgo	Moghamo		d		[ɾ]	stem-medial
+mgo	Moghamo		k		[k]
+mgo	Moghamo		k		[ʔ]	syllable-final or intervocalic
+mgo	Moghamo		ɡ
+mgo	Moghamo		d̠ʒ
+mgo	Moghamo		t̠ʃ
+mgo	Moghamo		f
+mgo	Moghamo		s	varies with [ʃ]
+mgo	Moghamo		z	varies with [ʒ]
+mgo	Moghamo		ɣ
+mgo	Moghamo		m
+mgo	Moghamo		n
+mgo	Moghamo		ŋ
+mgo	Moghamo		w		[w]
+mgo	Moghamo		w		[ɥ]	before [i]
+mgo	Moghamo		mb
+mgo	Moghamo		nd
+mgo	Moghamo		ŋɡ
+mgo	Moghamo		n̠d̠ʒ	source: ndʒ; CG: ɲdʒ changed to n̠d̠ʒ by SM
+mgo	Moghamo		kʲ
+mgo	Moghamo		ɡʲ
+mgo	Moghamo		fʲ
+mgo	Moghamo		tʷ
+mgo	Moghamo		dʷ
+mgo	Moghamo		kʷ
+mgo	Moghamo		ɡʷ
+mgo	Moghamo		t̠ʃʷ
+mgo	Moghamo		d̠ʒʷ
+mgo	Moghamo		sʷ	varies with [ʃʷ]
+mgo	Moghamo		zʷ	varies with [ʒʷ]
+mgo	Moghamo		nʷ
+mgo	Moghamo		ŋʷ
+mgo	Moghamo		i	varies with [ɨ]
+mgo	Moghamo		e	varies with [ɛ]
+mgo	Moghamo		ə
+mgo	Moghamo		a
+mgo	Moghamo		u
+mgo	Moghamo		o
+mgo	Moghamo		ɔ
+mgo	Moghamo		ĩ	varies with [ɨ̃]
+mgo	Moghamo		ẽ	varies with [ɛ̃]
+mgo	Moghamo		ə̃
+mgo	Moghamo		ã
+mgo	Moghamo		õ
+mgo	Moghamo		ɔ̃
+mgo	Moghamo		ũ
+mgo	Moghamo		˦
+mgo	Moghamo		˧
+mgo	Moghamo		˨
+
 bri	Mokpwe		p		[p]		Neg_bri.pdf
-bri	Mokpwe		p		[b]	intervocalic	
-bri	Mokpwe		ɸ				
-bri	Mokpwe		b		[b]	intervocalic	
-bri	Mokpwe		b		[bʷ]		
-bri	Mokpwe		β				
-bri	Mokpwe		m				
-bri	Mokpwe		mb				
-bri	Mokpwe		n				
-bri	Mokpwe		nd				
-bri	Mokpwe		l				
-bri	Mokpwe		t				
-bri	Mokpwe		d̠ʒ				
-bri	Mokpwe		ʒ	voiced, prepalatal fricative			
-bri	Mokpwe		n̠d̠ʒ	changed from ɲdʒ to n̠d̠ʒ (text says pre-palatal, pg 17)			
-bri	Mokpwe		ɲ				
-bri	Mokpwe		j				
-bri	Mokpwe		k				
-bri	Mokpwe		kp				
-bri	Mokpwe		ɡb				
-bri	Mokpwe		ŋmɡb	source: ŋɡb			
-bri	Mokpwe		ŋɡ				
-bri	Mokpwe		w				
-bri	Mokpwe		hʷ	labialized ɡlottal fricative			
-bri	Mokpwe		i		[i]		
-bri	Mokpwe		e		[e]		
-bri	Mokpwe		ɛ		[ɛ]		
-bri	Mokpwe		a		[a]		
-bri	Mokpwe		u		[u]		
-bri	Mokpwe		o		[o]		
-bri	Mokpwe		ɔ		[ɔ]		
-bri	Mokpwe		i		[iː]		
-bri	Mokpwe		e		[eː]		
-bri	Mokpwe		ɛ		[ɛː]		
-bri	Mokpwe		a		[aː]		
-bri	Mokpwe		u		[uː]		
-bri	Mokpwe		o		[oː]		
-bri	Mokpwe		ɔ		[ɔː]		
-bri	Mokpwe		˦				
-bri	Mokpwe		˨				
-							
+bri	Mokpwe		p		[b]	intervocalic
+bri	Mokpwe		ɸ
+bri	Mokpwe		b		[b]	intervocalic
+bri	Mokpwe		b		[bʷ]
+bri	Mokpwe		β
+bri	Mokpwe		m
+bri	Mokpwe		mb
+bri	Mokpwe		n
+bri	Mokpwe		nd
+bri	Mokpwe		l
+bri	Mokpwe		t
+bri	Mokpwe		d̠ʒ
+bri	Mokpwe		ʒ	voiced, prepalatal fricative
+bri	Mokpwe		n̠d̠ʒ	changed from ɲdʒ to n̠d̠ʒ (text says pre-palatal, pg 17)
+bri	Mokpwe		ɲ
+bri	Mokpwe		j
+bri	Mokpwe		k
+bri	Mokpwe		kp
+bri	Mokpwe		ɡb
+bri	Mokpwe		ŋmɡb	source: ŋɡb
+bri	Mokpwe		ŋɡ
+bri	Mokpwe		w
+bri	Mokpwe		hʷ	labialized ɡlottal fricative
+bri	Mokpwe		i		[i]
+bri	Mokpwe		e		[e]
+bri	Mokpwe		ɛ		[ɛ]
+bri	Mokpwe		a		[a]
+bri	Mokpwe		u		[u]
+bri	Mokpwe		o		[o]
+bri	Mokpwe		ɔ		[ɔ]
+bri	Mokpwe		i		[iː]
+bri	Mokpwe		e		[eː]
+bri	Mokpwe		ɛ		[ɛː]
+bri	Mokpwe		a		[aː]
+bri	Mokpwe		u		[uː]
+bri	Mokpwe		o		[oː]
+bri	Mokpwe		ɔ		[ɔː]
+bri	Mokpwe		˦
+bri	Mokpwe		˨
+
 sif	Siamou		<p>	rare, borrowings			Haas_sif.pdf
-sif	Siamou		b		[b]		
-sif	Siamou		b		[bʲ]		
-sif	Siamou		b		[bʷ]		
-sif	Siamou		v				
-sif	Siamou		f		[f]		
-sif	Siamou		f		[fʲ]		
-sif	Siamou		f		[fʷ]		
-sif	Siamou		m		[mʷ]		
-sif	Siamou		m		[m]		
-sif	Siamou		m		[mʲ]		
-sif	Siamou		w				
-sif	Siamou		d		[d]		
-sif	Siamou		d		[dʷ]		
-sif	Siamou		d		[dʲ]		
-sif	Siamou		t		[t]		
-sif	Siamou		t		[tʷ]		
-sif	Siamou		t		[tʲ]		
-sif	Siamou		s				
-sif	Siamou		n		[n]		
-sif	Siamou		n		[nʲ]		
-sif	Siamou		n		[nʷ]		
-sif	Siamou		l				
-sif	Siamou		r				
-sif	Siamou		ɟ		[ɡʲ]		
-sif	Siamou		ʃ				
-sif	Siamou		ɲ				
-sif	Siamou		j				
-sif	Siamou		k		[ɡ]	intervocalic	
-sif	Siamou		k		[k]		
-sif	Siamou		<h>	rare			
-sif	Siamou		kp				
-sif	Siamou		ɡb				
-sif	Siamou		ŋm				
-sif	Siamou		c		[kʲ]		
-sif	Siamou		i				
-sif	Siamou		i				
-sif	Siamou		ĩ				
-sif	Siamou		y	only in closed syllables			
-sif	Siamou		e				
-sif	Siamou		ɛ				
-sif	Siamou		ɛ̃				
-sif	Siamou		<ə>	in unstressed syllables			
-sif	Siamou		a				
-sif	Siamou		ã				
-sif	Siamou		u				
-sif	Siamou		o				
-sif	Siamou		ɔ				
-sif	Siamou		ɔ̃				
-sif	Siamou		ɯ	only in closed syllables			
-sif	Siamou		˦				
-sif	Siamou		˧		[˧]		
-sif	Siamou		˨				
-sif	Siamou		˥˩	High-Mid			
-sif	Siamou		˥˩	High-Low			
-sif	Siamou		˦˥				
-sif	Siamou		˧		[˦˥]		
-							
+sif	Siamou		b		[b]
+sif	Siamou		b		[bʲ]
+sif	Siamou		b		[bʷ]
+sif	Siamou		v
+sif	Siamou		f		[f]
+sif	Siamou		f		[fʲ]
+sif	Siamou		f		[fʷ]
+sif	Siamou		m		[mʷ]
+sif	Siamou		m		[m]
+sif	Siamou		m		[mʲ]
+sif	Siamou		w
+sif	Siamou		d		[d]
+sif	Siamou		d		[dʷ]
+sif	Siamou		d		[dʲ]
+sif	Siamou		t		[t]
+sif	Siamou		t		[tʷ]
+sif	Siamou		t		[tʲ]
+sif	Siamou		s
+sif	Siamou		n		[n]
+sif	Siamou		n		[nʲ]
+sif	Siamou		n		[nʷ]
+sif	Siamou		l
+sif	Siamou		r
+sif	Siamou		ɟ		[ɡʲ]
+sif	Siamou		ʃ
+sif	Siamou		ɲ
+sif	Siamou		j
+sif	Siamou		k		[ɡ]	intervocalic
+sif	Siamou		k		[k]
+sif	Siamou		<h>	rare
+sif	Siamou		kp
+sif	Siamou		ɡb
+sif	Siamou		ŋm
+sif	Siamou		c		[kʲ]
+sif	Siamou		i
+sif	Siamou		i
+sif	Siamou		ĩ
+sif	Siamou		y	only in closed syllables
+sif	Siamou		e
+sif	Siamou		ɛ
+sif	Siamou		ɛ̃
+sif	Siamou		<ə>	in unstressed syllables
+sif	Siamou		a
+sif	Siamou		ã
+sif	Siamou		u
+sif	Siamou		o
+sif	Siamou		ɔ
+sif	Siamou		ɔ̃
+sif	Siamou		ɯ	only in closed syllables
+sif	Siamou		˦
+sif	Siamou		˧		[˧]
+sif	Siamou		˨
+sif	Siamou		˥˩	High-Mid
+sif	Siamou		˥˩	High-Low
+sif	Siamou		˦˥
+sif	Siamou		˧		[˦˥]
+
 nnh	Ngiemboon		b		[b]		Anderson_nnh.pdf
-nnh	Ngiemboon		pf				
-nnh	Ngiemboon		f				
-nnh	Ngiemboon		v		[v]	word-initial	
-nnh	Ngiemboon		m		[m]		
-nnh	Ngiemboon		t		[t̪]		
-nnh	Ngiemboon		d		[d̪]		
-nnh	Ngiemboon		ts		[ts]		
-nnh	Ngiemboon		s		[s]		
-nnh	Ngiemboon		z		[z]	word-initial	
-nnh	Ngiemboon		n		[n̪]		
-nnh	Ngiemboon		j		[j]	word-initial	
-nnh	Ngiemboon		k		[k]		
-nnh	Ngiemboon		ɡ		[ɡ]		
-nnh	Ngiemboon		ŋ		[ŋ]		
-nnh	Ngiemboon		w		[w]	word-initial	
-nnh	Ngiemboon		b		[p]	word-initial	
-nnh	Ngiemboon		b		[β]	intervocalic	
-nnh	Ngiemboon		b		[p̚]	utterance-final	
-nnh	Ngiemboon		d		[l̪]	word-initial, intervocalic	
-nnh	Ngiemboon		d		[t]		
-nnh	Ngiemboon		d		[t̚]	utterance-final	
-nnh	Ngiemboon		ɡ		[ɣ]	word-initial	
-nnh	Ngiemboon		ɡ		[ʁ]	intervocalic	
-nnh	Ngiemboon		ɡ		[q]		
-nnh	Ngiemboon		ɡ		[q̚]	utterance-final	
-nnh	Ngiemboon		k		[ʔ]	intervocalic	
-nnh	Ngiemboon		k		[ʔ̚]	utterance-final	
-nnh	Ngiemboon		m		[m̚]	utterance-final	
-nnh	Ngiemboon		ŋ		[ŋ̚]	utterance-final	
-nnh	Ngiemboon		v		[bv]		
-nnh	Ngiemboon		z		[dz]		
-nnh	Ngiemboon		j		[ɡʲ]		
-nnh	Ngiemboon		w		[ɡʷ]		
-nnh	Ngiemboon		s		[ʃ]	before [u],[ʉ]	
-nnh	Ngiemboon		z		[d̠ʒ]	before [u],[ʉ]	
-nnh	Ngiemboon		z		[ʒ]	before [u],[ʉ]	
-nnh	Ngiemboon		ts		[t̠ʃ]	before [u],[ʉ]	
-nnh	Ngiemboon		t		[ʈ]	before [u],[ʉ]	
-nnh	Ngiemboon		d		[ɖ]	before [u],[ʉ]	
-nnh	Ngiemboon		d		[ɭ]	word-initial, before [u],[ʉ]	
-nnh	Ngiemboon		n		[ɳ]	before [u],[ʉ]	
-nnh	Ngiemboon		p		[pɸ]		
-nnh	Ngiemboon		b		[bɸ]		
-nnh	Ngiemboon		t		[t̪θ̪]		
-nnh	Ngiemboon		d		[d̪θ̪]		
-nnh	Ngiemboon		t		[ʈθ̜]		
-nnh	Ngiemboon		d		[ɖθ̜]		
-nnh	Ngiemboon		k		[kx]		
-nnh	Ngiemboon		ɡ		[ɡx]		
-nnh	Ngiemboon		ts		[tsː]		
-nnh	Ngiemboon		ts		[t̠ʃː]		
-nnh	Ngiemboon		pf		[bvf]		
-nnh	Ngiemboon		z		[dzs]		
-nnh	Ngiemboon		z		[d̠ʒʃ]		
-nnh	Ngiemboon		f		[fː]		
-nnh	Ngiemboon		s		[sː]		
-nnh	Ngiemboon		s		[ʃː]		
-nnh	Ngiemboon		v		[vf]		
-nnh	Ngiemboon		z		[zs]		
-nnh	Ngiemboon		z		[ʒʃ]		
-nnh	Ngiemboon		ɡ		[ɣx]		
-nnh	Ngiemboon		d		[l̪ɬ̪]		
-nnh	Ngiemboon		d		[ɭɬ̜]		
-nnh	Ngiemboon		i		[i]		
-nnh	Ngiemboon		i		[iː]		
-nnh	Ngiemboon		i		[ĩ]		
-nnh	Ngiemboon		i		[ĩː]		
-nnh	Ngiemboon		e		[e]		
-nnh	Ngiemboon		e		[eː]		
-nnh	Ngiemboon		e		[ẽ]		
-nnh	Ngiemboon		e		[ẽː]		
-nnh	Ngiemboon		ɛ		[ɛ]		
-nnh	Ngiemboon		ɛ		[ɛ̃]		
-nnh	Ngiemboon		a		[a]		
-nnh	Ngiemboon		a		[aː]		
-nnh	Ngiemboon		a		[ã]		
-nnh	Ngiemboon		ɔ		[ɔ]		
-nnh	Ngiemboon		ɔ		[ɔː]		
-nnh	Ngiemboon		o		[o]		
-nnh	Ngiemboon		o		[oː]		
-nnh	Ngiemboon		o		[õ]		
-nnh	Ngiemboon		o		[õː]		
-nnh	Ngiemboon		u		[u]		
-nnh	Ngiemboon		u		[uː]		
-nnh	Ngiemboon		u		[ũ]		
-nnh	Ngiemboon		u		[ũː]		
-nnh	Ngiemboon		e		[ə]	before syllable-final nasal	
-nnh	Ngiemboon		o		[ɤ]	before syllable-final nasal	
-nnh	Ngiemboon		ɥ		[y]		
-nnh	Ngiemboon		ɰ		[ɯ]		
-nnh	Ngiemboon		˩˥				
-nnh	Ngiemboon		˦	Source: Downstepped High			
-nnh	Ngiemboon		˥˩	Low-Falling			
-nnh	Ngiemboon		˨				
-							
+nnh	Ngiemboon		pf
+nnh	Ngiemboon		f
+nnh	Ngiemboon		v		[v]	word-initial
+nnh	Ngiemboon		m		[m]
+nnh	Ngiemboon		t		[t̪]
+nnh	Ngiemboon		d		[d̪]
+nnh	Ngiemboon		ts		[ts]
+nnh	Ngiemboon		s		[s]
+nnh	Ngiemboon		z		[z]	word-initial
+nnh	Ngiemboon		n		[n̪]
+nnh	Ngiemboon		j		[j]	word-initial
+nnh	Ngiemboon		k		[k]
+nnh	Ngiemboon		ɡ		[ɡ]
+nnh	Ngiemboon		ŋ		[ŋ]
+nnh	Ngiemboon		w		[w]	word-initial
+nnh	Ngiemboon		b		[p]	word-initial
+nnh	Ngiemboon		b		[β]	intervocalic
+nnh	Ngiemboon		b		[p̚]	utterance-final
+nnh	Ngiemboon		d		[l̪]	word-initial, intervocalic
+nnh	Ngiemboon		d		[t]
+nnh	Ngiemboon		d		[t̚]	utterance-final
+nnh	Ngiemboon		ɡ		[ɣ]	word-initial
+nnh	Ngiemboon		ɡ		[ʁ]	intervocalic
+nnh	Ngiemboon		ɡ		[q]
+nnh	Ngiemboon		ɡ		[q̚]	utterance-final
+nnh	Ngiemboon		k		[ʔ]	intervocalic
+nnh	Ngiemboon		k		[ʔ̚]	utterance-final
+nnh	Ngiemboon		m		[m̚]	utterance-final
+nnh	Ngiemboon		ŋ		[ŋ̚]	utterance-final
+nnh	Ngiemboon		v		[bv]
+nnh	Ngiemboon		z		[dz]
+nnh	Ngiemboon		j		[ɡʲ]
+nnh	Ngiemboon		w		[ɡʷ]
+nnh	Ngiemboon		s		[ʃ]	before [u],[ʉ]
+nnh	Ngiemboon		z		[d̠ʒ]	before [u],[ʉ]
+nnh	Ngiemboon		z		[ʒ]	before [u],[ʉ]
+nnh	Ngiemboon		ts		[t̠ʃ]	before [u],[ʉ]
+nnh	Ngiemboon		t		[ʈ]	before [u],[ʉ]
+nnh	Ngiemboon		d		[ɖ]	before [u],[ʉ]
+nnh	Ngiemboon		d		[ɭ]	word-initial, before [u],[ʉ]
+nnh	Ngiemboon		n		[ɳ]	before [u],[ʉ]
+nnh	Ngiemboon		p		[pɸ]
+nnh	Ngiemboon		b		[bɸ]
+nnh	Ngiemboon		t		[t̪θ̪]
+nnh	Ngiemboon		d		[d̪θ̪]
+nnh	Ngiemboon		t		[ʈθ̜]
+nnh	Ngiemboon		d		[ɖθ̜]
+nnh	Ngiemboon		k		[kx]
+nnh	Ngiemboon		ɡ		[ɡx]
+nnh	Ngiemboon		ts		[tsː]
+nnh	Ngiemboon		ts		[t̠ʃː]
+nnh	Ngiemboon		pf		[bvf]
+nnh	Ngiemboon		z		[dzs]
+nnh	Ngiemboon		z		[d̠ʒʃ]
+nnh	Ngiemboon		f		[fː]
+nnh	Ngiemboon		s		[sː]
+nnh	Ngiemboon		s		[ʃː]
+nnh	Ngiemboon		v		[vf]
+nnh	Ngiemboon		z		[zs]
+nnh	Ngiemboon		z		[ʒʃ]
+nnh	Ngiemboon		ɡ		[ɣx]
+nnh	Ngiemboon		d		[l̪ɬ̪]
+nnh	Ngiemboon		d		[ɭɬ̜]
+nnh	Ngiemboon		i		[i]
+nnh	Ngiemboon		i		[iː]
+nnh	Ngiemboon		i		[ĩ]
+nnh	Ngiemboon		i		[ĩː]
+nnh	Ngiemboon		e		[e]
+nnh	Ngiemboon		e		[eː]
+nnh	Ngiemboon		e		[ẽ]
+nnh	Ngiemboon		e		[ẽː]
+nnh	Ngiemboon		ɛ		[ɛ]
+nnh	Ngiemboon		ɛ		[ɛ̃]
+nnh	Ngiemboon		a		[a]
+nnh	Ngiemboon		a		[aː]
+nnh	Ngiemboon		a		[ã]
+nnh	Ngiemboon		ɔ		[ɔ]
+nnh	Ngiemboon		ɔ		[ɔː]
+nnh	Ngiemboon		o		[o]
+nnh	Ngiemboon		o		[oː]
+nnh	Ngiemboon		o		[õ]
+nnh	Ngiemboon		o		[õː]
+nnh	Ngiemboon		u		[u]
+nnh	Ngiemboon		u		[uː]
+nnh	Ngiemboon		u		[ũ]
+nnh	Ngiemboon		u		[ũː]
+nnh	Ngiemboon		e		[ə]	before syllable-final nasal
+nnh	Ngiemboon		o		[ɤ]	before syllable-final nasal
+nnh	Ngiemboon		ɥ		[y]
+nnh	Ngiemboon		ɰ		[ɯ]
+nnh	Ngiemboon		˩˥
+nnh	Ngiemboon		˦	Source: Downstepped High
+nnh	Ngiemboon		˥˩	Low-Falling
+nnh	Ngiemboon		˨
+
 yas	Nugunu		p		[pʰ]		Patman_yas.pdf
-yas	Nugunu		b				
-yas	Nugunu		mp		[mpʰ]		
-yas	Nugunu		mb				
-yas	Nugunu		m				
-yas	Nugunu		f				
-yas	Nugunu		t		[tʰ]		
-yas	Nugunu		d				
-yas	Nugunu		nt				
-yas	Nugunu		nd				
-yas	Nugunu		n				
-yas	Nugunu		s				
-yas	Nugunu		l				
-yas	Nugunu		t̠ʃ				
-yas	Nugunu		n̠t̠ʃ	source: ntʃ; SM changed ɲtʃ to n̠t̠ʃ			
-yas	Nugunu		ɲ				
-yas	Nugunu		j				
-yas	Nugunu		k				
-yas	Nugunu		ɡ				
-yas	Nugunu		ŋk				
-yas	Nugunu		ŋɡ				
-yas	Nugunu		ŋ				
-yas	Nugunu		h				
-yas	Nugunu		<w>	borrowings only			
-yas	Nugunu		i				
-yas	Nugunu		e				
-yas	Nugunu		u				
-yas	Nugunu		o				
-yas	Nugunu		ɛ				
-yas	Nugunu		a				
-yas	Nugunu		o				
-yas	Nugunu		ɔ				
-yas	Nugunu		˩˥				
-yas	Nugunu		˥˩				
-yas	Nugunu		˦				
-yas	Nugunu		˨				
-							
+yas	Nugunu		b
+yas	Nugunu		mp		[mpʰ]
+yas	Nugunu		mb
+yas	Nugunu		m
+yas	Nugunu		f
+yas	Nugunu		t		[tʰ]
+yas	Nugunu		d
+yas	Nugunu		nt
+yas	Nugunu		nd
+yas	Nugunu		n
+yas	Nugunu		s
+yas	Nugunu		l
+yas	Nugunu		t̠ʃ
+yas	Nugunu		n̠t̠ʃ	source: ntʃ; SM changed ɲtʃ to n̠t̠ʃ
+yas	Nugunu		ɲ
+yas	Nugunu		j
+yas	Nugunu		k
+yas	Nugunu		ɡ
+yas	Nugunu		ŋk
+yas	Nugunu		ŋɡ
+yas	Nugunu		ŋ
+yas	Nugunu		h
+yas	Nugunu		<w>	borrowings only
+yas	Nugunu		i
+yas	Nugunu		e
+yas	Nugunu		u
+yas	Nugunu		o
+yas	Nugunu		ɛ
+yas	Nugunu		a
+yas	Nugunu		o
+yas	Nugunu		ɔ
+yas	Nugunu		˩˥
+yas	Nugunu		˥˩
+yas	Nugunu		˦
+yas	Nugunu		˨
+
 nza	Mbembe		p		[p]		Eyoh_nza.pdf
-nza	Mbembe		p		[pʰ]		
-nza	Mbembe		b		[b]		
-nza	Mbembe		b		[bʱ]		
-nza	Mbembe		t				
-nza	Mbembe		d				
-nza	Mbembe		k				
-nza	Mbembe		ɡ				
-nza	Mbembe		kp				
-nza	Mbembe		ɡb				
-nza	Mbembe		f				
-nza	Mbembe		v				
-nza	Mbembe		s	varies with [θ]			
-nza	Mbembe		z				
-nza	Mbembe		ʃ	varies with [sʲ],[ʃʲ]			
-nza	Mbembe		ʒ	varies with [zʲ],[ʒʲ]			
-nza	Mbembe		t̠ʃ	varies with [tsʲ],[t̠ʃʲ]			
-nza	Mbembe		d̠ʒ	varies with [dzʲ],[d̠ʒʲ]			
-nza	Mbembe		h				
-nza	Mbembe		m				
-nza	Mbembe		n				
-nza	Mbembe		ɲ				
-nza	Mbembe		ŋ				
-nza	Mbembe		l				
-nza	Mbembe		ɾ				
-nza	Mbembe		w				
-nza	Mbembe		j				
-nza	Mbembe		mp				
-nza	Mbembe		mb				
-nza	Mbembe		nt				
-nza	Mbembe		nd				
-nza	Mbembe		ŋk				
-nza	Mbembe		ŋɡ				
-nza	Mbembe		ŋmkp	source ŋkp			
-nza	Mbembe		ŋmɡb	source ŋɡb			
-nza	Mbembe		ɱf				
-nza	Mbembe		ɱv				
-nza	Mbembe		ns				
-nza	Mbembe		nz				
-nza	Mbembe		n̠ʃ	varies with [nsʲ]; SM changed from nʃ to n̠ʃ			
-nza	Mbembe		n̠t̠ʃ	source ntʃ; SM changed from ɲtʃ to n̠t̠ʃ			
-nza	Mbembe		n̠d̠ʒ	source ndʒ; SM changed from ɲdʒ to n̠d̠ʒ			
-nza	Mbembe		pɾ				
-nza	Mbembe		bɾ				
-nza	Mbembe		tɾ				
-nza	Mbembe		dɾ				
-nza	Mbembe		kɾ				
-nza	Mbembe		ɡɾ				
-nza	Mbembe		kpɾ				
-nza	Mbembe		ɡbɾ				
-nza	Mbembe		fɾ				
-nza	Mbembe		vɾ				
-nza	Mbembe		sɾ				
-nza	Mbembe		zɾ				
-nza	Mbembe		t̠ʃɾ				
-nza	Mbembe		d̠ʒɾ				
-nza	Mbembe		mɾ				
-nza	Mbembe		nɾ				
-nza	Mbembe		ŋɾ				
-nza	Mbembe		mpɾ				
-nza	Mbembe		mbɾ	SM: corrected from mnɾ to mbɾ			
-nza	Mbembe		ntɾ				
-nza	Mbembe		ndɾ				
-nza	Mbembe		ŋkɾ				
-nza	Mbembe		nɡɾ				
-nza	Mbembe		ŋmkpɾ	source ŋkpɾ			
-nza	Mbembe		ɱfɾ				
-nza	Mbembe		ɱvɾ				
-nza	Mbembe		nsɾ				
-nza	Mbembe		nzɾ				
-nza	Mbembe		n̠t̠ʃɾ	source ntʃɾ; SM changed ɲt̠ʃɾ to n̠t̠ʃɾ			
-nza	Mbembe		kʷɾ				
-nza	Mbembe		pʲ				
-nza	Mbembe		bʲ				
-nza	Mbembe		kʲ				
-nza	Mbembe		kpʲ				
-nza	Mbembe		fʲ				
-nza	Mbembe		vʲ				
-nza	Mbembe		mʲ				
-nza	Mbembe		mbʲ				
-nza	Mbembe		ɱvʲ				
-nza	Mbembe		pʷ				
-nza	Mbembe		bʷ				
-nza	Mbembe		tʷ				
-nza	Mbembe		dʷ				
-nza	Mbembe		kʷ				
-nza	Mbembe		ɡʷ				
-nza	Mbembe		kpʷ				
-nza	Mbembe		t̠ʃʷ				
-nza	Mbembe		d̠ʒʷ				
-nza	Mbembe		fʷ				
-nza	Mbembe		vʷ				
-nza	Mbembe		sʷ				
-nza	Mbembe		mʷ				
-nza	Mbembe		nʷ				
-nza	Mbembe		ŋʷ				
-nza	Mbembe		mpʷ				
-nza	Mbembe		mbʷ				
-nza	Mbembe		ndʷ				
-nza	Mbembe		ŋkʷ				
-nza	Mbembe		ŋɡʷ				
-nza	Mbembe		i				
-nza	Mbembe		u				
-nza	Mbembe		e				
-nza	Mbembe		o				
-nza	Mbembe		ɛ				
-nza	Mbembe		ɔ				
-nza	Mbembe		a				
-nza	Mbembe		ɑ				
-nza	Mbembe		uː				
-nza	Mbembe		eː				
-nza	Mbembe		ɛː				
-nza	Mbembe		ɔː				
-nza	Mbembe		˧				
-nza	Mbembe		˩˥	The authors report other phonetic manifestations of tone, e.g. HM, ML, MH			
-nza	Mbembe		˥˩				
-nza	Mbembe		˦				
-nza	Mbembe		˨				
-							
+nza	Mbembe		p		[pʰ]
+nza	Mbembe		b		[b]
+nza	Mbembe		b		[bʱ]
+nza	Mbembe		t
+nza	Mbembe		d
+nza	Mbembe		k
+nza	Mbembe		ɡ
+nza	Mbembe		kp
+nza	Mbembe		ɡb
+nza	Mbembe		f
+nza	Mbembe		v
+nza	Mbembe		s	varies with [θ]
+nza	Mbembe		z
+nza	Mbembe		ʃ	varies with [sʲ],[ʃʲ]
+nza	Mbembe		ʒ	varies with [zʲ],[ʒʲ]
+nza	Mbembe		t̠ʃ	varies with [tsʲ],[t̠ʃʲ]
+nza	Mbembe		d̠ʒ	varies with [dzʲ],[d̠ʒʲ]
+nza	Mbembe		h
+nza	Mbembe		m
+nza	Mbembe		n
+nza	Mbembe		ɲ
+nza	Mbembe		ŋ
+nza	Mbembe		l
+nza	Mbembe		ɾ
+nza	Mbembe		w
+nza	Mbembe		j
+nza	Mbembe		mp
+nza	Mbembe		mb
+nza	Mbembe		nt
+nza	Mbembe		nd
+nza	Mbembe		ŋk
+nza	Mbembe		ŋɡ
+nza	Mbembe		ŋmkp	source ŋkp
+nza	Mbembe		ŋmɡb	source ŋɡb
+nza	Mbembe		ɱf
+nza	Mbembe		ɱv
+nza	Mbembe		ns
+nza	Mbembe		nz
+nza	Mbembe		n̠ʃ	varies with [nsʲ]; SM changed from nʃ to n̠ʃ
+nza	Mbembe		n̠t̠ʃ	source ntʃ; SM changed from ɲtʃ to n̠t̠ʃ
+nza	Mbembe		n̠d̠ʒ	source ndʒ; SM changed from ɲdʒ to n̠d̠ʒ
+nza	Mbembe		pɾ
+nza	Mbembe		bɾ
+nza	Mbembe		tɾ
+nza	Mbembe		dɾ
+nza	Mbembe		kɾ
+nza	Mbembe		ɡɾ
+nza	Mbembe		kpɾ
+nza	Mbembe		ɡbɾ
+nza	Mbembe		fɾ
+nza	Mbembe		vɾ
+nza	Mbembe		sɾ
+nza	Mbembe		zɾ
+nza	Mbembe		t̠ʃɾ
+nza	Mbembe		d̠ʒɾ
+nza	Mbembe		mɾ
+nza	Mbembe		nɾ
+nza	Mbembe		ŋɾ
+nza	Mbembe		mpɾ
+nza	Mbembe		mbɾ	SM: corrected from mnɾ to mbɾ
+nza	Mbembe		ntɾ
+nza	Mbembe		ndɾ
+nza	Mbembe		ŋkɾ
+nza	Mbembe		nɡɾ
+nza	Mbembe		ŋmkpɾ	source ŋkpɾ
+nza	Mbembe		ɱfɾ
+nza	Mbembe		ɱvɾ
+nza	Mbembe		nsɾ
+nza	Mbembe		nzɾ
+nza	Mbembe		n̠t̠ʃɾ	source ntʃɾ; SM changed ɲt̠ʃɾ to n̠t̠ʃɾ
+nza	Mbembe		kʷɾ
+nza	Mbembe		pʲ
+nza	Mbembe		bʲ
+nza	Mbembe		kʲ
+nza	Mbembe		kpʲ
+nza	Mbembe		fʲ
+nza	Mbembe		vʲ
+nza	Mbembe		mʲ
+nza	Mbembe		mbʲ
+nza	Mbembe		ɱvʲ
+nza	Mbembe		pʷ
+nza	Mbembe		bʷ
+nza	Mbembe		tʷ
+nza	Mbembe		dʷ
+nza	Mbembe		kʷ
+nza	Mbembe		ɡʷ
+nza	Mbembe		kpʷ
+nza	Mbembe		t̠ʃʷ
+nza	Mbembe		d̠ʒʷ
+nza	Mbembe		fʷ
+nza	Mbembe		vʷ
+nza	Mbembe		sʷ
+nza	Mbembe		mʷ
+nza	Mbembe		nʷ
+nza	Mbembe		ŋʷ
+nza	Mbembe		mpʷ
+nza	Mbembe		mbʷ
+nza	Mbembe		ndʷ
+nza	Mbembe		ŋkʷ
+nza	Mbembe		ŋɡʷ
+nza	Mbembe		i
+nza	Mbembe		u
+nza	Mbembe		e
+nza	Mbembe		o
+nza	Mbembe		ɛ
+nza	Mbembe		ɔ
+nza	Mbembe		a
+nza	Mbembe		ɑ
+nza	Mbembe		uː
+nza	Mbembe		eː
+nza	Mbembe		ɛː
+nza	Mbembe		ɔː
+nza	Mbembe		˧
+nza	Mbembe		˩˥	The authors report other phonetic manifestations of tone, e.g. HM, ML, MH
+nza	Mbembe		˥˩
+nza	Mbembe		˦
+nza	Mbembe		˨
+
 orc	Orma		p		[p]		Hoskins_orc.pdf
-orc	Orma		p		[p̚]	before /p/	
-orc	Orma		pʼ		[p̚]	before /p/	
-orc	Orma		pʼ		[pʼ]		
-orc	Orma		pʼ		[p]	before consonants other than /p/	
-orc	Orma		b		[b̚]	before /b/	
-orc	Orma		b		[b]		
-orc	Orma		f				
-orc	Orma		t		[t̚]	before /t/	
-orc	Orma		t		[t]		
-orc	Orma		tʼ		[tʼ]	before /tʼ/	
-orc	Orma		d		[d̚]	before /d/	
-orc	Orma		d		[d]		
-orc	Orma		ɗ		[ɗ̚]	before /ɗ/	
-orc	Orma		ɗ		[ɗ]		
-orc	Orma		s				
-orc	Orma		t̠ʃ		[t̥̚]	before /t̠ʃ/	
-orc	Orma		t̠ʃ		[t̠ʃ]		
-orc	Orma		t̠ʃʼ		[t̥̚]	before /t̠ʃʼ/	
-orc	Orma		t̠ʃʼ		[t̠ʃʼ]		
-orc	Orma		d̠ʒ		[d̥̚]	before /d̠ʒ]	
-orc	Orma		d̠ʒ		[d̠ʒ]		
-orc	Orma		m		[n]	before /f/, in free variation	
-orc	Orma		m		[m]		
-orc	Orma		n		[m]	before /f/, in free variation	
-orc	Orma		n		[ŋ]	before velar stops	
-orc	Orma		n		[n]		
-orc	Orma		nʲ		[n]	before /nʲ/	
-orc	Orma		nʲ		[nʲ]		
-orc	Orma		ɾ		[r]	clause initial, ɡeminates, followinɡ /b/	
-orc	Orma		ɾ		[r̥]	ɡeminates, precedinɡ voiceless vowel	
-orc	Orma		ɾ		[ɾ]		
-orc	Orma		l				
-orc	Orma		w				
-orc	Orma		j		[ç]	before voiceless vowel	
-orc	Orma		j		[j]		
-orc	Orma		k		[k̚]	before /k/	
-orc	Orma		k		[k]		
-orc	Orma		kʼ		[k̚]	before /kʼ/	
-orc	Orma		kʼ		[kʼ]		
-orc	Orma		ɡ		[ɡ̚]	before /ɡ/	
-orc	Orma		ɡ		[ɡ]		
-orc	Orma		h				
-orc	Orma		i		[i]		
-orc	Orma		e		[e]		
-orc	Orma		a		[a]		
-orc	Orma		o		[o]		
-orc	Orma		u		[u]		
-orc	Orma		iː				
-orc	Orma		eː				
-orc	Orma		aː				
-orc	Orma		oː				
-orc	Orma		uː				
-orc	Orma		i		[i̥]		
-orc	Orma		e		[e̥]		
-orc	Orma		a		[ḁ]		
-orc	Orma		o		[o̥]		
-orc	Orma		u		[u̥]		
-							
+orc	Orma		p		[p̚]	before /p/
+orc	Orma		pʼ		[p̚]	before /p/
+orc	Orma		pʼ		[pʼ]
+orc	Orma		pʼ		[p]	before consonants other than /p/
+orc	Orma		b		[b̚]	before /b/
+orc	Orma		b		[b]
+orc	Orma		f
+orc	Orma		t		[t̚]	before /t/
+orc	Orma		t		[t]
+orc	Orma		tʼ		[tʼ]	before /tʼ/
+orc	Orma		d		[d̚]	before /d/
+orc	Orma		d		[d]
+orc	Orma		ɗ		[ɗ̚]	before /ɗ/
+orc	Orma		ɗ		[ɗ]
+orc	Orma		s
+orc	Orma		t̠ʃ		[t̥̚]	before /t̠ʃ/
+orc	Orma		t̠ʃ		[t̠ʃ]
+orc	Orma		t̠ʃʼ		[t̥̚]	before /t̠ʃʼ/
+orc	Orma		t̠ʃʼ		[t̠ʃʼ]
+orc	Orma		d̠ʒ		[d̥̚]	before /d̠ʒ]
+orc	Orma		d̠ʒ		[d̠ʒ]
+orc	Orma		m		[n]	before /f/, in free variation
+orc	Orma		m		[m]
+orc	Orma		n		[m]	before /f/, in free variation
+orc	Orma		n		[ŋ]	before velar stops
+orc	Orma		n		[n]
+orc	Orma		nʲ		[n]	before /nʲ/
+orc	Orma		nʲ		[nʲ]
+orc	Orma		ɾ		[r]	clause initial, ɡeminates, followinɡ /b/
+orc	Orma		ɾ		[r̥]	ɡeminates, precedinɡ voiceless vowel
+orc	Orma		ɾ		[ɾ]
+orc	Orma		l
+orc	Orma		w
+orc	Orma		j		[ç]	before voiceless vowel
+orc	Orma		j		[j]
+orc	Orma		k		[k̚]	before /k/
+orc	Orma		k		[k]
+orc	Orma		kʼ		[k̚]	before /kʼ/
+orc	Orma		kʼ		[kʼ]
+orc	Orma		ɡ		[ɡ̚]	before /ɡ/
+orc	Orma		ɡ		[ɡ]
+orc	Orma		h
+orc	Orma		i		[i]
+orc	Orma		e		[e]
+orc	Orma		a		[a]
+orc	Orma		o		[o]
+orc	Orma		u		[u]
+orc	Orma		iː
+orc	Orma		eː
+orc	Orma		aː
+orc	Orma		oː
+orc	Orma		uː
+orc	Orma		i		[i̥]
+orc	Orma		e		[e̥]
+orc	Orma		a		[ḁ]
+orc	Orma		o		[o̥]
+orc	Orma		u		[u̥]
+
 pny	Pinyin		b		[p]		Mbah_pny.pdf
-pny	Pinyin		b		[pʰ]	only before [u] in open syllables	
-pny	Pinyin		b		[b]	after nasals	
-pny	Pinyin		b		[β]	intervocalic within a root	
-pny	Pinyin		d		[d]	after nasals	
-pny	Pinyin		d		[l]		
-pny	Pinyin		d		[ɾ]	in suffixes	
-pny	Pinyin		ɡ		[ɡ]	after nasal	
-pny	Pinyin		ɡ		[ɣ]		
-pny	Pinyin		t				
-pny	Pinyin		k		[k]	root initial	
-pny	Pinyin		k		[ʔ]		
-pny	Pinyin		z		[z]		
-pny	Pinyin		z		[dz]	after nasals	
-pny	Pinyin		ʒ		[ʒ]		
-pny	Pinyin		ʒ		[d̠ʒ]	after nasals	
-pny	Pinyin		f				
-pny	Pinyin		s				
-pny	Pinyin		ʃ				
-pny	Pinyin		ts				
-pny	Pinyin		t̠ʃ				
-pny	Pinyin		m				
-pny	Pinyin		n				
-pny	Pinyin		ɲ				
-pny	Pinyin		ŋ				
-pny	Pinyin		w				
-pny	Pinyin		ɥ				
-pny	Pinyin		j				
-pny	Pinyin		bʲ		[pʲ]		
-pny	Pinyin		bʲ		[bʲ]	after nasals	
-pny	Pinyin		dʲ		[dʲ]	after nasals	
-pny	Pinyin		dʲ		[lʲ]		
-pny	Pinyin		tʲ				
-pny	Pinyin		kʲ				
-pny	Pinyin		ɡʲ				
-pny	Pinyin		mʲ				
-pny	Pinyin		nʲ				
-pny	Pinyin		pʷ		[pʷ]		
-pny	Pinyin		pʷ		[bʷ]	after nasals	
-pny	Pinyin		dʷ		[dʷ]	after nasals	
-pny	Pinyin		dʷ		[lʷ]		
-pny	Pinyin		ɡʷ				
-pny	Pinyin		kʷ				
-pny	Pinyin		tʷ				
-pny	Pinyin		tsʷ				
-pny	Pinyin		t̠ʃʷ				
-pny	Pinyin		ʃʷ				
-pny	Pinyin		sʷ				
-pny	Pinyin		zʷ				
-pny	Pinyin		ʒʷ				
-pny	Pinyin		nʷ				
-pny	Pinyin		ɲʷ				
-pny	Pinyin		ŋʷ				
-pny	Pinyin		ɡᶣ				
-pny	Pinyin		kᶣ				
-pny	Pinyin		i				
-pny	Pinyin		y				
-pny	Pinyin		ɛ				
-pny	Pinyin		a				
-pny	Pinyin		ɔ				
-pny	Pinyin		u				
-pny	Pinyin		ə				
-pny	Pinyin		ɨ				
-pny	Pinyin		aː				
-pny	Pinyin		əː				
-pny	Pinyin		iː				
-pny	Pinyin		ɨː				
-pny	Pinyin		ɔː				
-pny	Pinyin		uː				
-pny	Pinyin		iɛ				
-pny	Pinyin		yə				
-pny	Pinyin		iə				
-pny	Pinyin		ɨə				
-pny	Pinyin		uə				
-pny	Pinyin		˧				
-pny	Pinyin		˩˥				
-pny	Pinyin		˥˩				
-pny	Pinyin		˦				
-pny	Pinyin		˨				
-							
+pny	Pinyin		b		[pʰ]	only before [u] in open syllables
+pny	Pinyin		b		[b]	after nasals
+pny	Pinyin		b		[β]	intervocalic within a root
+pny	Pinyin		d		[d]	after nasals
+pny	Pinyin		d		[l]
+pny	Pinyin		d		[ɾ]	in suffixes
+pny	Pinyin		ɡ		[ɡ]	after nasal
+pny	Pinyin		ɡ		[ɣ]
+pny	Pinyin		t
+pny	Pinyin		k		[k]	root initial
+pny	Pinyin		k		[ʔ]
+pny	Pinyin		z		[z]
+pny	Pinyin		z		[dz]	after nasals
+pny	Pinyin		ʒ		[ʒ]
+pny	Pinyin		ʒ		[d̠ʒ]	after nasals
+pny	Pinyin		f
+pny	Pinyin		s
+pny	Pinyin		ʃ
+pny	Pinyin		ts
+pny	Pinyin		t̠ʃ
+pny	Pinyin		m
+pny	Pinyin		n
+pny	Pinyin		ɲ
+pny	Pinyin		ŋ
+pny	Pinyin		w
+pny	Pinyin		ɥ
+pny	Pinyin		j
+pny	Pinyin		bʲ		[pʲ]
+pny	Pinyin		bʲ		[bʲ]	after nasals
+pny	Pinyin		dʲ		[dʲ]	after nasals
+pny	Pinyin		dʲ		[lʲ]
+pny	Pinyin		tʲ
+pny	Pinyin		kʲ
+pny	Pinyin		ɡʲ
+pny	Pinyin		mʲ
+pny	Pinyin		nʲ
+pny	Pinyin		pʷ		[pʷ]
+pny	Pinyin		pʷ		[bʷ]	after nasals
+pny	Pinyin		dʷ		[dʷ]	after nasals
+pny	Pinyin		dʷ		[lʷ]
+pny	Pinyin		ɡʷ
+pny	Pinyin		kʷ
+pny	Pinyin		tʷ
+pny	Pinyin		tsʷ
+pny	Pinyin		t̠ʃʷ
+pny	Pinyin		ʃʷ
+pny	Pinyin		sʷ
+pny	Pinyin		zʷ
+pny	Pinyin		ʒʷ
+pny	Pinyin		nʷ
+pny	Pinyin		ɲʷ
+pny	Pinyin		ŋʷ
+pny	Pinyin		ɡᶣ
+pny	Pinyin		kᶣ
+pny	Pinyin		i
+pny	Pinyin		y
+pny	Pinyin		ɛ
+pny	Pinyin		a
+pny	Pinyin		ɔ
+pny	Pinyin		u
+pny	Pinyin		ə
+pny	Pinyin		ɨ
+pny	Pinyin		aː
+pny	Pinyin		əː
+pny	Pinyin		iː
+pny	Pinyin		ɨː
+pny	Pinyin		ɔː
+pny	Pinyin		uː
+pny	Pinyin		iɛ
+pny	Pinyin		yə
+pny	Pinyin		iə
+pny	Pinyin		ɨə
+pny	Pinyin		uə
+pny	Pinyin		˧
+pny	Pinyin		˩˥
+pny	Pinyin		˥˩
+pny	Pinyin		˦
+pny	Pinyin		˨
+
 pnz	Pana		p				Pnoya_pnz.pdf
-pnz	Pana		b				
-pnz	Pana		ɓ				
-pnz	Pana		t				
-pnz	Pana		d				
-pnz	Pana		ɗ				
-pnz	Pana		k				
-pnz	Pana		ɡ				
-pnz	Pana		kp				
-pnz	Pana		ɡb				
-pnz	Pana		ts				
-pnz	Pana		f				
-pnz	Pana		v				
-pnz	Pana		s				
-pnz	Pana		z		[z]		
-pnz	Pana		z		[dz]	before nasals	
-pnz	Pana		h		[h]		
-pnz	Pana		h		[ʔ]	between identical vowels	
-pnz	Pana		m				
-pnz	Pana		n				
-pnz	Pana		ɲ				
-pnz	Pana		ŋ				
-pnz	Pana		ⱱ				
-pnz	Pana		ɾ				
-pnz	Pana		l				
-pnz	Pana		w				
-pnz	Pana		j				
-pnz	Pana		mb				
-pnz	Pana		nd				
-pnz	Pana		ŋɡ				
-pnz	Pana		ŋmɡb				
-pnz	Pana		ndz				
-pnz	Pana		ŋʷ				
-pnz	Pana		hʲ				
-pnz	Pana		sʷ				
-pnz	Pana		hʷ				
-pnz	Pana		i				
-pnz	Pana		e				
-pnz	Pana		ɛ				
-pnz	Pana		a				
-pnz	Pana		u				
-pnz	Pana		o				
-pnz	Pana		ɔ				
-pnz	Pana		ĩ				
-pnz	Pana		ẽ				
-pnz	Pana		ɛ̃				
-pnz	Pana		ã				
-pnz	Pana		ũ				
-pnz	Pana		õ				
-pnz	Pana		ɔ̃				
-pnz	Pana		iː				
-pnz	Pana		eː				
-pnz	Pana		ɛː				
-pnz	Pana		aː				
-pnz	Pana		oː				
-pnz	Pana		uː				
-pnz	Pana		ɔː				
-pnz	Pana		ĩː				
-pnz	Pana		ẽː				
-pnz	Pana		ɛ̃ː				
-pnz	Pana		ãː				
-pnz	Pana		õː				
-pnz	Pana		ɔ̃ː				
-pnz	Pana		ũː				
-pnz	Pana		˩˥				
-pnz	Pana		˥˩				
-pnz	Pana		˦				
-pnz	Pana		˨				
-							
+pnz	Pana		b
+pnz	Pana		ɓ
+pnz	Pana		t
+pnz	Pana		d
+pnz	Pana		ɗ
+pnz	Pana		k
+pnz	Pana		ɡ
+pnz	Pana		kp
+pnz	Pana		ɡb
+pnz	Pana		ts
+pnz	Pana		f
+pnz	Pana		v
+pnz	Pana		s
+pnz	Pana		z		[z]
+pnz	Pana		z		[dz]	before nasals
+pnz	Pana		h		[h]
+pnz	Pana		h		[ʔ]	between identical vowels
+pnz	Pana		m
+pnz	Pana		n
+pnz	Pana		ɲ
+pnz	Pana		ŋ
+pnz	Pana		ⱱ
+pnz	Pana		ɾ
+pnz	Pana		l
+pnz	Pana		w
+pnz	Pana		j
+pnz	Pana		mb
+pnz	Pana		nd
+pnz	Pana		ŋɡ
+pnz	Pana		ŋmɡb
+pnz	Pana		ndz
+pnz	Pana		ŋʷ
+pnz	Pana		hʲ
+pnz	Pana		sʷ
+pnz	Pana		hʷ
+pnz	Pana		i
+pnz	Pana		e
+pnz	Pana		ɛ
+pnz	Pana		a
+pnz	Pana		u
+pnz	Pana		o
+pnz	Pana		ɔ
+pnz	Pana		ĩ
+pnz	Pana		ẽ
+pnz	Pana		ɛ̃
+pnz	Pana		ã
+pnz	Pana		ũ
+pnz	Pana		õ
+pnz	Pana		ɔ̃
+pnz	Pana		iː
+pnz	Pana		eː
+pnz	Pana		ɛː
+pnz	Pana		aː
+pnz	Pana		oː
+pnz	Pana		uː
+pnz	Pana		ɔː
+pnz	Pana		ĩː
+pnz	Pana		ẽː
+pnz	Pana		ɛ̃ː
+pnz	Pana		ãː
+pnz	Pana		õː
+pnz	Pana		ɔ̃ː
+pnz	Pana		ũː
+pnz	Pana		˩˥
+pnz	Pana		˥˩
+pnz	Pana		˦
+pnz	Pana		˨
+
 atu	Thok Reel		˩˥				Reid_atu.pdf
-atu	Thok Reel		˦				
-atu	Thok Reel		˨				
-atu	Thok Reel		p		[p]		
-atu	Thok Reel		b				
-atu	Thok Reel		m				
-atu	Thok Reel		t̪		[t̪]		
-atu	Thok Reel		d̪				
-atu	Thok Reel		n̪				
-atu	Thok Reel		t				
-atu	Thok Reel		d				
-atu	Thok Reel		n				
-atu	Thok Reel		lʲ				
-atu	Thok Reel		r				
-atu	Thok Reel		c		[c]		
-atu	Thok Reel		ɟ				
-atu	Thok Reel		ɲ				
-atu	Thok Reel		j				
-atu	Thok Reel		k				
-atu	Thok Reel		ɡ				
-atu	Thok Reel		ŋ				
-atu	Thok Reel		w				
-atu	Thok Reel		ʔ		[ʔ]		
-atu	Thok Reel		p		[ɸ]		
-atu	Thok Reel		t̪		[s]		
-atu	Thok Reel		c		[ç]		
-atu	Thok Reel		ʔ		[ɦ]	between breathy vowels	
-atu	Thok Reel		i				
-atu	Thok Reel		e				
-atu	Thok Reel		ɛ				
-atu	Thok Reel		a				
-atu	Thok Reel		ɔ				
-atu	Thok Reel		o				
-atu	Thok Reel		u				
-atu	Thok Reel		i̤				
-atu	Thok Reel		ɛ̤				
-atu	Thok Reel		a̤				
-atu	Thok Reel		ɔ̤				
-atu	Thok Reel		ṳ				
-atu	Thok Reel		e̤				
-atu	Thok Reel		o̤				
-atu	Thok Reel		iˑ				
-atu	Thok Reel		eˑ				
-atu	Thok Reel		ɛˑ				
-atu	Thok Reel		aˑ				
-atu	Thok Reel		ɔˑ				
-atu	Thok Reel		oˑ				
-atu	Thok Reel		uˑ				
-atu	Thok Reel		iː				
-atu	Thok Reel		eː				
-atu	Thok Reel		ɛː				
-atu	Thok Reel		aː				
-atu	Thok Reel		ɔː				
-atu	Thok Reel		oː				
-atu	Thok Reel		uː				
-atu	Thok Reel		i̤ˑ				
-atu	Thok Reel		ɛ̤ˑ				
-atu	Thok Reel		a̤ˑ				
-atu	Thok Reel		ɔ̤ˑ				
-atu	Thok Reel		ṳˑ				
-atu	Thok Reel		e̤ˑ				
-atu	Thok Reel		i̤ː				
-atu	Thok Reel		ɛ̤ː				
-atu	Thok Reel		a̤ː				
-atu	Thok Reel		ɔ̤ː				
-atu	Thok Reel		ṳː				
-atu	Thok Reel		e̤ː				
-							
+atu	Thok Reel		˦
+atu	Thok Reel		˨
+atu	Thok Reel		p		[p]
+atu	Thok Reel		b
+atu	Thok Reel		m
+atu	Thok Reel		t̪		[t̪]
+atu	Thok Reel		d̪
+atu	Thok Reel		n̪
+atu	Thok Reel		t
+atu	Thok Reel		d
+atu	Thok Reel		n
+atu	Thok Reel		lʲ
+atu	Thok Reel		r
+atu	Thok Reel		c		[c]
+atu	Thok Reel		ɟ
+atu	Thok Reel		ɲ
+atu	Thok Reel		j
+atu	Thok Reel		k
+atu	Thok Reel		ɡ
+atu	Thok Reel		ŋ
+atu	Thok Reel		w
+atu	Thok Reel		ʔ		[ʔ]
+atu	Thok Reel		p		[ɸ]
+atu	Thok Reel		t̪		[s]
+atu	Thok Reel		c		[ç]
+atu	Thok Reel		ʔ		[ɦ]	between breathy vowels
+atu	Thok Reel		i
+atu	Thok Reel		e
+atu	Thok Reel		ɛ
+atu	Thok Reel		a
+atu	Thok Reel		ɔ
+atu	Thok Reel		o
+atu	Thok Reel		u
+atu	Thok Reel		i̤
+atu	Thok Reel		ɛ̤
+atu	Thok Reel		a̤
+atu	Thok Reel		ɔ̤
+atu	Thok Reel		ṳ
+atu	Thok Reel		e̤
+atu	Thok Reel		o̤
+atu	Thok Reel		iˑ
+atu	Thok Reel		eˑ
+atu	Thok Reel		ɛˑ
+atu	Thok Reel		aˑ
+atu	Thok Reel		ɔˑ
+atu	Thok Reel		oˑ
+atu	Thok Reel		uˑ
+atu	Thok Reel		iː
+atu	Thok Reel		eː
+atu	Thok Reel		ɛː
+atu	Thok Reel		aː
+atu	Thok Reel		ɔː
+atu	Thok Reel		oː
+atu	Thok Reel		uː
+atu	Thok Reel		i̤ˑ
+atu	Thok Reel		ɛ̤ˑ
+atu	Thok Reel		a̤ˑ
+atu	Thok Reel		ɔ̤ˑ
+atu	Thok Reel		ṳˑ
+atu	Thok Reel		e̤ˑ
+atu	Thok Reel		i̤ː
+atu	Thok Reel		ɛ̤ː
+atu	Thok Reel		a̤ː
+atu	Thok Reel		ɔ̤ː
+atu	Thok Reel		ṳː
+atu	Thok Reel		e̤ː
+
 udl	Ouldeme		b				Kinnaird_udl.pdf
-udl	Ouldeme		ɓ				
-udl	Ouldeme		d				
-udl	Ouldeme		dz		[dz]		
-udl	Ouldeme		dz		[d̠ʒ]	front vowels	
-udl	Ouldeme		ɗ				
-udl	Ouldeme		f				
-udl	Ouldeme		ɡ				
-udl	Ouldeme		ɡʷ				
-udl	Ouldeme		ɣ				
-udl	Ouldeme		ɣʷ				
-udl	Ouldeme		χ				
-udl	Ouldeme		hʷ				
-udl	Ouldeme		k				
-udl	Ouldeme		kʷ				
-udl	Ouldeme		l				
-udl	Ouldeme		ɬ				
-udl	Ouldeme		ɮ				
-udl	Ouldeme		m				
-udl	Ouldeme		mb				
-udl	Ouldeme		n				
-udl	Ouldeme		nd				
-udl	Ouldeme		nz				
-udl	Ouldeme		ŋ				
-udl	Ouldeme		ŋɡ				
-udl	Ouldeme		ŋɡʷ				
-udl	Ouldeme		p				
-udl	Ouldeme		r				
-udl	Ouldeme		s		[s]		
-udl	Ouldeme		s		[ʃ]	front vowels	
-udl	Ouldeme		t				
-udl	Ouldeme		ts		[ts]		
-udl	Ouldeme		ts		[t̠ʃ]	front vowels	
-udl	Ouldeme		v				
-udl	Ouldeme		w				
-udl	Ouldeme		j				
-udl	Ouldeme		z		[z]		
-udl	Ouldeme		z		[ʒ]	front vowels	
-udl	Ouldeme		a		[a]		
-udl	Ouldeme		a		[ɛ]	varies with [a]	
-udl	Ouldeme		e				
-udl	Ouldeme		i				
-udl	Ouldeme		ə				
-udl	Ouldeme		u		[o]	varies with [ɔ]	
-udl	Ouldeme		u		[u]		
-udl	Ouldeme		˧				
-udl	Ouldeme		˦				
-udl	Ouldeme		˨				
-							
+udl	Ouldeme		ɓ
+udl	Ouldeme		d
+udl	Ouldeme		dz		[dz]
+udl	Ouldeme		dz		[d̠ʒ]	front vowels
+udl	Ouldeme		ɗ
+udl	Ouldeme		f
+udl	Ouldeme		ɡ
+udl	Ouldeme		ɡʷ
+udl	Ouldeme		ɣ
+udl	Ouldeme		ɣʷ
+udl	Ouldeme		χ
+udl	Ouldeme		hʷ
+udl	Ouldeme		k
+udl	Ouldeme		kʷ
+udl	Ouldeme		l
+udl	Ouldeme		ɬ
+udl	Ouldeme		ɮ
+udl	Ouldeme		m
+udl	Ouldeme		mb
+udl	Ouldeme		n
+udl	Ouldeme		nd
+udl	Ouldeme		nz
+udl	Ouldeme		ŋ
+udl	Ouldeme		ŋɡ
+udl	Ouldeme		ŋɡʷ
+udl	Ouldeme		p
+udl	Ouldeme		r
+udl	Ouldeme		s		[s]
+udl	Ouldeme		s		[ʃ]	front vowels
+udl	Ouldeme		t
+udl	Ouldeme		ts		[ts]
+udl	Ouldeme		ts		[t̠ʃ]	front vowels
+udl	Ouldeme		v
+udl	Ouldeme		w
+udl	Ouldeme		j
+udl	Ouldeme		z		[z]
+udl	Ouldeme		z		[ʒ]	front vowels
+udl	Ouldeme		a		[a]
+udl	Ouldeme		a		[ɛ]	varies with [a]
+udl	Ouldeme		e
+udl	Ouldeme		i
+udl	Ouldeme		ə
+udl	Ouldeme		u		[o]	varies with [ɔ]
+udl	Ouldeme		u		[u]
+udl	Ouldeme		˧
+udl	Ouldeme		˦
+udl	Ouldeme		˨
+
 les	Balese		˧				Vorbichler_les.pdf
-les	Balese		˦				
-les	Balese		˨				
-les	Balese		i				
-les	Balese		e				
-les	Balese		ɛ				
-les	Balese		<œ>				
-les	Balese		a				
-les	Balese		ɔ				
-les	Balese		o				
-les	Balese		ʊ				
-les	Balese		u				
-les	Balese		ɪ				
-les	Balese		b				
-les	Balese		ɓ				
-les	Balese		p				
-les	Balese		bv				
-les	Balese		pf				
-les	Balese		f				
-les	Balese		m				
-les	Balese		d				
-les	Balese		dʷ				
-les	Balese		ɭ				
-les	Balese		ɭʷ				
-les	Balese		t				
-les	Balese		ʈ				
-les	Balese		ɾ				
-les	Balese		ɾʲ				
-les	Balese		<ɾʷ>				
-les	Balese		n				
-les	Balese		j				
-les	Balese		s				
-les	Balese		<sʷ>				
-les	Balese		t̠ʃ				
-les	Balese		d̠ʒ				
-les	Balese		ɡ				
-les	Balese		k				
-les	Balese		w				
-les	Balese		h				
-les	Balese		ɡb				
-les	Balese		ɠɓ				
-les	Balese		ʔ				
-							
+les	Balese		˦
+les	Balese		˨
+les	Balese		i
+les	Balese		e
+les	Balese		ɛ
+les	Balese		<œ>
+les	Balese		a
+les	Balese		ɔ
+les	Balese		o
+les	Balese		ʊ
+les	Balese		u
+les	Balese		ɪ
+les	Balese		b
+les	Balese		ɓ
+les	Balese		p
+les	Balese		bv
+les	Balese		pf
+les	Balese		f
+les	Balese		m
+les	Balese		d
+les	Balese		dʷ
+les	Balese		ɭ
+les	Balese		ɭʷ
+les	Balese		t
+les	Balese		ʈ
+les	Balese		ɾ
+les	Balese		ɾʲ
+les	Balese		<ɾʷ>
+les	Balese		n
+les	Balese		j
+les	Balese		s
+les	Balese		<sʷ>
+les	Balese		t̠ʃ
+les	Balese		d̠ʒ
+les	Balese		ɡ
+les	Balese		k
+les	Balese		w
+les	Balese		h
+les	Balese		ɡb
+les	Balese		ɠɓ
+les	Balese		ʔ
+
 neb	Toura		p				Bearth_neb.pdf
-neb	Toura		b				
-neb	Toura		t				
-neb	Toura		kp				
-neb	Toura		ɓ				
-neb	Toura		m				
-neb	Toura		f				
-neb	Toura		w		[w]		
-neb	Toura		d				
-neb	Toura		ɡb				
-neb	Toura		v		[v]		
-neb	Toura		k				
-neb	Toura		l	varies with [ɾ] intervocalically in oral vowel contexts	[l]		
-neb	Toura		n				
-neb	Toura		s	varies with [ts], [ʃ], [t̠ʃ] before non-anterior vowels			
-neb	Toura		j		[j]		
-neb	Toura		z	varies with [ʒ], [dz], [d̠ʒ] before non-anterior vowels			
-neb	Toura		ɡ				
-neb	Toura		kʷ				
-neb	Toura		ɡʷ				
-neb	Toura		l		[d̪]	intervocalic between anterior vowels	
-neb	Toura		l		[n]	intervocalic between nasal vowel	
-neb	Toura		ŋ				
-neb	Toura		v		[ɱv]	before nasal vowels	
-neb	Toura		w		[ŋʷ]	before nasal vowels	
-neb	Toura		j		[ɲ]	before nasal vowels	
-neb	Toura		i				
-neb	Toura		ɪː				
-neb	Toura		e				
-neb	Toura		ɛ				
-neb	Toura		u				
-neb	Toura		ʊː				
-neb	Toura		o				
-neb	Toura		ɔ				
-neb	Toura		a				
-neb	Toura		ĩ				
-neb	Toura		ɛ̃				
-neb	Toura		ũ				
-neb	Toura		ɔ̃				
-neb	Toura		ã				
-neb	Toura		˦˥				
-neb	Toura		˥˩	Mid-Low			
-neb	Toura		˨				
-neb	Toura		˦				
-							
+neb	Toura		b
+neb	Toura		t
+neb	Toura		kp
+neb	Toura		ɓ
+neb	Toura		m
+neb	Toura		f
+neb	Toura		w		[w]
+neb	Toura		d
+neb	Toura		ɡb
+neb	Toura		v		[v]
+neb	Toura		k
+neb	Toura		l	varies with [ɾ] intervocalically in oral vowel contexts	[l]
+neb	Toura		n
+neb	Toura		s	varies with [ts], [ʃ], [t̠ʃ] before non-anterior vowels
+neb	Toura		j		[j]
+neb	Toura		z	varies with [ʒ], [dz], [d̠ʒ] before non-anterior vowels
+neb	Toura		ɡ
+neb	Toura		kʷ
+neb	Toura		ɡʷ
+neb	Toura		l		[d̪]	intervocalic between anterior vowels
+neb	Toura		l		[n]	intervocalic between nasal vowel
+neb	Toura		ŋ
+neb	Toura		v		[ɱv]	before nasal vowels
+neb	Toura		w		[ŋʷ]	before nasal vowels
+neb	Toura		j		[ɲ]	before nasal vowels
+neb	Toura		i
+neb	Toura		ɪː
+neb	Toura		e
+neb	Toura		ɛ
+neb	Toura		u
+neb	Toura		ʊː
+neb	Toura		o
+neb	Toura		ɔ
+neb	Toura		a
+neb	Toura		ĩ
+neb	Toura		ɛ̃
+neb	Toura		ũ
+neb	Toura		ɔ̃
+neb	Toura		ã
+neb	Toura		˦˥
+neb	Toura		˥˩	Mid-Low
+neb	Toura		˨
+neb	Toura		˦
+
 gwe	Kigweno		p				Sewangi_gwe.pdf
-gwe	Kigweno		b				
-gwe	Kigweno		t				
-gwe	Kigweno		d				
-gwe	Kigweno		k				
-gwe	Kigweno		ɡ				
-gwe	Kigweno		ɟ				
-gwe	Kigweno		pf				
-gwe	Kigweno		c				
-gwe	Kigweno		kʲ				
-gwe	Kigweno		f				
-gwe	Kigweno		β				
-gwe	Kigweno		θ				
-gwe	Kigweno		ʃ				
-gwe	Kigweno		ɣ				
-gwe	Kigweno		h				
-gwe	Kigweno		l				
-gwe	Kigweno		r				
-gwe	Kigweno		m				
-gwe	Kigweno		n				
-gwe	Kigweno		ɲ				
-gwe	Kigweno		ŋ				
-gwe	Kigweno		j				
-gwe	Kigweno		w				
-gwe	Kigweno		i				
-gwe	Kigweno		e				
-gwe	Kigweno		a				
-gwe	Kigweno		u				
-gwe	Kigweno		o				
-							
+gwe	Kigweno		b
+gwe	Kigweno		t
+gwe	Kigweno		d
+gwe	Kigweno		k
+gwe	Kigweno		ɡ
+gwe	Kigweno		ɟ
+gwe	Kigweno		pf
+gwe	Kigweno		c
+gwe	Kigweno		kʲ
+gwe	Kigweno		f
+gwe	Kigweno		β
+gwe	Kigweno		θ
+gwe	Kigweno		ʃ
+gwe	Kigweno		ɣ
+gwe	Kigweno		h
+gwe	Kigweno		l
+gwe	Kigweno		r
+gwe	Kigweno		m
+gwe	Kigweno		n
+gwe	Kigweno		ɲ
+gwe	Kigweno		ŋ
+gwe	Kigweno		j
+gwe	Kigweno		w
+gwe	Kigweno		i
+gwe	Kigweno		e
+gwe	Kigweno		a
+gwe	Kigweno		u
+gwe	Kigweno		o
+
 suw	Sisumbwa		a				Kahigi_suw.pdf
-suw	Sisumbwa		b				
-suw	Sisumbwa		β				
-suw	Sisumbwa		<t̠ʃ>	rare			
-suw	Sisumbwa		d				
-suw	Sisumbwa		e				
-suw	Sisumbwa		f				
-suw	Sisumbwa		ɡ				
-suw	Sisumbwa		h				
-suw	Sisumbwa		i				
-suw	Sisumbwa		<d̠ʒ>	rare			
-suw	Sisumbwa		k				
-suw	Sisumbwa		l				
-suw	Sisumbwa		m				
-suw	Sisumbwa		n				
-suw	Sisumbwa		o				
-suw	Sisumbwa		p				
-suw	Sisumbwa		s				
-suw	Sisumbwa		<ʃ>	rare			
-suw	Sisumbwa		t				
-suw	Sisumbwa		u				
-suw	Sisumbwa		v				
-suw	Sisumbwa		w				
-suw	Sisumbwa		j				
-suw	Sisumbwa		z				
-suw	Sisumbwa		˦				
-suw	Sisumbwa		˨				
-suw	Sisumbwa		iː				
-suw	Sisumbwa		eː				
-suw	Sisumbwa		aː				
-suw	Sisumbwa		oː				
-suw	Sisumbwa		uː				
-							
+suw	Sisumbwa		b
+suw	Sisumbwa		β
+suw	Sisumbwa		<t̠ʃ>	rare
+suw	Sisumbwa		d
+suw	Sisumbwa		e
+suw	Sisumbwa		f
+suw	Sisumbwa		ɡ
+suw	Sisumbwa		h
+suw	Sisumbwa		i
+suw	Sisumbwa		<d̠ʒ>	rare
+suw	Sisumbwa		k
+suw	Sisumbwa		l
+suw	Sisumbwa		m
+suw	Sisumbwa		n
+suw	Sisumbwa		o
+suw	Sisumbwa		p
+suw	Sisumbwa		s
+suw	Sisumbwa		<ʃ>	rare
+suw	Sisumbwa		t
+suw	Sisumbwa		u
+suw	Sisumbwa		v
+suw	Sisumbwa		w
+suw	Sisumbwa		j
+suw	Sisumbwa		z
+suw	Sisumbwa		˦
+suw	Sisumbwa		˨
+suw	Sisumbwa		iː
+suw	Sisumbwa		eː
+suw	Sisumbwa		aː
+suw	Sisumbwa		oː
+suw	Sisumbwa		uː
+
 zin	Luzinza		p				Rubanza_zin.pdf
-zin	Luzinza		b				
-zin	Luzinza		m				
-zin	Luzinza		w				
-zin	Luzinza		f				
-zin	Luzinza		v				
-zin	Luzinza		t				
-zin	Luzinza		s				
-zin	Luzinza		d				
-zin	Luzinza		n				
-zin	Luzinza		z				
-zin	Luzinza		l	varies with [r], except in rare instances			
-zin	Luzinza		c				
-zin	Luzinza		ʃ				
-zin	Luzinza		ɟ				
-zin	Luzinza		ɲ				
-zin	Luzinza		j				
-zin	Luzinza		k				
-zin	Luzinza		ɡ				
-zin	Luzinza		h				
-zin	Luzinza		a				
-zin	Luzinza		e				
-zin	Luzinza		i				
-zin	Luzinza		o				
-zin	Luzinza		u				
-zin	Luzinza		aː				
-zin	Luzinza		eː				
-zin	Luzinza		iː				
-zin	Luzinza		oː				
-zin	Luzinza		uː				
-							
+zin	Luzinza		b
+zin	Luzinza		m
+zin	Luzinza		w
+zin	Luzinza		f
+zin	Luzinza		v
+zin	Luzinza		t
+zin	Luzinza		s
+zin	Luzinza		d
+zin	Luzinza		n
+zin	Luzinza		z
+zin	Luzinza		l	varies with [r], except in rare instances
+zin	Luzinza		c
+zin	Luzinza		ʃ
+zin	Luzinza		ɟ
+zin	Luzinza		ɲ
+zin	Luzinza		j
+zin	Luzinza		k
+zin	Luzinza		ɡ
+zin	Luzinza		h
+zin	Luzinza		a
+zin	Luzinza		e
+zin	Luzinza		i
+zin	Luzinza		o
+zin	Luzinza		u
+zin	Luzinza		aː
+zin	Luzinza		eː
+zin	Luzinza		iː
+zin	Luzinza		oː
+zin	Luzinza		uː
+
 mer	Kimeru		a				Rubanza_mer.pdf
-mer	Kimeru		e				
-mer	Kimeru		i				
-mer	Kimeru		o				
-mer	Kimeru		u				
-mer	Kimeru		aː				
-mer	Kimeru		eː				
-mer	Kimeru		iː				
-mer	Kimeru		oː				
-mer	Kimeru		uː				
-mer	Kimeru		b				
-mer	Kimeru		p				
-mer	Kimeru		m				
-mer	Kimeru		β				
-mer	Kimeru		f				
-mer	Kimeru		d				
-mer	Kimeru		t				
-mer	Kimeru		n				
-mer	Kimeru		s				
-mer	Kimeru		l				
-mer	Kimeru		r				
-mer	Kimeru		ʃ				
-mer	Kimeru		ɲ				
-mer	Kimeru		ŋ				
-mer	Kimeru		k				
-mer	Kimeru		w				
-mer	Kimeru		j				
-							
+mer	Kimeru		e
+mer	Kimeru		i
+mer	Kimeru		o
+mer	Kimeru		u
+mer	Kimeru		aː
+mer	Kimeru		eː
+mer	Kimeru		iː
+mer	Kimeru		oː
+mer	Kimeru		uː
+mer	Kimeru		b
+mer	Kimeru		p
+mer	Kimeru		m
+mer	Kimeru		β
+mer	Kimeru		f
+mer	Kimeru		d
+mer	Kimeru		t
+mer	Kimeru		n
+mer	Kimeru		s
+mer	Kimeru		l
+mer	Kimeru		r
+mer	Kimeru		ʃ
+mer	Kimeru		ɲ
+mer	Kimeru		ŋ
+mer	Kimeru		k
+mer	Kimeru		w
+mer	Kimeru		j
+
 hka	Kikahe		p				Kahigi_hka.pdf
-hka	Kikahe		b				
-hka	Kikahe		t				
-hka	Kikahe		d				
-hka	Kikahe		c				
-hka	Kikahe		ɟ				
-hka	Kikahe		k				
-hka	Kikahe		ɣ				
-hka	Kikahe		ɡ				
-hka	Kikahe		f				
-hka	Kikahe		v	varies with [bv]			
-hka	Kikahe		s				
-hka	Kikahe		ʃ				
-hka	Kikahe		h				
-hka	Kikahe		m				
-hka	Kikahe		n				
-hka	Kikahe		ɲ				
-hka	Kikahe		ŋ				
-hka	Kikahe		w				
-hka	Kikahe		j				
-hka	Kikahe		r				
-hka	Kikahe		l				
-hka	Kikahe		i				
-hka	Kikahe		ɛ				
-hka	Kikahe		ɑ				
-hka	Kikahe		ɔ				
-hka	Kikahe		u				
-hka	Kikahe		iː	apparent contrast			
-hka	Kikahe		ɛː	apparent contrast			
-hka	Kikahe		ɑː	apparent contrast			
-hka	Kikahe		ɔː	apparent contrast			
-hka	Kikahe		uː	apparent contrast			
-							
+hka	Kikahe		b
+hka	Kikahe		t
+hka	Kikahe		d
+hka	Kikahe		c
+hka	Kikahe		ɟ
+hka	Kikahe		k
+hka	Kikahe		ɣ
+hka	Kikahe		ɡ
+hka	Kikahe		f
+hka	Kikahe		v	varies with [bv]
+hka	Kikahe		s
+hka	Kikahe		ʃ
+hka	Kikahe		h
+hka	Kikahe		m
+hka	Kikahe		n
+hka	Kikahe		ɲ
+hka	Kikahe		ŋ
+hka	Kikahe		w
+hka	Kikahe		j
+hka	Kikahe		r
+hka	Kikahe		l
+hka	Kikahe		i
+hka	Kikahe		ɛ
+hka	Kikahe		ɑ
+hka	Kikahe		ɔ
+hka	Kikahe		u
+hka	Kikahe		iː	apparent contrast
+hka	Kikahe		ɛː	apparent contrast
+hka	Kikahe		ɑː	apparent contrast
+hka	Kikahe		ɔː	apparent contrast
+hka	Kikahe		uː	apparent contrast
+
 han	Kihangaza		β				Rubangumya_han.pdf
-han	Kihangaza		p				
-han	Kihangaza		m				
-han	Kihangaza		w				
-han	Kihangaza		v				
-han	Kihangaza		f				
-han	Kihangaza		pf				
-han	Kihangaza		d				
-han	Kihangaza		t				
-han	Kihangaza		z				
-han	Kihangaza		s				
-han	Kihangaza		ts				
-han	Kihangaza		r	varies with [l]			
-han	Kihangaza		n				
-han	Kihangaza		ɟ				
-han	Kihangaza		c				
-han	Kihangaza		ʒ				
-han	Kihangaza		ʃ				
-han	Kihangaza		ɲ				
-han	Kihangaza		j				
-han	Kihangaza		ɡ				
-han	Kihangaza		k				
-han	Kihangaza		h				
-han	Kihangaza		a				
-han	Kihangaza		e				
-han	Kihangaza		i				
-han	Kihangaza		o				
-han	Kihangaza		u				
-han	Kihangaza		aː				
-han	Kihangaza		eː				
-han	Kihangaza		iː				
-han	Kihangaza		oː				
-han	Kihangaza		uː				
-han	Kihangaza		˦				
-han	Kihangaza		˨				
-							
+han	Kihangaza		p
+han	Kihangaza		m
+han	Kihangaza		w
+han	Kihangaza		v
+han	Kihangaza		f
+han	Kihangaza		pf
+han	Kihangaza		d
+han	Kihangaza		t
+han	Kihangaza		z
+han	Kihangaza		s
+han	Kihangaza		ts
+han	Kihangaza		r	varies with [l]
+han	Kihangaza		n
+han	Kihangaza		ɟ
+han	Kihangaza		c
+han	Kihangaza		ʒ
+han	Kihangaza		ʃ
+han	Kihangaza		ɲ
+han	Kihangaza		j
+han	Kihangaza		ɡ
+han	Kihangaza		k
+han	Kihangaza		h
+han	Kihangaza		a
+han	Kihangaza		e
+han	Kihangaza		i
+han	Kihangaza		o
+han	Kihangaza		u
+han	Kihangaza		aː
+han	Kihangaza		eː
+han	Kihangaza		iː
+han	Kihangaza		oː
+han	Kihangaza		uː
+han	Kihangaza		˦
+han	Kihangaza		˨
+
 old	Kimochi		p				Mrikaria_old.pdf
-old	Kimochi		b				
-old	Kimochi		m				
-old	Kimochi		w				
-old	Kimochi		f				
-old	Kimochi		pf				
-old	Kimochi		d				
-old	Kimochi		t				
-old	Kimochi		s				
-old	Kimochi		ts				
-old	Kimochi		n				
-old	Kimochi		ɟ				
-old	Kimochi		c				
-old	Kimochi		ʃ				
-old	Kimochi		l	varies with [r]			
-old	Kimochi		ɲ				
-old	Kimochi		j				
-old	Kimochi		ɡ				
-old	Kimochi		k				
-old	Kimochi		h				
-old	Kimochi		a				
-old	Kimochi		e				
-old	Kimochi		i				
-old	Kimochi		o				
-old	Kimochi		u				
-							
+old	Kimochi		b
+old	Kimochi		m
+old	Kimochi		w
+old	Kimochi		f
+old	Kimochi		pf
+old	Kimochi		d
+old	Kimochi		t
+old	Kimochi		s
+old	Kimochi		ts
+old	Kimochi		n
+old	Kimochi		ɟ
+old	Kimochi		c
+old	Kimochi		ʃ
+old	Kimochi		l	varies with [r]
+old	Kimochi		ɲ
+old	Kimochi		j
+old	Kimochi		ɡ
+old	Kimochi		k
+old	Kimochi		h
+old	Kimochi		a
+old	Kimochi		e
+old	Kimochi		i
+old	Kimochi		o
+old	Kimochi		u
+
 ssc	Kisimbiti		β				Mreta_ssc.pdf
-ssc	Kisimbiti		c				
-ssc	Kisimbiti		d				
-ssc	Kisimbiti		f				
-ssc	Kisimbiti		ɡ				
-ssc	Kisimbiti		ɣ				
-ssc	Kisimbiti		h				
-ssc	Kisimbiti		ɟ				
-ssc	Kisimbiti		k				
-ssc	Kisimbiti		l				
-ssc	Kisimbiti		m				
-ssc	Kisimbiti		n				
-ssc	Kisimbiti		ɲ				
-ssc	Kisimbiti		ŋ				
-ssc	Kisimbiti		p				
-ssc	Kisimbiti		r				
-ssc	Kisimbiti		s				
-ssc	Kisimbiti		ʃ				
-ssc	Kisimbiti		t				
-ssc	Kisimbiti		v				
-ssc	Kisimbiti		w				
-ssc	Kisimbiti		j				
-ssc	Kisimbiti		z				
-ssc	Kisimbiti		i				
-ssc	Kisimbiti		e				
-ssc	Kisimbiti		ɛ				
-ssc	Kisimbiti		a				
-ssc	Kisimbiti		ɔ				
-ssc	Kisimbiti		o				
-ssc	Kisimbiti		u				
-ssc	Kisimbiti		iː				
-ssc	Kisimbiti		ɛː				
-ssc	Kisimbiti		eː				
-ssc	Kisimbiti		aː				
-ssc	Kisimbiti		ɔː				
-ssc	Kisimbiti		oː				
-ssc	Kisimbiti		uː				
-ssc	Kisimbiti		˦				
-ssc	Kisimbiti		˨				
-							
+ssc	Kisimbiti		c
+ssc	Kisimbiti		d
+ssc	Kisimbiti		f
+ssc	Kisimbiti		ɡ
+ssc	Kisimbiti		ɣ
+ssc	Kisimbiti		h
+ssc	Kisimbiti		ɟ
+ssc	Kisimbiti		k
+ssc	Kisimbiti		l
+ssc	Kisimbiti		m
+ssc	Kisimbiti		n
+ssc	Kisimbiti		ɲ
+ssc	Kisimbiti		ŋ
+ssc	Kisimbiti		p
+ssc	Kisimbiti		r
+ssc	Kisimbiti		s
+ssc	Kisimbiti		ʃ
+ssc	Kisimbiti		t
+ssc	Kisimbiti		v
+ssc	Kisimbiti		w
+ssc	Kisimbiti		j
+ssc	Kisimbiti		z
+ssc	Kisimbiti		i
+ssc	Kisimbiti		e
+ssc	Kisimbiti		ɛ
+ssc	Kisimbiti		a
+ssc	Kisimbiti		ɔ
+ssc	Kisimbiti		o
+ssc	Kisimbiti		u
+ssc	Kisimbiti		iː
+ssc	Kisimbiti		ɛː
+ssc	Kisimbiti		eː
+ssc	Kisimbiti		aː
+ssc	Kisimbiti		ɔː
+ssc	Kisimbiti		oː
+ssc	Kisimbiti		uː
+ssc	Kisimbiti		˦
+ssc	Kisimbiti		˨
+
 kya	Eciruuri		b				Massamba_kya.pdf
-kya	Eciruuri		<p>	rare			
-kya	Eciruuri		β				
-kya	Eciruuri		m				
-kya	Eciruuri		w				
-kya	Eciruuri		f				
-kya	Eciruuri		d				
-kya	Eciruuri		t				
-kya	Eciruuri		s				
-kya	Eciruuri		l	varies with [ɾ]			
-kya	Eciruuri		n				
-kya	Eciruuri		ɟ				
-kya	Eciruuri		t̠ʃ				
-kya	Eciruuri		ɲ				
-kya	Eciruuri		j				
-kya	Eciruuri		ɡ				
-kya	Eciruuri		k				
-kya	Eciruuri		i				
-kya	Eciruuri		e		[e]		
-kya	Eciruuri		e		[ɛ]		
-kya	Eciruuri		a				
-kya	Eciruuri		o		[o]		
-kya	Eciruuri		o		[ɔ]		
-kya	Eciruuri		u				
-kya	Eciruuri		iː				
-kya	Eciruuri		eː		[eː]		
-kya	Eciruuri		eː		[ɛː]		
-kya	Eciruuri		aː				
-kya	Eciruuri		oː		[oː]		
-kya	Eciruuri		oː		[ɔː]		
-kya	Eciruuri		uː		uː		
-kya	Eciruuri		˦				
-kya	Eciruuri		˨				
-							
+kya	Eciruuri		<p>	rare
+kya	Eciruuri		β
+kya	Eciruuri		m
+kya	Eciruuri		w
+kya	Eciruuri		f
+kya	Eciruuri		d
+kya	Eciruuri		t
+kya	Eciruuri		s
+kya	Eciruuri		l	varies with [ɾ]
+kya	Eciruuri		n
+kya	Eciruuri		ɟ
+kya	Eciruuri		t̠ʃ
+kya	Eciruuri		ɲ
+kya	Eciruuri		j
+kya	Eciruuri		ɡ
+kya	Eciruuri		k
+kya	Eciruuri		i
+kya	Eciruuri		e		[e]
+kya	Eciruuri		e		[ɛ]
+kya	Eciruuri		a
+kya	Eciruuri		o		[o]
+kya	Eciruuri		o		[ɔ]
+kya	Eciruuri		u
+kya	Eciruuri		iː
+kya	Eciruuri		eː		[eː]
+kya	Eciruuri		eː		[ɛː]
+kya	Eciruuri		aː
+kya	Eciruuri		oː		[oː]
+kya	Eciruuri		oː		[ɔː]
+kya	Eciruuri		uː		uː
+kya	Eciruuri		˦
+kya	Eciruuri		˨
+
 www	Wawa		˧	Mid-High, i.e. there are four tone levels			Martin_www.pdf
-www	Wawa		˧	Mid-Low, i.e. there are four tone levels			
-www	Wawa		˦	Low			
-www	Wawa		˨	High			
-www	Wawa		p				
-www	Wawa		b				
-www	Wawa		m				
-www	Wawa		f				
-www	Wawa		t				
-www	Wawa		d		[d]		
-www	Wawa		d		[r]	word-final	
-www	Wawa		d		[ɾ]	intervocalic	
-www	Wawa		n				
-www	Wawa		s	varies with [sː]			
-www	Wawa		ɲ				
-www	Wawa		k				
-www	Wawa		ɡ	has an intervocalic allophone described as a 'tapped velar stop'			
-www	Wawa		ŋ				
-www	Wawa		h				
-www	Wawa		kp				
-www	Wawa		ɡb				
-www	Wawa		ŋm				
-www	Wawa		t̠ʃ				
-www	Wawa		d̠ʒ				
-www	Wawa		j				
-www	Wawa		w				
-www	Wawa		l				
-www	Wawa		kʷ				
-www	Wawa		ɡʷ				
-www	Wawa		mb				
-www	Wawa		nd				
-www	Wawa		ŋɡ				
-www	Wawa		ŋmɡb				
-www	Wawa		ɱv	status unclear			
-www	Wawa		n̠d̠ʒ	SM: changed from ɲdʒ to n̠d̠ʒ			
-www	Wawa		ŋɡʷ				
-www	Wawa		i				
-www	Wawa		e				
-www	Wawa		ɛ				
-www	Wawa		ə				
-www	Wawa		a				
-www	Wawa		o				
-www	Wawa		ɔ				
-www	Wawa		u				
-www	Wawa		aː				
-www	Wawa		uː				
-www	Wawa		oː				
-www	Wawa		ɔː				
-www	Wawa		iː				
-www	Wawa		eː				
-www	Wawa		ɛː				
-www	Wawa		əː				
-							
+www	Wawa		˧	Mid-Low, i.e. there are four tone levels
+www	Wawa		˦	Low
+www	Wawa		˨	High
+www	Wawa		p
+www	Wawa		b
+www	Wawa		m
+www	Wawa		f
+www	Wawa		t
+www	Wawa		d		[d]
+www	Wawa		d		[r]	word-final
+www	Wawa		d		[ɾ]	intervocalic
+www	Wawa		n
+www	Wawa		s	varies with [sː]
+www	Wawa		ɲ
+www	Wawa		k
+www	Wawa		ɡ	has an intervocalic allophone described as a 'tapped velar stop'
+www	Wawa		ŋ
+www	Wawa		h
+www	Wawa		kp
+www	Wawa		ɡb
+www	Wawa		ŋm
+www	Wawa		t̠ʃ
+www	Wawa		d̠ʒ
+www	Wawa		j
+www	Wawa		w
+www	Wawa		l
+www	Wawa		kʷ
+www	Wawa		ɡʷ
+www	Wawa		mb
+www	Wawa		nd
+www	Wawa		ŋɡ
+www	Wawa		ŋmɡb
+www	Wawa		ɱv	status unclear
+www	Wawa		n̠d̠ʒ	SM: changed from ɲdʒ to n̠d̠ʒ
+www	Wawa		ŋɡʷ
+www	Wawa		i
+www	Wawa		e
+www	Wawa		ɛ
+www	Wawa		ə
+www	Wawa		a
+www	Wawa		o
+www	Wawa		ɔ
+www	Wawa		u
+www	Wawa		aː
+www	Wawa		uː
+www	Wawa		oː
+www	Wawa		ɔː
+www	Wawa		iː
+www	Wawa		eː
+www	Wawa		ɛː
+www	Wawa		əː
+
 shi	Tachelhit		b				1997_kossmann_berber_phonology.pdf
-shi	Tachelhit		f				
-shi	Tachelhit		m				
-shi	Tachelhit		t̪				
-shi	Tachelhit		d̪				
-shi	Tachelhit		s̪				
-shi	Tachelhit		z̪				
-shi	Tachelhit		n̪				
-shi	Tachelhit		ɾ̪				
-shi	Tachelhit		l̪				
-shi	Tachelhit		tˤ				
-shi	Tachelhit		dˤ				
-shi	Tachelhit		sˤ				
-shi	Tachelhit		zˤ				
-shi	Tachelhit		rˤ				
-shi	Tachelhit		lˤ				
-shi	Tachelhit		ʃ				
-shi	Tachelhit		ʒ				
-shi	Tachelhit		j				
-shi	Tachelhit		k				
-shi	Tachelhit		ɡ				
-shi	Tachelhit		x				
-shi	Tachelhit		ɣ				
-shi	Tachelhit		kʷ				
-shi	Tachelhit		ɡʷ				
-shi	Tachelhit		xʷ				
-shi	Tachelhit		ɣʷ				
-shi	Tachelhit		w				
-shi	Tachelhit		q				
-shi	Tachelhit		qʷ				
-shi	Tachelhit		ħ				
-shi	Tachelhit		ʕ				
-shi	Tachelhit		h				
-shi	Tachelhit		i				
-shi	Tachelhit		a				
-shi	Tachelhit		u				
-shi	Tachelhit		<ə>	phonetic only			
-							
+shi	Tachelhit		f
+shi	Tachelhit		m
+shi	Tachelhit		t̪
+shi	Tachelhit		d̪
+shi	Tachelhit		s̪
+shi	Tachelhit		z̪
+shi	Tachelhit		n̪
+shi	Tachelhit		ɾ̪
+shi	Tachelhit		l̪
+shi	Tachelhit		tˤ
+shi	Tachelhit		dˤ
+shi	Tachelhit		sˤ
+shi	Tachelhit		zˤ
+shi	Tachelhit		rˤ
+shi	Tachelhit		lˤ
+shi	Tachelhit		ʃ
+shi	Tachelhit		ʒ
+shi	Tachelhit		j
+shi	Tachelhit		k
+shi	Tachelhit		ɡ
+shi	Tachelhit		x
+shi	Tachelhit		ɣ
+shi	Tachelhit		kʷ
+shi	Tachelhit		ɡʷ
+shi	Tachelhit		xʷ
+shi	Tachelhit		ɣʷ
+shi	Tachelhit		w
+shi	Tachelhit		q
+shi	Tachelhit		qʷ
+shi	Tachelhit		ħ
+shi	Tachelhit		ʕ
+shi	Tachelhit		h
+shi	Tachelhit		i
+shi	Tachelhit		a
+shi	Tachelhit		u
+shi	Tachelhit		<ə>	phonetic only
+
 tug	Tounia		˧				Boyeldieu_boua.pdf
-tug	Tounia		˦				
-tug	Tounia		˨				
-tug	Tounia		h		[χ]	before anterior vowels	
-tug	Tounia		h		[h]		
-tug	Tounia		ɓ		[ˀɓ]		
-tug	Tounia		ɓ		[ˀm]	before nasal and nasalized vowels	
-tug	Tounia		b		[b]	syllable initial	
-tug	Tounia		b		[ɓ]		
-tug	Tounia		b		[b̚]	absolute final position	
-tug	Tounia		mb				
-tug	Tounia		m				
-tug	Tounia		s				
-tug	Tounia		t				
-tug	Tounia		d		[d]	syllable initial	
-tug	Tounia		d		[d̚]	absolute final position	
-tug	Tounia		d		[ɗ]		
-tug	Tounia		ɗ		[ˀɗ]		
-tug	Tounia		ɗ		[ˀn]	before nasal and nasalized vowels	
-tug	Tounia		nd				
-tug	Tounia		n				
-tug	Tounia		l				
-tug	Tounia		r				
-tug	Tounia		c				
-tug	Tounia		ɟ		[ɟ]	syllable initial	
-tug	Tounia		ɟ		[ɟ̚]	absolute final position	
-tug	Tounia		ɟ		[ʄ]		
-tug	Tounia		ˀɲ				
-tug	Tounia		ɲɟ				
-tug	Tounia		ɲ		[ɲ]		
-tug	Tounia		ɲ		[ĩ]		
-tug	Tounia		j		[j]		
-tug	Tounia		j		[i]		
-tug	Tounia		k				
-tug	Tounia		ɡ		[ɡ]	syllable initial	
-tug	Tounia		ɡ		[ɠ]		
-tug	Tounia		ɡ		[ɡ̚]	absolute final position	
-tug	Tounia		ŋɡ		[ŋ]	in final position	
-tug	Tounia		ŋɡ		[ŋɡ]		
-tug	Tounia		w		[w]		
-tug	Tounia		w		[w̃]		
-tug	Tounia		w		[u]		
-tug	Tounia		ʔ				
-tug	Tounia		i				
-tug	Tounia		e				
-tug	Tounia		ɛ				
-tug	Tounia		a				
-tug	Tounia		ɔ				
-tug	Tounia		o				
-tug	Tounia		u				
-tug	Tounia		<ə>	realized in some particles and is sometimes [ɨ] or [ʉ]			
-tug	Tounia		ĩ				
-tug	Tounia		ɛ̃				
-tug	Tounia		ã				
-tug	Tounia		ɔ̃				
-tug	Tounia		ũ				
-							
+tug	Tounia		˦
+tug	Tounia		˨
+tug	Tounia		h		[χ]	before anterior vowels
+tug	Tounia		h		[h]
+tug	Tounia		ɓ		[ˀɓ]
+tug	Tounia		ɓ		[ˀm]	before nasal and nasalized vowels
+tug	Tounia		b		[b]	syllable initial
+tug	Tounia		b		[ɓ]
+tug	Tounia		b		[b̚]	absolute final position
+tug	Tounia		mb
+tug	Tounia		m
+tug	Tounia		s
+tug	Tounia		t
+tug	Tounia		d		[d]	syllable initial
+tug	Tounia		d		[d̚]	absolute final position
+tug	Tounia		d		[ɗ]
+tug	Tounia		ɗ		[ˀɗ]
+tug	Tounia		ɗ		[ˀn]	before nasal and nasalized vowels
+tug	Tounia		nd
+tug	Tounia		n
+tug	Tounia		l
+tug	Tounia		r
+tug	Tounia		c
+tug	Tounia		ɟ		[ɟ]	syllable initial
+tug	Tounia		ɟ		[ɟ̚]	absolute final position
+tug	Tounia		ɟ		[ʄ]
+tug	Tounia		ˀɲ
+tug	Tounia		ɲɟ
+tug	Tounia		ɲ		[ɲ]
+tug	Tounia		ɲ		[ĩ]
+tug	Tounia		j		[j]
+tug	Tounia		j		[i]
+tug	Tounia		k
+tug	Tounia		ɡ		[ɡ]	syllable initial
+tug	Tounia		ɡ		[ɠ]
+tug	Tounia		ɡ		[ɡ̚]	absolute final position
+tug	Tounia		ŋɡ		[ŋ]	in final position
+tug	Tounia		ŋɡ		[ŋɡ]
+tug	Tounia		w		[w]
+tug	Tounia		w		[w̃]
+tug	Tounia		w		[u]
+tug	Tounia		ʔ
+tug	Tounia		i
+tug	Tounia		e
+tug	Tounia		ɛ
+tug	Tounia		a
+tug	Tounia		ɔ
+tug	Tounia		o
+tug	Tounia		u
+tug	Tounia		<ə>	realized in some particles and is sometimes [ɨ] or [ʉ]
+tug	Tounia		ĩ
+tug	Tounia		ɛ̃
+tug	Tounia		ã
+tug	Tounia		ɔ̃
+tug	Tounia		ũ
+
 sef	Senoufo, Cebaara	Tangari	˧				sef_tangari.pdf
-sef	Senoufo, Cebaara	Tangari	˦				
-sef	Senoufo, Cebaara	Tangari	˨				
-sef	Senoufo, Cebaara	Tangari	p	voiceless stops are said to vary freely with their aspirated counterparts (assumedly in word-initial position)			
-sef	Senoufo, Cebaara	Tangari	b				
-sef	Senoufo, Cebaara	Tangari	m				
-sef	Senoufo, Cebaara	Tangari	t	voiceless stops are said to vary freely with their aspirated counterparts (assumedly in word-initial position)			
-sef	Senoufo, Cebaara	Tangari	d				
-sef	Senoufo, Cebaara	Tangari	t̠ʃ				
-sef	Senoufo, Cebaara	Tangari	d̠ʒ				
-sef	Senoufo, Cebaara	Tangari	s				
-sef	Senoufo, Cebaara	Tangari	z				
-sef	Senoufo, Cebaara	Tangari	r		[r]		
-sef	Senoufo, Cebaara	Tangari	r		[ɾ]	intervocalic	
-sef	Senoufo, Cebaara	Tangari	r		[r̥]	word final	
-sef	Senoufo, Cebaara	Tangari	l				
-sef	Senoufo, Cebaara	Tangari	n				
-sef	Senoufo, Cebaara	Tangari	ʃ				
-sef	Senoufo, Cebaara	Tangari	ʒ				
-sef	Senoufo, Cebaara	Tangari	j				
-sef	Senoufo, Cebaara	Tangari	k	voiceless stops are said to vary freely with their aspirated counterparts (assumedly in word-initial position)			
-sef	Senoufo, Cebaara	Tangari	ɡ		[ɡ]		
-sef	Senoufo, Cebaara	Tangari	ɡ		[ɡ̚]	word final	
-sef	Senoufo, Cebaara	Tangari	w				
-sef	Senoufo, Cebaara	Tangari	ŋ				
-sef	Senoufo, Cebaara	Tangari	kp				
-sef	Senoufo, Cebaara	Tangari	ɡb				
-sef	Senoufo, Cebaara	Tangari	ʔ				
-sef	Senoufo, Cebaara	Tangari	f				
-sef	Senoufo, Cebaara	Tangari	<v>	questionable phonemicity			
-sef	Senoufo, Cebaara	Tangari	i				
-sef	Senoufo, Cebaara	Tangari	e	frequently surfaces as [ɪ]			
-sef	Senoufo, Cebaara	Tangari	ɛ				
-sef	Senoufo, Cebaara	Tangari	ɛ̃				
-sef	Senoufo, Cebaara	Tangari	ɛː				
-sef	Senoufo, Cebaara	Tangari	<ɛ̃ː>	questionable			
-sef	Senoufo, Cebaara	Tangari	a				
-sef	Senoufo, Cebaara	Tangari	ã				
-sef	Senoufo, Cebaara	Tangari	aː				
-sef	Senoufo, Cebaara	Tangari	ãː				
-sef	Senoufo, Cebaara	Tangari	u				
-sef	Senoufo, Cebaara	Tangari	o	frequently surfaces as [ʊ]			
-sef	Senoufo, Cebaara	Tangari	ɔ				
-sef	Senoufo, Cebaara	Tangari	ɔ̃				
-sef	Senoufo, Cebaara	Tangari	ɔː				
-sef	Senoufo, Cebaara	Tangari	ɔ̃ː				
-							
+sef	Senoufo, Cebaara	Tangari	˦
+sef	Senoufo, Cebaara	Tangari	˨
+sef	Senoufo, Cebaara	Tangari	p	voiceless stops are said to vary freely with their aspirated counterparts (assumedly in word-initial position)
+sef	Senoufo, Cebaara	Tangari	b
+sef	Senoufo, Cebaara	Tangari	m
+sef	Senoufo, Cebaara	Tangari	t	voiceless stops are said to vary freely with their aspirated counterparts (assumedly in word-initial position)
+sef	Senoufo, Cebaara	Tangari	d
+sef	Senoufo, Cebaara	Tangari	t̠ʃ
+sef	Senoufo, Cebaara	Tangari	d̠ʒ
+sef	Senoufo, Cebaara	Tangari	s
+sef	Senoufo, Cebaara	Tangari	z
+sef	Senoufo, Cebaara	Tangari	r		[r]
+sef	Senoufo, Cebaara	Tangari	r		[ɾ]	intervocalic
+sef	Senoufo, Cebaara	Tangari	r		[r̥]	word final
+sef	Senoufo, Cebaara	Tangari	l
+sef	Senoufo, Cebaara	Tangari	n
+sef	Senoufo, Cebaara	Tangari	ʃ
+sef	Senoufo, Cebaara	Tangari	ʒ
+sef	Senoufo, Cebaara	Tangari	j
+sef	Senoufo, Cebaara	Tangari	k	voiceless stops are said to vary freely with their aspirated counterparts (assumedly in word-initial position)
+sef	Senoufo, Cebaara	Tangari	ɡ		[ɡ]
+sef	Senoufo, Cebaara	Tangari	ɡ		[ɡ̚]	word final
+sef	Senoufo, Cebaara	Tangari	w
+sef	Senoufo, Cebaara	Tangari	ŋ
+sef	Senoufo, Cebaara	Tangari	kp
+sef	Senoufo, Cebaara	Tangari	ɡb
+sef	Senoufo, Cebaara	Tangari	ʔ
+sef	Senoufo, Cebaara	Tangari	f
+sef	Senoufo, Cebaara	Tangari	<v>	questionable phonemicity
+sef	Senoufo, Cebaara	Tangari	i
+sef	Senoufo, Cebaara	Tangari	e	frequently surfaces as [ɪ]
+sef	Senoufo, Cebaara	Tangari	ɛ
+sef	Senoufo, Cebaara	Tangari	ɛ̃
+sef	Senoufo, Cebaara	Tangari	ɛː
+sef	Senoufo, Cebaara	Tangari	<ɛ̃ː>	questionable
+sef	Senoufo, Cebaara	Tangari	a
+sef	Senoufo, Cebaara	Tangari	ã
+sef	Senoufo, Cebaara	Tangari	aː
+sef	Senoufo, Cebaara	Tangari	ãː
+sef	Senoufo, Cebaara	Tangari	u
+sef	Senoufo, Cebaara	Tangari	o	frequently surfaces as [ʊ]
+sef	Senoufo, Cebaara	Tangari	ɔ
+sef	Senoufo, Cebaara	Tangari	ɔ̃
+sef	Senoufo, Cebaara	Tangari	ɔː
+sef	Senoufo, Cebaara	Tangari	ɔ̃ː
+
 flr	Fuliiru		p		[p]		flr_vanotterloo.pdf
-flr	Fuliiru		p		[b]	postnasal	
-flr	Fuliiru		mb				
-flr	Fuliiru		m				
-flr	Fuliiru		b		[b]	postnasal	
-flr	Fuliiru		b		[ʋ]	author explains that [β] is used in the text, althouɡh the sound is more accurately described as a labial approximant	
-flr	Fuliiru		f		[f]		
-flr	Fuliiru		f		[v]	postnasal	
-flr	Fuliiru		v				
-flr	Fuliiru		t		[t]		
-flr	Fuliiru		t		[d]	postnasal	
-flr	Fuliiru		d				
-flr	Fuliiru		s		[s]		
-flr	Fuliiru		s		[z]	postnasal	
-flr	Fuliiru		z				
-flr	Fuliiru		nd				
-flr	Fuliiru		n		[n]		
-flr	Fuliiru		l		[l]		
-flr	Fuliiru		l		[ɾ]	after front vowels	
-flr	Fuliiru		l		[d]	postnasal	
-flr	Fuliiru		r	this phoneme contrasts with /l/ but appears to be the result of borrowinɡs from Kinyarwanda	[ɾ]		
-flr	Fuliiru		r		[d]	postnasal	
-flr	Fuliiru		ʃ		[ʃ]		
-flr	Fuliiru		ʃ		[ʒ]	postnasal	
-flr	Fuliiru		ɲ				
-flr	Fuliiru		j				
-flr	Fuliiru		k				
-flr	Fuliiru		ɡ			postnasal	
-flr	Fuliiru		ŋɡ				
-flr	Fuliiru		h		[h]		
-flr	Fuliiru		h		[b]	postnasal	
-flr	Fuliiru		<w>	rare			
-flr	Fuliiru		i				
-flr	Fuliiru		iː				
-flr	Fuliiru		e				
-flr	Fuliiru		eː				
-flr	Fuliiru		a				
-flr	Fuliiru		aː				
-flr	Fuliiru		u				
-flr	Fuliiru		uː				
-flr	Fuliiru		o				
-flr	Fuliiru		oː				
-flr	Fuliiru		ʒ				
-flr	Fuliiru		n		[m]	pre-labial	
-flr	Fuliiru		n		[ɲ]	before [j]	
-flr	Fuliiru		n		[ɱ]	before [f],[v]	
-flr	Fuliiru		n		[ŋ]	pre-velar	
-flr	Fuliiru		p		[pʲ]		
-flr	Fuliiru		t		[tʲ]		
-flr	Fuliiru		k		[kʲ]		
-flr	Fuliiru		b		[bʲ]		
-flr	Fuliiru		d		[dʲ]		
-flr	Fuliiru		ɡ		[ɡʲ]		
-flr	Fuliiru		l		[lʲ]		
-flr	Fuliiru		r		[rʲ]		
-flr	Fuliiru		f		[fʲ]		
-flr	Fuliiru		ʃ		[ʃʲ]		
-flr	Fuliiru		h		[hʲ]		
-flr	Fuliiru		v		[vʲ]		
-flr	Fuliiru		mb		[mbʲ]		
-flr	Fuliiru		nd		[ndʲ]		
-flr	Fuliiru		ŋɡ		[ŋɡʲ]		
-flr	Fuliiru		m		[mʲ]		
-flr	Fuliiru		n		[nʲ]		
-flr	Fuliiru		p		[pʷ]		
-flr	Fuliiru		t		[tʷ]		
-flr	Fuliiru		k		[kʷ]		
-flr	Fuliiru		b		[bʷ]		
-flr	Fuliiru		d		[dʷ]		
-flr	Fuliiru		ɡ		[ɡʷ]		
-flr	Fuliiru		l		[lʷ]		
-flr	Fuliiru		r		[rʷ]		
-flr	Fuliiru		j		[jʷ]		
-flr	Fuliiru		f		[fʷ]		
-flr	Fuliiru		s		[sʷ]		
-flr	Fuliiru		ʃ		[ʃʷ]		
-flr	Fuliiru		h		[hʷ]		
-flr	Fuliiru		v		[vʷ]		
-flr	Fuliiru		d̠ʒ		[d̠ʒʷ]		
-flr	Fuliiru		z		[zʷ]		
-flr	Fuliiru		mb		[mbʷ]		
-flr	Fuliiru		nd		[ndʷ]		
-flr	Fuliiru		ŋɡ		[ŋɡʷ]		
-flr	Fuliiru		m		[mʷ]		
-flr	Fuliiru		n		[nʷ]		
-flr	Fuliiru		ɲ		[ɲʷ]		
-flr	Fuliiru		i				
-flr	Fuliiru		iː				
-flr	Fuliiru		e				
-flr	Fuliiru		eː				
-flr	Fuliiru		a				
-flr	Fuliiru		aː				
-flr	Fuliiru		u				
-flr	Fuliiru		uː				
-flr	Fuliiru		o				
-flr	Fuliiru		oː				
-flr	Fuliiru		˦				
-flr	Fuliiru		˨				
-							
+flr	Fuliiru		p		[b]	postnasal
+flr	Fuliiru		mb
+flr	Fuliiru		m
+flr	Fuliiru		b		[b]	postnasal
+flr	Fuliiru		b		[ʋ]	author explains that [β] is used in the text, althouɡh the sound is more accurately described as a labial approximant
+flr	Fuliiru		f		[f]
+flr	Fuliiru		f		[v]	postnasal
+flr	Fuliiru		v
+flr	Fuliiru		t		[t]
+flr	Fuliiru		t		[d]	postnasal
+flr	Fuliiru		d
+flr	Fuliiru		s		[s]
+flr	Fuliiru		s		[z]	postnasal
+flr	Fuliiru		z
+flr	Fuliiru		nd
+flr	Fuliiru		n		[n]
+flr	Fuliiru		l		[l]
+flr	Fuliiru		l		[ɾ]	after front vowels
+flr	Fuliiru		l		[d]	postnasal
+flr	Fuliiru		r	this phoneme contrasts with /l/ but appears to be the result of borrowinɡs from Kinyarwanda	[ɾ]
+flr	Fuliiru		r		[d]	postnasal
+flr	Fuliiru		ʃ		[ʃ]
+flr	Fuliiru		ʃ		[ʒ]	postnasal
+flr	Fuliiru		ɲ
+flr	Fuliiru		j
+flr	Fuliiru		k
+flr	Fuliiru		ɡ			postnasal
+flr	Fuliiru		ŋɡ
+flr	Fuliiru		h		[h]
+flr	Fuliiru		h		[b]	postnasal
+flr	Fuliiru		<w>	rare
+flr	Fuliiru		i
+flr	Fuliiru		iː
+flr	Fuliiru		e
+flr	Fuliiru		eː
+flr	Fuliiru		a
+flr	Fuliiru		aː
+flr	Fuliiru		u
+flr	Fuliiru		uː
+flr	Fuliiru		o
+flr	Fuliiru		oː
+flr	Fuliiru		ʒ
+flr	Fuliiru		n		[m]	pre-labial
+flr	Fuliiru		n		[ɲ]	before [j]
+flr	Fuliiru		n		[ɱ]	before [f],[v]
+flr	Fuliiru		n		[ŋ]	pre-velar
+flr	Fuliiru		p		[pʲ]
+flr	Fuliiru		t		[tʲ]
+flr	Fuliiru		k		[kʲ]
+flr	Fuliiru		b		[bʲ]
+flr	Fuliiru		d		[dʲ]
+flr	Fuliiru		ɡ		[ɡʲ]
+flr	Fuliiru		l		[lʲ]
+flr	Fuliiru		r		[rʲ]
+flr	Fuliiru		f		[fʲ]
+flr	Fuliiru		ʃ		[ʃʲ]
+flr	Fuliiru		h		[hʲ]
+flr	Fuliiru		v		[vʲ]
+flr	Fuliiru		mb		[mbʲ]
+flr	Fuliiru		nd		[ndʲ]
+flr	Fuliiru		ŋɡ		[ŋɡʲ]
+flr	Fuliiru		m		[mʲ]
+flr	Fuliiru		n		[nʲ]
+flr	Fuliiru		p		[pʷ]
+flr	Fuliiru		t		[tʷ]
+flr	Fuliiru		k		[kʷ]
+flr	Fuliiru		b		[bʷ]
+flr	Fuliiru		d		[dʷ]
+flr	Fuliiru		ɡ		[ɡʷ]
+flr	Fuliiru		l		[lʷ]
+flr	Fuliiru		r		[rʷ]
+flr	Fuliiru		j		[jʷ]
+flr	Fuliiru		f		[fʷ]
+flr	Fuliiru		s		[sʷ]
+flr	Fuliiru		ʃ		[ʃʷ]
+flr	Fuliiru		h		[hʷ]
+flr	Fuliiru		v		[vʷ]
+flr	Fuliiru		d̠ʒ		[d̠ʒʷ]
+flr	Fuliiru		z		[zʷ]
+flr	Fuliiru		mb		[mbʷ]
+flr	Fuliiru		nd		[ndʷ]
+flr	Fuliiru		ŋɡ		[ŋɡʷ]
+flr	Fuliiru		m		[mʷ]
+flr	Fuliiru		n		[nʷ]
+flr	Fuliiru		ɲ		[ɲʷ]
+flr	Fuliiru		i
+flr	Fuliiru		iː
+flr	Fuliiru		e
+flr	Fuliiru		eː
+flr	Fuliiru		a
+flr	Fuliiru		aː
+flr	Fuliiru		u
+flr	Fuliiru		uː
+flr	Fuliiru		o
+flr	Fuliiru		oː
+flr	Fuliiru		˦
+flr	Fuliiru		˨
+
 sad	Sandawe		˦				sandawe_2008.pdf
-sad	Sandawe		˧				
-sad	Sandawe		˨				
-sad	Sandawe		˩˥				
-sad	Sandawe		˥˩	High-Fall			
-sad	Sandawe		˥˩	Mid-Fall			
-sad	Sandawe		˥˩	Low-Fall			
-sad	Sandawe		b				
-sad	Sandawe		p				
-sad	Sandawe		pʰ				
-sad	Sandawe		m		[m]		
-sad	Sandawe		m		[ŋ]	before velar stops	
-sad	Sandawe		f				
-sad	Sandawe		d				
-sad	Sandawe		t				
-sad	Sandawe		tʰ				
-sad	Sandawe		tsʼ				
-sad	Sandawe		n		[n]		
-sad	Sandawe		n		[ŋ]	before velar stops	
-sad	Sandawe		s				
-sad	Sandawe		ɾ				
-sad	Sandawe		d̠ʒ				
-sad	Sandawe		t̠ʃ				
-sad	Sandawe		t̠ʃʰ				
-sad	Sandawe		<j>	rare			
-sad	Sandawe		dɮ				
-sad	Sandawe		tɬ				
-sad	Sandawe		tɬʼ		[tɬʼ]		
-sad	Sandawe		tɬʼ		[kɬʼ]	before [u] and [w]	
-sad	Sandawe		ɬ				
-sad	Sandawe		l				
-sad	Sandawe		ɡ				
-sad	Sandawe		k				
-sad	Sandawe		kʰ				
-sad	Sandawe		kʼ				
-sad	Sandawe		x				
-sad	Sandawe		w				
-sad	Sandawe		ʔ				
-sad	Sandawe		h				
-sad	Sandawe		kǀ				
-sad	Sandawe		kǀʰ				
-sad	Sandawe		kǃ				
-sad	Sandawe		kǃʰ				
-sad	Sandawe		kǁ				
-sad	Sandawe		kǁʰ				
-sad	Sandawe		<ɡǀ>	rare			
-sad	Sandawe		<ɡǃ>	rare			
-sad	Sandawe		<ɡǁ>	rare			
-sad	Sandawe		kǀʼ				
-sad	Sandawe		ŋǀ				
-sad	Sandawe		kǃʼ				
-sad	Sandawe		ŋǃ				
-sad	Sandawe		kǁʼ				
-sad	Sandawe		ŋǁ				
-sad	Sandawe		i		[i]		
-sad	Sandawe		i		[i̥]		
-sad	Sandawe		iː				
-sad	Sandawe		ĩː				
-sad	Sandawe		e				
-sad	Sandawe		eː				
-sad	Sandawe		ẽː				
-sad	Sandawe		a				
-sad	Sandawe		aː				
-sad	Sandawe		ãː				
-sad	Sandawe		u		[u]		
-sad	Sandawe		u		[u̥]		
-sad	Sandawe		uː				
-sad	Sandawe		ũː				
-sad	Sandawe		o				
-sad	Sandawe		oː				
-sad	Sandawe		õː				
-							
+sad	Sandawe		˧
+sad	Sandawe		˨
+sad	Sandawe		˩˥
+sad	Sandawe		˥˩	High-Fall
+sad	Sandawe		˥˩	Mid-Fall
+sad	Sandawe		˥˩	Low-Fall
+sad	Sandawe		b
+sad	Sandawe		p
+sad	Sandawe		pʰ
+sad	Sandawe		m		[m]
+sad	Sandawe		m		[ŋ]	before velar stops
+sad	Sandawe		f
+sad	Sandawe		d
+sad	Sandawe		t
+sad	Sandawe		tʰ
+sad	Sandawe		tsʼ
+sad	Sandawe		n		[n]
+sad	Sandawe		n		[ŋ]	before velar stops
+sad	Sandawe		s
+sad	Sandawe		ɾ
+sad	Sandawe		d̠ʒ
+sad	Sandawe		t̠ʃ
+sad	Sandawe		t̠ʃʰ
+sad	Sandawe		<j>	rare
+sad	Sandawe		dɮ
+sad	Sandawe		tɬ
+sad	Sandawe		tɬʼ		[tɬʼ]
+sad	Sandawe		tɬʼ		[kɬʼ]	before [u] and [w]
+sad	Sandawe		ɬ
+sad	Sandawe		l
+sad	Sandawe		ɡ
+sad	Sandawe		k
+sad	Sandawe		kʰ
+sad	Sandawe		kʼ
+sad	Sandawe		x
+sad	Sandawe		w
+sad	Sandawe		ʔ
+sad	Sandawe		h
+sad	Sandawe		kǀ
+sad	Sandawe		kǀʰ
+sad	Sandawe		kǃ
+sad	Sandawe		kǃʰ
+sad	Sandawe		kǁ
+sad	Sandawe		kǁʰ
+sad	Sandawe		<ɡǀ>	rare
+sad	Sandawe		<ɡǃ>	rare
+sad	Sandawe		<ɡǁ>	rare
+sad	Sandawe		kǀʼ
+sad	Sandawe		ŋǀ
+sad	Sandawe		kǃʼ
+sad	Sandawe		ŋǃ
+sad	Sandawe		kǁʼ
+sad	Sandawe		ŋǁ
+sad	Sandawe		i		[i]
+sad	Sandawe		i		[i̥]
+sad	Sandawe		iː
+sad	Sandawe		ĩː
+sad	Sandawe		e
+sad	Sandawe		eː
+sad	Sandawe		ẽː
+sad	Sandawe		a
+sad	Sandawe		aː
+sad	Sandawe		ãː
+sad	Sandawe		u		[u]
+sad	Sandawe		u		[u̥]
+sad	Sandawe		uː
+sad	Sandawe		ũː
+sad	Sandawe		o
+sad	Sandawe		oː
+sad	Sandawe		õː
+
 tvd	Tsuvaɗi		i				tvd_blench.pdf
-tvd	Tsuvaɗi		e				
-tvd	Tsuvaɗi		a				
-tvd	Tsuvaɗi		ɔ				
-tvd	Tsuvaɗi		o				
-tvd	Tsuvaɗi		u				
-tvd	Tsuvaɗi		iː				
-tvd	Tsuvaɗi		eː				
-tvd	Tsuvaɗi		aː				
-tvd	Tsuvaɗi		oː				
-tvd	Tsuvaɗi		ɔː				
-tvd	Tsuvaɗi		uː				
-tvd	Tsuvaɗi		ĩ				
-tvd	Tsuvaɗi		ẽ				
-tvd	Tsuvaɗi		ã				
-tvd	Tsuvaɗi		ɔ̃				
-tvd	Tsuvaɗi		õ				
-tvd	Tsuvaɗi		ũ				
-tvd	Tsuvaɗi		ĩː				
-tvd	Tsuvaɗi		ẽː				
-tvd	Tsuvaɗi		ãː				
-tvd	Tsuvaɗi		ɔ̃ː				
-tvd	Tsuvaɗi		õː				
-tvd	Tsuvaɗi		ũː				
-tvd	Tsuvaɗi		p				
-tvd	Tsuvaɗi		b				
-tvd	Tsuvaɗi		ɓ				
-tvd	Tsuvaɗi		m				
-tvd	Tsuvaɗi		f				
-tvd	Tsuvaɗi		v				
-tvd	Tsuvaɗi		t				
-tvd	Tsuvaɗi		d				
-tvd	Tsuvaɗi		ɗ				
-tvd	Tsuvaɗi		n				
-tvd	Tsuvaɗi		s				
-tvd	Tsuvaɗi		z				
-tvd	Tsuvaɗi		l		[l]		
-tvd	Tsuvaɗi		ʃ				
-tvd	Tsuvaɗi		ʒ				
-tvd	Tsuvaɗi		ɟ		[ɟ]		
-tvd	Tsuvaɗi		ɲ				
-tvd	Tsuvaɗi		j				
-tvd	Tsuvaɗi		k				
-tvd	Tsuvaɗi		ɡ				
-tvd	Tsuvaɗi		w				
-tvd	Tsuvaɗi		ʔ				
-tvd	Tsuvaɗi		h				
-tvd	Tsuvaɗi		kː				
-tvd	Tsuvaɗi		lː				
-tvd	Tsuvaɗi		mː				
-tvd	Tsuvaɗi		nː				
-tvd	Tsuvaɗi		tː				
-tvd	Tsuvaɗi		l		[r]	marked only as phonetic, not clear if an allophone of /l/ or /d/	
-tvd	Tsuvaɗi		ɟ		[c]	marked only as phonetic, but assumed to be an allophone of /ɟ/	
-tvd	Tsuvaɗi		˦				
-tvd	Tsuvaɗi		˨				
-tvd	Tsuvaɗi		˩˥				
-							
+tvd	Tsuvaɗi		e
+tvd	Tsuvaɗi		a
+tvd	Tsuvaɗi		ɔ
+tvd	Tsuvaɗi		o
+tvd	Tsuvaɗi		u
+tvd	Tsuvaɗi		iː
+tvd	Tsuvaɗi		eː
+tvd	Tsuvaɗi		aː
+tvd	Tsuvaɗi		oː
+tvd	Tsuvaɗi		ɔː
+tvd	Tsuvaɗi		uː
+tvd	Tsuvaɗi		ĩ
+tvd	Tsuvaɗi		ẽ
+tvd	Tsuvaɗi		ã
+tvd	Tsuvaɗi		ɔ̃
+tvd	Tsuvaɗi		õ
+tvd	Tsuvaɗi		ũ
+tvd	Tsuvaɗi		ĩː
+tvd	Tsuvaɗi		ẽː
+tvd	Tsuvaɗi		ãː
+tvd	Tsuvaɗi		ɔ̃ː
+tvd	Tsuvaɗi		õː
+tvd	Tsuvaɗi		ũː
+tvd	Tsuvaɗi		p
+tvd	Tsuvaɗi		b
+tvd	Tsuvaɗi		ɓ
+tvd	Tsuvaɗi		m
+tvd	Tsuvaɗi		f
+tvd	Tsuvaɗi		v
+tvd	Tsuvaɗi		t
+tvd	Tsuvaɗi		d
+tvd	Tsuvaɗi		ɗ
+tvd	Tsuvaɗi		n
+tvd	Tsuvaɗi		s
+tvd	Tsuvaɗi		z
+tvd	Tsuvaɗi		l		[l]
+tvd	Tsuvaɗi		ʃ
+tvd	Tsuvaɗi		ʒ
+tvd	Tsuvaɗi		ɟ		[ɟ]
+tvd	Tsuvaɗi		ɲ
+tvd	Tsuvaɗi		j
+tvd	Tsuvaɗi		k
+tvd	Tsuvaɗi		ɡ
+tvd	Tsuvaɗi		w
+tvd	Tsuvaɗi		ʔ
+tvd	Tsuvaɗi		h
+tvd	Tsuvaɗi		kː
+tvd	Tsuvaɗi		lː
+tvd	Tsuvaɗi		mː
+tvd	Tsuvaɗi		nː
+tvd	Tsuvaɗi		tː
+tvd	Tsuvaɗi		l		[r]	marked only as phonetic, not clear if an allophone of /l/ or /d/
+tvd	Tsuvaɗi		ɟ		[c]	marked only as phonetic, but assumed to be an allophone of /ɟ/
+tvd	Tsuvaɗi		˦
+tvd	Tsuvaɗi		˨
+tvd	Tsuvaɗi		˩˥
+
 etu	Ejagham		p		[p]		Watters_1981_Dissertation.pdf
-etu	Ejagham		b		[b]		
-etu	Ejagham		f				
-etu	Ejagham		m				
-etu	Ejagham		t		[t]		
-etu	Ejagham		d				
-etu	Ejagham		s				
-etu	Ejagham		ɾ				
-etu	Ejagham		n				
-etu	Ejagham		j				
-etu	Ejagham		t̠ʃ		[t̠ʃ]		
-etu	Ejagham		d̠ʒ				
-etu	Ejagham		ɲ				
-etu	Ejagham		k		[k]		
-etu	Ejagham		ɡ				
-etu	Ejagham		ŋ				
-etu	Ejagham		kp				
-etu	Ejagham		ɡb				
-etu	Ejagham		w				
-etu	Ejagham		p		[pʰ]	word-initial	
-etu	Ejagham		t		[tʰ]	word-initial	
-etu	Ejagham		t̠ʃ		[t̠ʃʰ]	word-initial	
-etu	Ejagham		k		[kʰ]	word-initial	
-etu	Ejagham		t		[t̪]	before hiɡh vowels	
-etu	Ejagham		d		[d̪]	before hiɡh vowels	
-etu	Ejagham		t̠ʃ		[t]	before hiɡh vowels	
-etu	Ejagham		d̠ʒ		[d]	before hiɡh vowels	
-etu	Ejagham		k		[c]	before hiɡh vowels	
-etu	Ejagham		ɡ		[ɟ]	before hiɡh vowels	
-etu	Ejagham		k		[kʲ]	optional before [ɛ]	
-etu	Ejagham		b		[β]	intervocalic	
-etu	Ejagham		b		[p]	final position	
-etu	Ejagham		d		[t]	final position	
-etu	Ejagham		d̠ʒ		[t̠ʃ]	final position	
-etu	Ejagham		ɡ		[k]	final position	
-etu	Ejagham		d		[ð]	intervocalic	
-etu	Ejagham		ɡ		[ɣ]	intervocalic	
-etu	Ejagham		b		[βʷ]	optional before [u]	
-etu	Ejagham		ɡ		[ɣʷ]	optional before [u]	
-etu	Ejagham		i		[i]		
-etu	Ejagham		ɛ		[ɛ]		
-etu	Ejagham		y				
-etu	Ejagham		ə		[ə]		
-etu	Ejagham		a		[a]		
-etu	Ejagham		u		[u]		
-etu	Ejagham		ɔ		[ɔ]		
-etu	Ejagham		i		[ɨ]		
-etu	Ejagham		ɛ		[e]		
-etu	Ejagham		ə		[ə̝]		
-etu	Ejagham		a		[ʌ]		
-etu	Ejagham		u		[u̞]	open, hiɡh, back, rounded vowel	
-etu	Ejagham		ɔ		[o]		
-etu	Ejagham		˦				
-etu	Ejagham		˧				
-etu	Ejagham		˨				
-							
+etu	Ejagham		b		[b]
+etu	Ejagham		f
+etu	Ejagham		m
+etu	Ejagham		t		[t]
+etu	Ejagham		d
+etu	Ejagham		s
+etu	Ejagham		ɾ
+etu	Ejagham		n
+etu	Ejagham		j
+etu	Ejagham		t̠ʃ		[t̠ʃ]
+etu	Ejagham		d̠ʒ
+etu	Ejagham		ɲ
+etu	Ejagham		k		[k]
+etu	Ejagham		ɡ
+etu	Ejagham		ŋ
+etu	Ejagham		kp
+etu	Ejagham		ɡb
+etu	Ejagham		w
+etu	Ejagham		p		[pʰ]	word-initial
+etu	Ejagham		t		[tʰ]	word-initial
+etu	Ejagham		t̠ʃ		[t̠ʃʰ]	word-initial
+etu	Ejagham		k		[kʰ]	word-initial
+etu	Ejagham		t		[t̪]	before hiɡh vowels
+etu	Ejagham		d		[d̪]	before hiɡh vowels
+etu	Ejagham		t̠ʃ		[t]	before hiɡh vowels
+etu	Ejagham		d̠ʒ		[d]	before hiɡh vowels
+etu	Ejagham		k		[c]	before hiɡh vowels
+etu	Ejagham		ɡ		[ɟ]	before hiɡh vowels
+etu	Ejagham		k		[kʲ]	optional before [ɛ]
+etu	Ejagham		b		[β]	intervocalic
+etu	Ejagham		b		[p]	final position
+etu	Ejagham		d		[t]	final position
+etu	Ejagham		d̠ʒ		[t̠ʃ]	final position
+etu	Ejagham		ɡ		[k]	final position
+etu	Ejagham		d		[ð]	intervocalic
+etu	Ejagham		ɡ		[ɣ]	intervocalic
+etu	Ejagham		b		[βʷ]	optional before [u]
+etu	Ejagham		ɡ		[ɣʷ]	optional before [u]
+etu	Ejagham		i		[i]
+etu	Ejagham		ɛ		[ɛ]
+etu	Ejagham		y
+etu	Ejagham		ə		[ə]
+etu	Ejagham		a		[a]
+etu	Ejagham		u		[u]
+etu	Ejagham		ɔ		[ɔ]
+etu	Ejagham		i		[ɨ]
+etu	Ejagham		ɛ		[e]
+etu	Ejagham		ə		[ə̝]
+etu	Ejagham		a		[ʌ]
+etu	Ejagham		u		[u̞]	open, hiɡh, back, rounded vowel
+etu	Ejagham		ɔ		[o]
+etu	Ejagham		˦
+etu	Ejagham		˧
+etu	Ejagham		˨
+
 ybb	Yemba		b		[b]		ybb_1991.pdf
-ybb	Yemba		v				
-ybb	Yemba		f				
-ybb	Yemba		pf				
-ybb	Yemba		m				
-ybb	Yemba		w		[w]		
-ybb	Yemba		d		[d]		
-ybb	Yemba		t				
-ybb	Yemba		z		[z]		
-ybb	Yemba		s		[s]		
-ybb	Yemba		ts		[ts]		
-ybb	Yemba		n				
-ybb	Yemba		j		[j]		
-ybb	Yemba		ɡ		[ɡ]		
-ybb	Yemba		k				
-ybb	Yemba		ŋ				
-ybb	Yemba		ʔ				
-ybb	Yemba		b		[p]		
-ybb	Yemba		ts		[t̠ʃ]		
-ybb	Yemba		z		[ʒ]		
-ybb	Yemba		s		[ʃ]		
-ybb	Yemba		d		[l]		
-ybb	Yemba		ɡ		[ɣ]		
-ybb	Yemba		w		[ɡʷ]		
-ybb	Yemba		j		[ɡʲ]		
-ybb	Yemba		i				
-ybb	Yemba		e				
-ybb	Yemba		ɛ				
-ybb	Yemba		a				
-ybb	Yemba		u		[u]		
-ybb	Yemba		o				
-ybb	Yemba		ɔ				
-ybb	Yemba		u		[ʉ]		
-ybb	Yemba		˦				
-ybb	Yemba		˨				
-ybb	Yemba		˥˩	Low-Fall			
-ybb	Yemba		˦	source Downstepped High			
-							
+ybb	Yemba		v
+ybb	Yemba		f
+ybb	Yemba		pf
+ybb	Yemba		m
+ybb	Yemba		w		[w]
+ybb	Yemba		d		[d]
+ybb	Yemba		t
+ybb	Yemba		z		[z]
+ybb	Yemba		s		[s]
+ybb	Yemba		ts		[ts]
+ybb	Yemba		n
+ybb	Yemba		j		[j]
+ybb	Yemba		ɡ		[ɡ]
+ybb	Yemba		k
+ybb	Yemba		ŋ
+ybb	Yemba		ʔ
+ybb	Yemba		b		[p]
+ybb	Yemba		ts		[t̠ʃ]
+ybb	Yemba		z		[ʒ]
+ybb	Yemba		s		[ʃ]
+ybb	Yemba		d		[l]
+ybb	Yemba		ɡ		[ɣ]
+ybb	Yemba		w		[ɡʷ]
+ybb	Yemba		j		[ɡʲ]
+ybb	Yemba		i
+ybb	Yemba		e
+ybb	Yemba		ɛ
+ybb	Yemba		a
+ybb	Yemba		u		[u]
+ybb	Yemba		o
+ybb	Yemba		ɔ
+ybb	Yemba		u		[ʉ]
+ybb	Yemba		˦
+ybb	Yemba		˨
+ybb	Yemba		˥˩	Low-Fall
+ybb	Yemba		˦	source Downstepped High
+
 bfj	Nchufie		p				bfj_koopman.pdf
-bfj	Nchufie		pʰ				
-bfj	Nchufie		m				
-bfj	Nchufie		<mb>	occurs in some non-derived environment, word-initially			
-bfj	Nchufie		<ɱ>	included in the inventory, not phonemic, but status unclear			
-bfj	Nchufie		f				
-bfj	Nchufie		w		[w]		
-bfj	Nchufie		w		[v]		
-bfj	Nchufie		t				
-bfj	Nchufie		tʰ				
-bfj	Nchufie		t̠ʃ				
-bfj	Nchufie		d̠ʒ				
-bfj	Nchufie		n				
-bfj	Nchufie		<nd>	occurs in some non-derived environment, word-initially			
-bfj	Nchufie		<n̠d̠ʒ>	occurs in some non-derived environment, word-initially; SM changed from <ɲdʒ> to <n̠d̠ʒ> (text says post-alveolar)			
-bfj	Nchufie		s				
-bfj	Nchufie		z				
-bfj	Nchufie		l				
-bfj	Nchufie		<ɲ>	included in the inventory, not phonemic, but status unclear			
-bfj	Nchufie		j				
-bfj	Nchufie		kʰ	states that k lenites to ɡ/ɣ intervocalically			
-bfj	Nchufie		ŋ				
-bfj	Nchufie		ŋɡ				
-bfj	Nchufie		ɣ		[ɣ]		
-bfj	Nchufie		ɣ		[ɡ]	before hiɡh vowels	
-bfj	Nchufie		kʷ				
-bfj	Nchufie		<ŋʷ>				
-bfj	Nchufie		<ŋɡʷ>				
-bfj	Nchufie		w		[ɣʷ]	before round vowels	
-bfj	Nchufie		i		[i]		
-bfj	Nchufie		i		[ɪ]	in closed syllables	
-bfj	Nchufie		e				
-bfj	Nchufie		ɛ				
-bfj	Nchufie		a				
-bfj	Nchufie		ə				
-bfj	Nchufie		ɐ				
-bfj	Nchufie		ɯ				
-bfj	Nchufie		ɔ				
-bfj	Nchufie		o				
-bfj	Nchufie		u				
-bfj	Nchufie		˦	superhigh was also identified as marking past tense			
-bfj	Nchufie		˧				
-bfj	Nchufie		˨	superlow was also identified as marking object reversal			
-bfj	Nchufie		ĩ				
-bfj	Nchufie		ɛ̃				
-bfj	Nchufie		ẽ				
-bfj	Nchufie		ã				
-bfj	Nchufie		ə̃				
-bfj	Nchufie		ɐ̃				
-bfj	Nchufie		ɯ̃				
-bfj	Nchufie		ɔ̃				
-bfj	Nchufie		õ				
-bfj	Nchufie		ũ				
-bfj	Nchufie		iː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		ɛː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		eː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		aː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		əː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		ɐː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		ɯː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		ɔː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		oː	with creaky voice, perhaps with relation to CVʔ syllables			
-bfj	Nchufie		uː	with creaky voice, perhaps with relation to CVʔ syllables			
-							
+bfj	Nchufie		pʰ
+bfj	Nchufie		m
+bfj	Nchufie		<mb>	occurs in some non-derived environment, word-initially
+bfj	Nchufie		<ɱ>	included in the inventory, not phonemic, but status unclear
+bfj	Nchufie		f
+bfj	Nchufie		w		[w]
+bfj	Nchufie		w		[v]
+bfj	Nchufie		t
+bfj	Nchufie		tʰ
+bfj	Nchufie		t̠ʃ
+bfj	Nchufie		d̠ʒ
+bfj	Nchufie		n
+bfj	Nchufie		<nd>	occurs in some non-derived environment, word-initially
+bfj	Nchufie		<n̠d̠ʒ>	occurs in some non-derived environment, word-initially; SM changed from <ɲdʒ> to <n̠d̠ʒ> (text says post-alveolar)
+bfj	Nchufie		s
+bfj	Nchufie		z
+bfj	Nchufie		l
+bfj	Nchufie		<ɲ>	included in the inventory, not phonemic, but status unclear
+bfj	Nchufie		j
+bfj	Nchufie		kʰ	states that k lenites to ɡ/ɣ intervocalically
+bfj	Nchufie		ŋ
+bfj	Nchufie		ŋɡ
+bfj	Nchufie		ɣ		[ɣ]
+bfj	Nchufie		ɣ		[ɡ]	before hiɡh vowels
+bfj	Nchufie		kʷ
+bfj	Nchufie		<ŋʷ>
+bfj	Nchufie		<ŋɡʷ>
+bfj	Nchufie		w		[ɣʷ]	before round vowels
+bfj	Nchufie		i		[i]
+bfj	Nchufie		i		[ɪ]	in closed syllables
+bfj	Nchufie		e
+bfj	Nchufie		ɛ
+bfj	Nchufie		a
+bfj	Nchufie		ə
+bfj	Nchufie		ɐ
+bfj	Nchufie		ɯ
+bfj	Nchufie		ɔ
+bfj	Nchufie		o
+bfj	Nchufie		u
+bfj	Nchufie		˦	superhigh was also identified as marking past tense
+bfj	Nchufie		˧
+bfj	Nchufie		˨	superlow was also identified as marking object reversal
+bfj	Nchufie		ĩ
+bfj	Nchufie		ɛ̃
+bfj	Nchufie		ẽ
+bfj	Nchufie		ã
+bfj	Nchufie		ə̃
+bfj	Nchufie		ɐ̃
+bfj	Nchufie		ɯ̃
+bfj	Nchufie		ɔ̃
+bfj	Nchufie		õ
+bfj	Nchufie		ũ
+bfj	Nchufie		iː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		ɛː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		eː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		aː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		əː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		ɐː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		ɯː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		ɔː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		oː	with creaky voice, perhaps with relation to CVʔ syllables
+bfj	Nchufie		uː	with creaky voice, perhaps with relation to CVʔ syllables
+
 bji	Burji		p	ɡemination is stated to be phonemic, yet it is not clear if this applies to all consonants			bji_amborn.pdf
-bji	Burji		b				
-bji	Burji		pʼ				
-bji	Burji		f				
-bji	Burji		m				
-bji	Burji		w				
-bji	Burji		t				
-bji	Burji		d				
-bji	Burji		tʼ				
-bji	Burji		ᶑ				
-bji	Burji		s				
-bji	Burji		z				
-bji	Burji		n				
-bji	Burji		r				
-bji	Burji		l				
-bji	Burji		c				
-bji	Burji		t̠ʃ				
-bji	Burji		d̠ʒ				
-bji	Burji		t̠ʃʼ				
-bji	Burji		ɲ				
-bji	Burji		j				
-bji	Burji		ɡ				
-bji	Burji		kʼ				
-bji	Burji		ʔ				
-bji	Burji		h				
-bji	Burji		ʃ	the authors discuss this sound, yet it is not included in the chart			
-bji	Burji		i				
-bji	Burji		iː				
-bji	Burji		e				
-bji	Burji		eː				
-bji	Burji		a				
-bji	Burji		aː				
-bji	Burji		o				
-bji	Burji		oː				
-bji	Burji		u				
-bji	Burji		uː				
-							
+bji	Burji		b
+bji	Burji		pʼ
+bji	Burji		f
+bji	Burji		m
+bji	Burji		w
+bji	Burji		t
+bji	Burji		d
+bji	Burji		tʼ
+bji	Burji		ᶑ
+bji	Burji		s
+bji	Burji		z
+bji	Burji		n
+bji	Burji		r
+bji	Burji		l
+bji	Burji		c
+bji	Burji		t̠ʃ
+bji	Burji		d̠ʒ
+bji	Burji		t̠ʃʼ
+bji	Burji		ɲ
+bji	Burji		j
+bji	Burji		ɡ
+bji	Burji		kʼ
+bji	Burji		ʔ
+bji	Burji		h
+bji	Burji		ʃ	the authors discuss this sound, yet it is not included in the chart
+bji	Burji		i
+bji	Burji		iː
+bji	Burji		e
+bji	Burji		eː
+bji	Burji		a
+bji	Burji		aː
+bji	Burji		o
+bji	Burji		oː
+bji	Burji		u
+bji	Burji		uː
+
 blo	Anii		i	author states that vowel lenɡth is contrastive but does not provide details			blo_morton.pdf
-blo	Anii		e	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		ə	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		u	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		o	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		ɪ	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		ɛ	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		ɨ	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		a	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		ʊ	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		ɔ	author states that vowel lenɡth is contrastive but does not provide details			
-blo	Anii		p				
-blo	Anii		b				
-blo	Anii		f				
-blo	Anii		m				
-blo	Anii		r				
-blo	Anii		t				
-blo	Anii		d				
-blo	Anii		s				
-blo	Anii		n				
-blo	Anii		t̠ʃ	some speakers have an allophone [ts] before non-low central vowels			
-blo	Anii		d̠ʒ				
-blo	Anii		ʃ				
-blo	Anii		ɲ				
-blo	Anii		j				
-blo	Anii		l				
-blo	Anii		k				
-blo	Anii		ɡ				
-blo	Anii		<h>	marginal			
-blo	Anii		ŋ				
-blo	Anii		kp				
-blo	Anii		ɡb				
-blo	Anii		ŋm				
-blo	Anii		w				
-blo	Anii		˦	personal communication from author			
-blo	Anii		˨	personal communication from author			
-							
+blo	Anii		e	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		ə	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		u	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		o	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		ɪ	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		ɛ	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		ɨ	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		a	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		ʊ	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		ɔ	author states that vowel lenɡth is contrastive but does not provide details
+blo	Anii		p
+blo	Anii		b
+blo	Anii		f
+blo	Anii		m
+blo	Anii		r
+blo	Anii		t
+blo	Anii		d
+blo	Anii		s
+blo	Anii		n
+blo	Anii		t̠ʃ	some speakers have an allophone [ts] before non-low central vowels
+blo	Anii		d̠ʒ
+blo	Anii		ʃ
+blo	Anii		ɲ
+blo	Anii		j
+blo	Anii		l
+blo	Anii		k
+blo	Anii		ɡ
+blo	Anii		<h>	marginal
+blo	Anii		ŋ
+blo	Anii		kp
+blo	Anii		ɡb
+blo	Anii		ŋm
+blo	Anii		w
+blo	Anii		˦	personal communication from author
+blo	Anii		˨	personal communication from author
+
 fip	Fipa	Kwa	i				fip_kwa.pdf
-fip	Fipa	Kwa	ɪ				
-fip	Fipa	Kwa	e				
-fip	Fipa	Kwa	a				
-fip	Fipa	Kwa	o				
-fip	Fipa	Kwa	ʊ				
-fip	Fipa	Kwa	u				
-fip	Fipa	Kwa	iː				
-fip	Fipa	Kwa	ɪː				
-fip	Fipa	Kwa	eː				
-fip	Fipa	Kwa	aː				
-fip	Fipa	Kwa	oː				
-fip	Fipa	Kwa	ʊː				
-fip	Fipa	Kwa	uː				
-fip	Fipa	Kwa	p				
-fip	Fipa	Kwa	b				
-fip	Fipa	Kwa	f				
-fip	Fipa	Kwa	v				
-fip	Fipa	Kwa	w				
-fip	Fipa	Kwa	m				
-fip	Fipa	Kwa	t				
-fip	Fipa	Kwa	d				
-fip	Fipa	Kwa	s				
-fip	Fipa	Kwa	z				
-fip	Fipa	Kwa	l				
-fip	Fipa	Kwa	n	ɡeminated is certain morpholoɡical environments			
-fip	Fipa	Kwa	t̠ʃ				
-fip	Fipa	Kwa	ʃ				
-fip	Fipa	Kwa	ʒ	apparent free variation with [zʲ]			
-fip	Fipa	Kwa	j				
-fip	Fipa	Kwa	ɲ				
-fip	Fipa	Kwa	k				
-fip	Fipa	Kwa	ɡ				
-fip	Fipa	Kwa	ŋ				
-fip	Fipa	Kwa	˦	opposinɡ underlying tone is /Ø/, realized phonetically as L			
-							
+fip	Fipa	Kwa	ɪ
+fip	Fipa	Kwa	e
+fip	Fipa	Kwa	a
+fip	Fipa	Kwa	o
+fip	Fipa	Kwa	ʊ
+fip	Fipa	Kwa	u
+fip	Fipa	Kwa	iː
+fip	Fipa	Kwa	ɪː
+fip	Fipa	Kwa	eː
+fip	Fipa	Kwa	aː
+fip	Fipa	Kwa	oː
+fip	Fipa	Kwa	ʊː
+fip	Fipa	Kwa	uː
+fip	Fipa	Kwa	p
+fip	Fipa	Kwa	b
+fip	Fipa	Kwa	f
+fip	Fipa	Kwa	v
+fip	Fipa	Kwa	w
+fip	Fipa	Kwa	m
+fip	Fipa	Kwa	t
+fip	Fipa	Kwa	d
+fip	Fipa	Kwa	s
+fip	Fipa	Kwa	z
+fip	Fipa	Kwa	l
+fip	Fipa	Kwa	n	ɡeminated is certain morpholoɡical environments
+fip	Fipa	Kwa	t̠ʃ
+fip	Fipa	Kwa	ʃ
+fip	Fipa	Kwa	ʒ	apparent free variation with [zʲ]
+fip	Fipa	Kwa	j
+fip	Fipa	Kwa	ɲ
+fip	Fipa	Kwa	k
+fip	Fipa	Kwa	ɡ
+fip	Fipa	Kwa	ŋ
+fip	Fipa	Kwa	˦	opposinɡ underlying tone is /Ø/, realized phonetically as L
+
 naw	Nawuri		p				naw_casali.pdf
-naw	Nawuri		pʷ				
-naw	Nawuri		b				
-naw	Nawuri		bʷ				
-naw	Nawuri		f				
-naw	Nawuri		fʷ				
-naw	Nawuri		m				
-naw	Nawuri		<mʷ>				
-naw	Nawuri		t				
-naw	Nawuri		d				
-naw	Nawuri		s				
-naw	Nawuri		sʷ				
-naw	Nawuri		n				
-naw	Nawuri		l				
-naw	Nawuri		r				
-naw	Nawuri		t̠ʃ				
-naw	Nawuri		<t̠ʃʷ>				
-naw	Nawuri		d̠ʒ				
-naw	Nawuri		ɲ	this is written as [ɳ], but I assume that this is an error, as there are no other retroflex consonants in the inventory, and the sound is listed at the palatal place of articulation			
-naw	Nawuri		j				
-naw	Nawuri		k				
-naw	Nawuri		kʷ				
-naw	Nawuri		ɡ				
-naw	Nawuri		h				
-naw	Nawuri		ŋ				
-naw	Nawuri		kp				
-naw	Nawuri		ɡb				
-naw	Nawuri		ŋm				
-naw	Nawuri		w				
-naw	Nawuri		i		[i]		
-naw	Nawuri		ɪ		[ɪ]		
-naw	Nawuri		e		[e]		
-naw	Nawuri		ɛ		[ɛ]		
-naw	Nawuri		a				
-naw	Nawuri		u				
-naw	Nawuri		o				
-naw	Nawuri		ɔ				
-naw	Nawuri		u̞				
-naw	Nawuri		i		[ɨ]	interconsonantally	
-naw	Nawuri		ɪ		[ɪ̠]		
-naw	Nawuri		e		[ə]		
-naw	Nawuri		ɛ		[ʌ]		
-naw	Nawuri		˦	from Casali's 1994 paper on Nawuri tone			
-naw	Nawuri		˨	from Casali's 1994 paper on Nawuri tone			
-							
+naw	Nawuri		pʷ
+naw	Nawuri		b
+naw	Nawuri		bʷ
+naw	Nawuri		f
+naw	Nawuri		fʷ
+naw	Nawuri		m
+naw	Nawuri		<mʷ>
+naw	Nawuri		t
+naw	Nawuri		d
+naw	Nawuri		s
+naw	Nawuri		sʷ
+naw	Nawuri		n
+naw	Nawuri		l
+naw	Nawuri		r
+naw	Nawuri		t̠ʃ
+naw	Nawuri		<t̠ʃʷ>
+naw	Nawuri		d̠ʒ
+naw	Nawuri		ɲ	this is written as [ɳ], but I assume that this is an error, as there are no other retroflex consonants in the inventory, and the sound is listed at the palatal place of articulation
+naw	Nawuri		j
+naw	Nawuri		k
+naw	Nawuri		kʷ
+naw	Nawuri		ɡ
+naw	Nawuri		h
+naw	Nawuri		ŋ
+naw	Nawuri		kp
+naw	Nawuri		ɡb
+naw	Nawuri		ŋm
+naw	Nawuri		w
+naw	Nawuri		i		[i]
+naw	Nawuri		ɪ		[ɪ]
+naw	Nawuri		e		[e]
+naw	Nawuri		ɛ		[ɛ]
+naw	Nawuri		a
+naw	Nawuri		u
+naw	Nawuri		o
+naw	Nawuri		ɔ
+naw	Nawuri		u̞
+naw	Nawuri		i		[ɨ]	interconsonantally
+naw	Nawuri		ɪ		[ɪ̠]
+naw	Nawuri		e		[ə]
+naw	Nawuri		ɛ		[ʌ]
+naw	Nawuri		˦	from Casali's 1994 paper on Nawuri tone
+naw	Nawuri		˨	from Casali's 1994 paper on Nawuri tone
+
 myo	Anfillo		p				myo_yigezu.pdf
-myo	Anfillo		b				
-myo	Anfillo		pʼ				
-myo	Anfillo		t				
-myo	Anfillo		d				
-myo	Anfillo		tʼ				
-myo	Anfillo		k				
-myo	Anfillo		ɡ				
-myo	Anfillo		kʼ				
-myo	Anfillo		ʔ				
-myo	Anfillo		sʼ				
-myo	Anfillo		ʃ				
-myo	Anfillo		h				
-myo	Anfillo		ts				
-myo	Anfillo		dz				
-myo	Anfillo		tsʼ				
-myo	Anfillo		m				
-myo	Anfillo		n				
-myo	Anfillo		l				
-myo	Anfillo		r				
-myo	Anfillo		w				
-myo	Anfillo		j				
-myo	Anfillo		i				
-myo	Anfillo		e				
-myo	Anfillo		a				
-myo	Anfillo		o				
-myo	Anfillo		u				
-myo	Anfillo		pː				
-myo	Anfillo		bː				
-myo	Anfillo		pʼː				
-myo	Anfillo		tː				
-myo	Anfillo		dː				
-myo	Anfillo		tʼː				
-myo	Anfillo		ɡː				
-myo	Anfillo		kʼː				
-myo	Anfillo		tsː				
-myo	Anfillo		sʼː				
-myo	Anfillo		mː				
-myo	Anfillo		nː				
-myo	Anfillo		wː				
-myo	Anfillo		kː				
-myo	Anfillo		jː				
-myo	Anfillo		lː				
-myo	Anfillo		iː				
-myo	Anfillo		eː				
-myo	Anfillo		aː				
-myo	Anfillo		oː				
-myo	Anfillo		uː				
-							
+myo	Anfillo		b
+myo	Anfillo		pʼ
+myo	Anfillo		t
+myo	Anfillo		d
+myo	Anfillo		tʼ
+myo	Anfillo		k
+myo	Anfillo		ɡ
+myo	Anfillo		kʼ
+myo	Anfillo		ʔ
+myo	Anfillo		sʼ
+myo	Anfillo		ʃ
+myo	Anfillo		h
+myo	Anfillo		ts
+myo	Anfillo		dz
+myo	Anfillo		tsʼ
+myo	Anfillo		m
+myo	Anfillo		n
+myo	Anfillo		l
+myo	Anfillo		r
+myo	Anfillo		w
+myo	Anfillo		j
+myo	Anfillo		i
+myo	Anfillo		e
+myo	Anfillo		a
+myo	Anfillo		o
+myo	Anfillo		u
+myo	Anfillo		pː
+myo	Anfillo		bː
+myo	Anfillo		pʼː
+myo	Anfillo		tː
+myo	Anfillo		dː
+myo	Anfillo		tʼː
+myo	Anfillo		ɡː
+myo	Anfillo		kʼː
+myo	Anfillo		tsː
+myo	Anfillo		sʼː
+myo	Anfillo		mː
+myo	Anfillo		nː
+myo	Anfillo		wː
+myo	Anfillo		kː
+myo	Anfillo		jː
+myo	Anfillo		lː
+myo	Anfillo		iː
+myo	Anfillo		eː
+myo	Anfillo		aː
+myo	Anfillo		oː
+myo	Anfillo		uː
+
 nto	Bokala-Nkole	Nkole	i				nto_mangulu.pdf
-nto	Bokala-Nkole	Nkole	e				
-nto	Bokala-Nkole	Nkole	ɛ				
-nto	Bokala-Nkole	Nkole	a				
-nto	Bokala-Nkole	Nkole	ɔ				
-nto	Bokala-Nkole	Nkole	o				
-nto	Bokala-Nkole	Nkole	u				
-nto	Bokala-Nkole	Nkole	w				
-nto	Bokala-Nkole	Nkole	l				
-nto	Bokala-Nkole	Nkole	j				
-nto	Bokala-Nkole	Nkole	<b>				
-nto	Bokala-Nkole	Nkole	<p>				
-nto	Bokala-Nkole	Nkole	<h>				
-nto	Bokala-Nkole	Nkole	<mp>				
-nto	Bokala-Nkole	Nkole	<nt>				
-nto	Bokala-Nkole	Nkole	<ns>				
-nto	Bokala-Nkole	Nkole	<ŋk>				
-nto	Bokala-Nkole	Nkole	ɡ				
-nto	Bokala-Nkole	Nkole	k				
-nto	Bokala-Nkole	Nkole	t				
-nto	Bokala-Nkole	Nkole	f				
-nto	Bokala-Nkole	Nkole	s				
-nto	Bokala-Nkole	Nkole	ts				
-nto	Bokala-Nkole	Nkole	m				
-nto	Bokala-Nkole	Nkole	n				
-nto	Bokala-Nkole	Nkole	ɲ				
-nto	Bokala-Nkole	Nkole	mb				
-nto	Bokala-Nkole	Nkole	nd				
-nto	Bokala-Nkole	Nkole	n̠d̠ʒ	SM: changed from ɲdʒ to n̠d̠ʒ			
-nto	Bokala-Nkole	Nkole	ŋɡ				
-							
+nto	Bokala-Nkole	Nkole	e
+nto	Bokala-Nkole	Nkole	ɛ
+nto	Bokala-Nkole	Nkole	a
+nto	Bokala-Nkole	Nkole	ɔ
+nto	Bokala-Nkole	Nkole	o
+nto	Bokala-Nkole	Nkole	u
+nto	Bokala-Nkole	Nkole	w
+nto	Bokala-Nkole	Nkole	l
+nto	Bokala-Nkole	Nkole	j
+nto	Bokala-Nkole	Nkole	<b>
+nto	Bokala-Nkole	Nkole	<p>
+nto	Bokala-Nkole	Nkole	<h>
+nto	Bokala-Nkole	Nkole	<mp>
+nto	Bokala-Nkole	Nkole	<nt>
+nto	Bokala-Nkole	Nkole	<ns>
+nto	Bokala-Nkole	Nkole	<ŋk>
+nto	Bokala-Nkole	Nkole	ɡ
+nto	Bokala-Nkole	Nkole	k
+nto	Bokala-Nkole	Nkole	t
+nto	Bokala-Nkole	Nkole	f
+nto	Bokala-Nkole	Nkole	s
+nto	Bokala-Nkole	Nkole	ts
+nto	Bokala-Nkole	Nkole	m
+nto	Bokala-Nkole	Nkole	n
+nto	Bokala-Nkole	Nkole	ɲ
+nto	Bokala-Nkole	Nkole	mb
+nto	Bokala-Nkole	Nkole	nd
+nto	Bokala-Nkole	Nkole	n̠d̠ʒ	SM: changed from ɲdʒ to n̠d̠ʒ
+nto	Bokala-Nkole	Nkole	ŋɡ
+
 tbr	Talasa		ɓ				xtc_schadeberg.pdf
-tbr	Talasa		f				
-tbr	Talasa		mb				
-tbr	Talasa		m				
-tbr	Talasa		d̪				
-tbr	Talasa		n̪d̪				
-tbr	Talasa		ɖ				
-tbr	Talasa		ɗ				
-tbr	Talasa		s		[s]		
-tbr	Talasa		ɳɖ	source nɖ			
-tbr	Talasa		nɗ				
-tbr	Talasa		n				
-tbr	Talasa		l				
-tbr	Talasa		r				
-tbr	Talasa		<ɟ>	rare			
-tbr	Talasa		ɲɟ				
-tbr	Talasa		ɲ				
-tbr	Talasa		j				
-tbr	Talasa		ɡ				
-tbr	Talasa		ŋɡ				
-tbr	Talasa		ŋ				
-tbr	Talasa		w				
-tbr	Talasa		ʔ				
-tbr	Talasa		ɓː				
-tbr	Talasa		d̪ː				
-tbr	Talasa		ɖː				
-tbr	Talasa		ɗː				
-tbr	Talasa		ɡː				
-tbr	Talasa		s		[z]	intervocalically	
-tbr	Talasa		sː				
-tbr	Talasa		<ʃ>	rare			
-tbr	Talasa		<pf>	rare			
-tbr	Talasa		mː				
-tbr	Talasa		nː				
-tbr	Talasa		ɲː				
-tbr	Talasa		ŋː				
-tbr	Talasa		lː				
-tbr	Talasa		rː				
-tbr	Talasa		jː				
-tbr	Talasa		wː				
-tbr	Talasa		i		[i]		
-tbr	Talasa		ɪ		[ɪ]		
-tbr	Talasa		e		[e]		
-tbr	Talasa		a		[a]		
-tbr	Talasa		ɔ				
-tbr	Talasa		ʊ				
-tbr	Talasa		u				
-tbr	Talasa		iː		[iː]		
-tbr	Talasa		ɪː		[ɪː]		
-tbr	Talasa		eː		[eː]		
-tbr	Talasa		aː		[aː]		
-tbr	Talasa		ɔː				
-tbr	Talasa		ʊː				
-tbr	Talasa		uː				
-tbr	Talasa		˦				
-tbr	Talasa		˨				
-tbr	Talasa		i		[ɯ]	followinɡ a hiɡh back vowel	
-tbr	Talasa		iː		[ɯː]	followinɡ a hiɡh back vowel	
-tbr	Talasa		ɪ		[ɷ]	followinɡ a hiɡh back vowel	
-tbr	Talasa		ɪː		[ɷː]	followinɡ a hiɡh back vowel	
-tbr	Talasa		e		[ɤ]	followinɡ a hiɡh back vowel	
-tbr	Talasa		eː		[ɤː]	followinɡ a hiɡh back vowel	
-tbr	Talasa		a		[ʌ]	followinɡ a hiɡh back vowel	
-tbr	Talasa		aː		[ʌː]	followinɡ a hiɡh back vowel	
-							
+tbr	Talasa		f
+tbr	Talasa		mb
+tbr	Talasa		m
+tbr	Talasa		d̪
+tbr	Talasa		n̪d̪
+tbr	Talasa		ɖ
+tbr	Talasa		ɗ
+tbr	Talasa		s		[s]
+tbr	Talasa		ɳɖ	source nɖ
+tbr	Talasa		nɗ
+tbr	Talasa		n
+tbr	Talasa		l
+tbr	Talasa		r
+tbr	Talasa		<ɟ>	rare
+tbr	Talasa		ɲɟ
+tbr	Talasa		ɲ
+tbr	Talasa		j
+tbr	Talasa		ɡ
+tbr	Talasa		ŋɡ
+tbr	Talasa		ŋ
+tbr	Talasa		w
+tbr	Talasa		ʔ
+tbr	Talasa		ɓː
+tbr	Talasa		d̪ː
+tbr	Talasa		ɖː
+tbr	Talasa		ɗː
+tbr	Talasa		ɡː
+tbr	Talasa		s		[z]	intervocalically
+tbr	Talasa		sː
+tbr	Talasa		<ʃ>	rare
+tbr	Talasa		<pf>	rare
+tbr	Talasa		mː
+tbr	Talasa		nː
+tbr	Talasa		ɲː
+tbr	Talasa		ŋː
+tbr	Talasa		lː
+tbr	Talasa		rː
+tbr	Talasa		jː
+tbr	Talasa		wː
+tbr	Talasa		i		[i]
+tbr	Talasa		ɪ		[ɪ]
+tbr	Talasa		e		[e]
+tbr	Talasa		a		[a]
+tbr	Talasa		ɔ
+tbr	Talasa		ʊ
+tbr	Talasa		u
+tbr	Talasa		iː		[iː]
+tbr	Talasa		ɪː		[ɪː]
+tbr	Talasa		eː		[eː]
+tbr	Talasa		aː		[aː]
+tbr	Talasa		ɔː
+tbr	Talasa		ʊː
+tbr	Talasa		uː
+tbr	Talasa		˦
+tbr	Talasa		˨
+tbr	Talasa		i		[ɯ]	followinɡ a hiɡh back vowel
+tbr	Talasa		iː		[ɯː]	followinɡ a hiɡh back vowel
+tbr	Talasa		ɪ		[ɷ]	followinɡ a hiɡh back vowel
+tbr	Talasa		ɪː		[ɷː]	followinɡ a hiɡh back vowel
+tbr	Talasa		e		[ɤ]	followinɡ a hiɡh back vowel
+tbr	Talasa		eː		[ɤː]	followinɡ a hiɡh back vowel
+tbr	Talasa		a		[ʌ]	followinɡ a hiɡh back vowel
+tbr	Talasa		aː		[ʌː]	followinɡ a hiɡh back vowel
+
 uiv	Iyive		p				uiv_foster.pdf
-uiv	Iyive		b				
-uiv	Iyive		kp				
-uiv	Iyive		ɡb				
-uiv	Iyive		m				
-uiv	Iyive		mb				
-uiv	Iyive		f				
-uiv	Iyive		v				
-uiv	Iyive		t				
-uiv	Iyive		d				
-uiv	Iyive		ts				
-uiv	Iyive		dz				
-uiv	Iyive		n				
-uiv	Iyive		s		[s]		
-uiv	Iyive		nd				
-uiv	Iyive		nz				
-uiv	Iyive		ndz				
-uiv	Iyive		t̠ʃ				
-uiv	Iyive		d̠ʒ				
-uiv	Iyive		ʃ				
-uiv	Iyive		n̠d̠ʒ	source ndʒ; changed from ɲdʒ to n̠d̠ʒ			
-uiv	Iyive		ɲ				
-uiv	Iyive		j				
-uiv	Iyive		k				
-uiv	Iyive		ɡ				
-uiv	Iyive		ŋ				
-uiv	Iyive		w				
-uiv	Iyive		ŋɡ		[ŋɡ]		
-uiv	Iyive		h				
-uiv	Iyive		ŋɡ		[ŋk]	word-final	
-uiv	Iyive		<ŋmɡb>	rare; source ŋɡb			
-uiv	Iyive		kʷ				
-uiv	Iyive		ɡʷ				
-uiv	Iyive		hʷ				
-uiv	Iyive		ŋɡʲ				
-uiv	Iyive		tʲ				
-uiv	Iyive		s		[ʃ]		
-uiv	Iyive		i				
-uiv	Iyive		ɛ				
-uiv	Iyive		ə				
-uiv	Iyive		a		[a]		
-uiv	Iyive		u				
-uiv	Iyive		o				
-uiv	Iyive		ɔ				
-uiv	Iyive		a		[ai]	before [j]	
-uiv	Iyive		˩˥				
-uiv	Iyive		˥˩				
-uiv	Iyive		˦				
-uiv	Iyive		˨				
-uiv	Iyive		pʷ				
-uiv	Iyive		bʷ				
-uiv	Iyive		tʷ				
-uiv	Iyive		tsʷ			s	
-uiv	Iyive		dzʷ				
-uiv	Iyive		t̠ʃʷ				
-uiv	Iyive		mʷ				
-uiv	Iyive		fʷ				
-uiv	Iyive		sʷ				
-uiv	Iyive		ʃʷ				
-uiv	Iyive		lʷ				
-uiv	Iyive		mbʷ				
-uiv	Iyive		ndzʷ				
-uiv	Iyive		ŋɡʷ				
-uiv	Iyive		dʲ				
-uiv	Iyive		ɡʲ				
-uiv	Iyive		hʲ				
-uiv	Iyive		lʲ				
+uiv	Iyive		b
+uiv	Iyive		kp
+uiv	Iyive		ɡb
+uiv	Iyive		m
+uiv	Iyive		mb
+uiv	Iyive		f
+uiv	Iyive		v
+uiv	Iyive		t
+uiv	Iyive		d
+uiv	Iyive		ts
+uiv	Iyive		dz
+uiv	Iyive		n
+uiv	Iyive		s		[s]
+uiv	Iyive		nd
+uiv	Iyive		nz
+uiv	Iyive		ndz
+uiv	Iyive		t̠ʃ
+uiv	Iyive		d̠ʒ
+uiv	Iyive		ʃ
+uiv	Iyive		n̠d̠ʒ	source ndʒ; changed from ɲdʒ to n̠d̠ʒ
+uiv	Iyive		ɲ
+uiv	Iyive		j
+uiv	Iyive		k
+uiv	Iyive		ɡ
+uiv	Iyive		ŋ
+uiv	Iyive		w
+uiv	Iyive		ŋɡ		[ŋɡ]
+uiv	Iyive		h
+uiv	Iyive		ŋɡ		[ŋk]	word-final
+uiv	Iyive		<ŋmɡb>	rare; source ŋɡb
+uiv	Iyive		kʷ
+uiv	Iyive		ɡʷ
+uiv	Iyive		hʷ
+uiv	Iyive		ŋɡʲ
+uiv	Iyive		tʲ
+uiv	Iyive		s		[ʃ]
+uiv	Iyive		i
+uiv	Iyive		ɛ
+uiv	Iyive		ə
+uiv	Iyive		a		[a]
+uiv	Iyive		u
+uiv	Iyive		o
+uiv	Iyive		ɔ
+uiv	Iyive		a		[ai]	before [j]
+uiv	Iyive		˩˥
+uiv	Iyive		˥˩
+uiv	Iyive		˦
+uiv	Iyive		˨
+uiv	Iyive		pʷ
+uiv	Iyive		bʷ
+uiv	Iyive		tʷ
+uiv	Iyive		tsʷ			s
+uiv	Iyive		dzʷ
+uiv	Iyive		t̠ʃʷ
+uiv	Iyive		mʷ
+uiv	Iyive		fʷ
+uiv	Iyive		sʷ
+uiv	Iyive		ʃʷ
+uiv	Iyive		lʷ
+uiv	Iyive		mbʷ
+uiv	Iyive		ndzʷ
+uiv	Iyive		ŋɡʷ
+uiv	Iyive		dʲ
+uiv	Iyive		ɡʲ
+uiv	Iyive		hʲ
+uiv	Iyive		lʲ


### PR DESCRIPTION
Also removes all trailing whitespace in gm-afr-inventories. Closes #43.